### PR TITLE
Modified local env url from tc.gccollab.ca to talent.local.ca

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,8 @@ APP_NAME="Talent Cloud"
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=https://tc.gccollab.ca
+APP_URL=https://talent.local.ca
 
-APPLICANT_DOMAIN=tc.gccollab.ca
-MANAGER_DOMAIN=tc.gccollab.ca
 APPLICANT_PREFIX=
 MANAGER_PREFIX=manager
 

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -31,7 +31,7 @@ build:
         nginx:
             sites:
                 # will add configuration file to "/etc/nginx/sites-enabled"
-                tc.gccollab.ca:
+                talent.local.ca:
                     host: 'local.dev'
                     web_root: 'public/'
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ docker-stop:
 	@make clean
 
 gen-certs:
-	@docker run --rm -v $(shell pwd)/etc/ssl:/certificates -e "SERVER=tc.gccollab.ca" jacoelho/generate-certificate
+	@docker run --rm -v $(shell pwd)/etc/ssl:/certificates -e "SERVER=talent.local.ca" jacoelho/generate-certificate
 
 logs:
 	@docker-compose logs -f

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ B) If prompted, allow Docker through Windows Firewall.
     If using Docker Toolbox, open the Docker Quickstart Terminal. Navigate to the TalentCloud directory. Run the rest of the commands in this terminal.
 
 5. Execute gen_certs.bat or run
-	`docker run --rm -v $pwd/etc/ssl:/certificates -e "SERVER=tc.gccollab.ca" jacoelho/generate-certificate`
+	`docker run --rm -v $pwd/etc/ssl:/certificates -e "SERVER=talent.local.ca" jacoelho/generate-certificate`
 
 	If that doesn't work, try manually replacing $pwd with the absolute path to the TalentCloud directory.
 
@@ -100,7 +100,7 @@ For further customization to your tests investigate the php.xml file and include
 useful commands:
 ```
 Generate site certificate
-	docker run --rm -v $pwd/etc/ssl:/certificates -e "SERVER=tc.gccollab.ca" jacoelho/generate-certificate
+	docker run --rm -v $pwd/etc/ssl:/certificates -e "SERVER=talent.local.ca" jacoelho/generate-certificate
 
 Run composer install
 	docker run --rm -v $(pwd):/app composer/composer install

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ B) If prompted, allow Docker through Windows Firewall.
 
 2. If using Docker for Windows, add
 	```
-	127.0.0.1	tc.gccollab.ca
-	127.0.0.1	manager.tc.gccollab.ca
+	127.0.0.1	talent.local.ca
 	```
 	to windows hosts file (at `C:\Windows\System32\Drivers\etc\hosts`).
     If using Docker Toolbox, instead of `127.0.0.1` use the ip address that appears when you open the Docker Quickstart Terminal.
@@ -79,16 +78,16 @@ B) If prompted, allow Docker through Windows Firewall.
 
 10. After the first-time set up, you should be able to start up the server simply by running `docker-compose up`, as long as other MySQL and Apache services are stopped.
 
-## OPTIONAL Installing and Running PHPUnit via composer in your docker container: 
+## OPTIONAL Installing and Running PHPUnit via composer in your docker container:
 
-First confirm that you have a successful installation of Composer running by typing out the command `composer`. 
+First confirm that you have a successful installation of Composer running by typing out the command `composer`.
 
 Second, you will want to run `docker-compose up -d` if you have not already done so and then `docker-compose exec talentcloud sh -c` to connect to your workspace.
 
 Finally, once you've connected to the TalentCloud server use the command below to run the tests in your tests folder.
 
 ```
