### PR TITLE
Remove relative paths from views

### DIFF
--- a/resources/views/common/header.html.twig
+++ b/resources/views/common/header.html.twig
@@ -8,7 +8,7 @@
     class="header"
     style="background-image: url('/images/bg_crowd.jpg');">
 
-    {% include "../common/menu" %}
+    {% include "common/menu" %}
 
     {# Header Content #}
 

--- a/resources/views/common/home/hero.html.twig
+++ b/resources/views/common/home/hero.html.twig
@@ -8,7 +8,7 @@
     class="home__hero"
     style="background-image: url('/images/bg_crowd.jpg');">
 
-    {% include "../common/menu" %}
+    {% include "common/menu" %}
 
     {# Hero Content #}
 

--- a/resources/views/manager/job_create/layout.html.twig
+++ b/resources/views/manager/job_create/layout.html.twig
@@ -18,7 +18,7 @@
 
                 <div class="manager-job-index__content-wrapper box lg-3of4">
 
-                    {% include "../../errors/form_errors" %}
+                    {% include "errors/form_errors" %}
 
                     {% include "manager/job_create/form" %}
 


### PR DESCRIPTION
The production server is unable to resolve relative paths in Laravel templates for some reason.