### PR TITLE
Remove integrity and crossorigin from analytics tag

### DIFF
--- a/resources/views/common/head.html.twig
+++ b/resources/views/common/head.html.twig
@@ -46,9 +46,8 @@
 
         <script
             async
-            src="https://www.googletagmanager.com/gtag/js?id=UA-115747902-1"
-            integrity="sha384-bRIbmosc8tXvRiCc91flCR8aYMe9gO4uflxPoGoBsRSw8gfjtnNFcTJhonxfWKqF"
-            crossorigin="anonymous"></script>
+            src="https://www.googletagmanager.com/gtag/js?id=UA-115747902-1">
+        </script>
 
         <script>
             window.dataLayer = window.dataLayer || [];

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -56,9 +56,8 @@
 
                 <script
                     async
-                    src="https://www.googletagmanager.com/gtag/js?id=UA-115747902-1"
-                    integrity="sha384-bRIbmosc8tXvRiCc91flCR8aYMe9gO4uflxPoGoBsRSw8gfjtnNFcTJhonxfWKqF"
-                    crossorigin="anonymous"></script>
+                    src="https://www.googletagmanager.com/gtag/js?id=UA-115747902-1">
+                </script>
 
                 <script>
                     window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
This has already been done on the live site