-docker-compose exec talentcloud sh -c "vendor/bin/phpunit" 
+docker-compose exec talentcloud sh -c "vendor/bin/phpunit"
 ```
 
 Or specify wherever you keep your tests saved if saved elsewhere on your filesystem.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
             - talentcloud
             - talentcloud-db
         environment:
-            - "NGINX_HOST=tc.gccollab.ca"
+            - "NGINX_HOST=talent.local.ca"
         command: /bin/sh -c "envsubst '$$NGINX_HOST' < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
         ports:
             - "80:80"

--- a/etc/nginx/default.conf
+++ b/etc/nginx/default.conf
@@ -3,7 +3,7 @@
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
-    server_name tc.gccollab.ca;
+    server_name talent.local.ca;
     return 301 https://$server_name$request_uri;
 
     error_log  /var/log/nginx/error.log;
@@ -54,7 +54,7 @@ server {
 }
 
 server {
-    server_name tc.gccollab.ca *.tc.gccollab.ca;
+    server_name talent.local.ca *.talent.local.ca;
 
     listen 443 ssl;
 

--- a/etc/nginx/default.template.conf
+++ b/etc/nginx/default.template.conf
@@ -3,7 +3,7 @@
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
-    server_name tc.gccollab.ca;
+    server_name talent.local.ca;
     return 301 https://$server_name$request_uri;
 
     error_log  /var/log/nginx/error.log;
@@ -54,7 +54,7 @@ server {
 }
 
 server {
-    server_name tc.gccollab.ca *.tc.gccollab.ca;
+    server_name talent.local.ca *.talent.local.ca;
 
     listen 443 ssl;
 

--- a/gen_certs.bat
+++ b/gen_certs.bat
@@ -1,3 +1,3 @@
-echo "Create SSL certificate for tc.gccollab.ca"
+echo "Create SSL certificate for talent.local.ca"
 SET CURRENTDIR="%cd%"
-docker run --rm -v %CURRENTDIR%/etc/ssl:/certificates -e "SERVER=tc.gccollab.ca" jacoelho/generate-certificate
+docker run --rm -v %CURRENTDIR%/etc/ssl:/certificates -e "SERVER=talent.local.ca" jacoelho/generate-certificate

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,7 +14,7 @@
 /* Home */
 // Route::get('/', 'HomepageController')->name('home');
 
-Route::group('prefix' => config('app.applicant_prefix')], function() {
+Route::group(['prefix' => config('app.applicant_prefix')], function() {
 
     /* Home */
     Route::get('/', 'HomepageController')->name('home');
@@ -666,7 +666,7 @@ $managerGroup = function() {
     Route::post('password/reset', 'Auth\ResetPasswordController@reset')->name('manager.password.reset.post');
 };
 
-Route::group('prefix' => config('app.manager_prefix')], $managerGroup);
+Route::group(['prefix' => config('app.manager_prefix')], $managerGroup);
 //Route::group(['domain' => 'hr.tc.gccollab.ca'], $managerGroup);
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,8 +14,7 @@
 /* Home */
 // Route::get('/', 'HomepageController')->name('home');
 
-Route::group(['domain' => config('app.applicant_domain'),
-    'prefix' => config('app.applicant_prefix')], function() {
+Route::group('prefix' => config('app.applicant_prefix')], function() {
 
     /* Home */
     Route::get('/', 'HomepageController')->name('home');
@@ -667,8 +666,7 @@ $managerGroup = function() {
     Route::post('password/reset', 'Auth\ResetPasswordController@reset')->name('manager.password.reset.post');
 };
 
-Route::group(['domain' => config('app.manager_domain'),
-    'prefix' => config('app.manager_prefix')], $managerGroup);
+Route::group('prefix' => config('app.manager_prefix')], $managerGroup);
 //Route::group(['domain' => 'hr.tc.gccollab.ca'], $managerGroup);
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -667,7 +667,7 @@ $managerGroup = function() {
 };
 
 Route::group(['prefix' => config('app.manager_prefix')], $managerGroup);
-//Route::group(['domain' => 'hr.tc.gccollab.ca'], $managerGroup);
+//Route::group(['domain' => 'hr.talent.local.ca'], $managerGroup);
 
 
 /* Testing ================================================================== */


### PR DESCRIPTION
To get the new local url `httops://talent.local.ca` working:
1. Merge this branch into your branch
2. In your .env file, change `APP_URL` to `https://talent.local.ca` *and delete* `APPLICANT_DOMAIN` and `MANAGER_DOMAIN`
3. On windows machines, go to your host file at `C:\Windows\System32\Drivers\etc\hosts`. Delete whatever talent-cloud-related entries are already there (you may have accumulated a couple). Add `127.0.0.1    talent.local.ca`. I don't know the apple equivalent to this step.
4. Restart your docker containers.
5. Restart your browser.