### PR TITLE
Task/manager publish job policy

### DIFF
--- a/app/Policies/JobPolicy.php
+++ b/app/Policies/JobPolicy.php
@@ -48,9 +48,10 @@ class JobPolicy extends BasePolicy
      */
     public function update(User $user, JobPoster $jobPoster)
     {
-        //Only managers can edit jobs, and only their own
+        //Only managers can edit jobs, and only their own, managers can't publish jobs or edit published jobs
         return $user->user_role->name == 'manager' &&
-            $jobPoster->manager->user->id == $user->id;
+            $jobPoster->manager->user->id == $user->id &&
+            !$jobPoster->published;
     }
 
     /**

--- a/tests/Feature/JobControllerTest.php
+++ b/tests/Feature/JobControllerTest.php
@@ -192,4 +192,17 @@ class JobControllerTest extends TestCase
         $response->assertSee($this->jobPoster->division);
         $response->assertSee($this->jobPoster->education);
     }
+
+        /**
+     * Ensure a manager cannot edit a published Job Poster they created.
+     *
+     * @return void
+     */
+    public function testManagerCanNotEditViewPublished() : void
+    {
+        $response = $this->actingAs($this->manager->user)
+            ->get('manager/jobs/' . $this->publishedJob->id . '/edit');
+
+        $response->assertStatus(500);
+    }
 }

--- a/tests/Unit/Policies/JobPolicyTest.php
+++ b/tests/Unit/Policies/JobPolicyTest.php
@@ -97,4 +97,20 @@ class JobPolicyTest extends TestCase
         ]);
         $this->assertTrue($this->policy->view($this->manager, $job));
     }
+
+    public function testManagerCanNotPublishJob()
+    {
+        $job = factory(JobPoster::class)->states('published')->make([
+            'manager_id' => $this->manager->manager->id
+        ]);
+        $this->assertFalse($this->policy->update($this->manager, $job));
+    }
+
+    public function testManagerCanUpdateDraftJob()
+    {
+        $job = factory(JobPoster::class)->states('unpublished')->make([
+            'manager_id' => $this->manager->manager->id
+        ]);
+        $this->assertTrue($this->policy->update($this->manager, $job));
+    }
 }


### PR DESCRIPTION
Resolves #729 
Managers should not be able to update published jobs

* Adds policy to stop managers from updating published jobs.
* Adds Unit Policy Test and Feature Test to verify