### PR TITLE
Some fixes to audit logs

### DIFF
--- a/app/Listeners/ApplicationStatusChanged.php
+++ b/app/Listeners/ApplicationStatusChanged.php
@@ -45,6 +45,7 @@ class ApplicationStatusChanged
         }
         //Log if application status has been changed
         else if ($application->application_status_id != $application->getOriginal('application_status_id')) {
+            $application->refresh();
             $applicationText = "{id=".$application->id."}";
             $statusText = "{".$application->application_status->name."}";
 

--- a/app/Listeners/JobPublished.php
+++ b/app/Listeners/JobPublished.php
@@ -33,7 +33,7 @@ class JobPublished
         //If job is being modified, only want to log when it goes from unpublished to published
         if ( ($job->wasRecentlyCreated && $job->published) ||
                 (!$job->wasRecentlyCreated && $job->published && !$job->getOriginal('published'))) {
-
+            $job->refresh();
             Log::notice('Job published: job {id='.$job->id."} published by manager {id=".$job->manager->id.", email=".$job->manager->user->email."}");
         }
     }

--- a/app/Listeners/LogSuccessfulLogin.php
+++ b/app/Listeners/LogSuccessfulLogin.php
@@ -28,6 +28,7 @@ class LogSuccessfulLogin
      */
     public function handle(Login $event)
     {
-        Log::notice("Login by user {id=".$event->user->id.", email=".$event->user->email.", role=".$event->user->user_role->name."}");
+        $user = $event->user;
+        Log::notice("Login by user {id=".$user->id.", email=".$user->email.", role=".$user->user_role->name."}");
     }
 }

--- a/resources/views/applicant/job_index/index.html.twig
+++ b/resources/views/applicant/job_index/index.html.twig
@@ -89,7 +89,7 @@
                             </div>
                             <div class="box small-1of2">
                                 <span>
-                                    {{ job_index.index.applicants_label|trans_choice(job.applicant_count) }}
+                                    {{ job_index.index.applicants_label|trans_choice(job.submitted_applications_count) }}
                                 </span>
                             </div>
 

--- a/resources/views/applicant/job_post/header.html.twig
+++ b/resources/views/applicant/job_post/header.html.twig
@@ -23,7 +23,7 @@
                     </span>
                     &nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;
                     <span>
-                        {{ job_post.header.applicants_so_far|trans_choice(job.applicant_count) }}
+                        {{ job_post.header.applicants_so_far|trans_choice(job.submitted_applications_count) }}
                     </span>
                 </p>
 


### PR DESCRIPTION
Application status now  being logged properly when it is changed, and applications no longer logged as retrieved when the number of submitted applications is shown.