### PR TITLE
Refactor JobControllerTest factory objects to use unpublished state

### DIFF
--- a/database/factories/JobPosterFactory.php
+++ b/database/factories/JobPosterFactory.php
@@ -32,7 +32,7 @@ $factory->define(JobPoster::class, function (Faker\Generator $faker) use ($faker
         'manager_id' => function () {
             return factory(Manager::class)->create()->id;
         },
-        'published' => $faker->boolean(50),
+        'published' => false,
         'city:en' => $faker->city,
         'title:en' => $faker->unique()->word,
         'impact:en' => $faker->paragraphs(

--- a/tests/Feature/JobControllerTest.php
+++ b/tests/Feature/JobControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Lang;
 
 use App\Models\Applicant;
@@ -20,6 +21,8 @@ use Doctrine\Common\Cache\VoidCache;
 
 class JobControllerTest extends TestCase
 {
+    use RefreshDatabase;
+
     /**
      * Run parent setup and provide reusable factories.
      *
@@ -33,14 +36,18 @@ class JobControllerTest extends TestCase
         $this->faker_fr = \Faker\Factory::create('fr_FR');
 
         $this->manager = factory(Manager::class)->create();
-        $this->jobPoster = factory(JobPoster::class)->create([
-            'manager_id' => $this->manager->id
-        ]);
+        $this->jobPoster = factory(JobPoster::class)
+            ->states('unpublished')
+            ->create([
+                'manager_id' => $this->manager->id
+            ]);
 
         $this->otherManager = factory(Manager::class)->create();
-        $this->otherJobPoster = factory(JobPoster::class)->create([
-            'manager_id' => $this->otherManager->id
-        ]);
+        $this->otherJobPoster = factory(JobPoster::class)
+            ->states('unpublished')
+            ->create([
+                'manager_id' => $this->otherManager->id
+            ]);
 
         $this->publishedJob = factory(JobPoster::class)->states('published')->create();
     }


### PR DESCRIPTION
Tests were failing randomly because we added a policy to prevent manager accounts from editing a published job poster, and a state wasn't specified within the tests, causing the factory-created job to be published ~50% of the time.