### PR TITLE
WIP Fixes Skill Claim in French #637

### DIFF
--- a/resources/lang/fr/common/skills.php
+++ b/resources/lang/fr/common/skills.php
@@ -17,7 +17,7 @@ return [
     'level_link_label' => '(Trouvez votre niveau de compétence)',
     'knowledge_label' => 'Comment j\'ai acquis cette compétence',
      'skill_status_null_label' => 'Statut: compétence pas ajouté',
-    'skill_status_label' => 'Statut: compétence',
+    'skill_status_label' => 'Statut:',
     'skill_level_null' => 'Aucun niveau de compétence n\'a été sélectionné.',
     'skill_levels' => [
         'hard' => [


### PR DESCRIPTION
Fixes the "Status: Claimed" area of a skill when translated in French. @gobyrne Please review to ensure this is now acting as you expect.