### PR TITLE
Resolve permission issues on /var/www/storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,10 @@ RUN apk update && apk upgrade && \
         libtool \
         make \
         pcre-dev && \
-    apk add --no-cache \
-        sudo \
-        postgresql-dev \
-        imagemagick-dev && \
+    apk add --no-cache postgresql-dev imagemagick-dev && \
         pecl install imagick && \
-        docker-php-ext-enable imagick && \
         pecl install xdebug && \
-        docker-php-ext-enable xdebug && \
+        docker-php-ext-enable imagick xdebug && \
         docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql && \
         docker-php-ext-install pgsql pdo_pgsql && \
     apk del .build-dependencies && \
@@ -33,8 +29,7 @@ WORKDIR /var/www
 
 RUN mkdir -p /var/www/vendor && \
     rm -rf .composer && \
-    chown -R www-data /var/www && \
-    sudo chown -R www-data /usr/local
+    chown -R www-data /usr/local
 
 USER www-data
 

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,12 @@
 # MySQL
 DB_DUMPS_DIR=database/db/dumps
 
+ROOT=/var/www
+
 build-db:
-	@docker exec -ti talentcloud sh -c "php artisan migrate:fresh"
-	@docker exec -ti talentcloud-db sh -c "psql -U talentcloud -f /manual_db/insert-data.sql"
-	@docker exec -ti talentcloud sh -c "php artisan db:seed"
+	@docker exec talentcloud sh -c "php artisan migrate:fresh"
+	@docker exec talentcloud-db sh -c "psql -U talentcloud -f /manual_db/insert-data.sql"
+	@docker exec talentcloud sh -c "php artisan db:seed"
 
 clean:
 	@rm -Rf database/db/pgsql/*
@@ -40,7 +42,11 @@ phpmd:
 	@docker-compose exec -T talentcloud ./vendor/bin/phpmd /app \
 	text cleancode,codesize
 
+set-root-perms:
+	@docker exec talentcloud sh -c "chgrp -R www-data ${ROOT}/storage ${ROOT}/bootstrap/cache"
+	@docker exec talentcloud sh -c "chmod -R g+w ${ROOT}/storage ${ROOT}/bootstrap/cache"
+
 test: code-sniff
 	@docker-compose exec -T talentcloud ./vendor/bin/phpunit --colors=always --configuration ./
 
-.PHONY: clean test code-sniff
+.PHONY: build-db clean code-sniff docker-start docker-stop gen-certs logs phpmd set-root-perms test


### PR DESCRIPTION
Changing the owner of the /var/www/ directory when creating a Docker image amounts to a no-op. Since the TalentCloud repository gets bind mounted in the container, changing the owner will also affect the Unix host filesystem and render the user unable to write to files under ./. The application, however, needs write access to ./storage.

I've opted to add a Makefile rule which sets the appropriate permissions on the /var/www/storage directory, allowing the PHP-FPM process to write to it. Running `make set-root-perms` after starting the Docker container resolves the issue.
