### PR TITLE
Screening Plan Skill Names bugfix

### DIFF
--- a/app/Http/Controllers/ScreeningPlanController.php
+++ b/app/Http/Controllers/ScreeningPlanController.php
@@ -34,7 +34,7 @@ class ScreeningPlanController extends Controller
                 if (!$plan_type_assessments->isEmpty()) {
                     $assessment_plan[$type->name] = [];
                     foreach ($plan_type_assessments as $assessment) {
-                        $assessment_plan[$type->name][] = $assessment->criterion->skill->skill;
+                        $assessment_plan[$type->name][] = $assessment->criterion->skill->name;
                     }
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5519,12 +5519,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5539,17 +5541,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5666,7 +5671,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5678,6 +5684,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5692,6 +5699,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5699,12 +5707,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5723,6 +5733,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5803,7 +5814,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5815,6 +5827,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5936,6 +5949,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -474,7 +474,7 @@
 
         //Update ui for Skill object to reflect that it has been setItem
         function setSkillSaved(object, response) {
-            $(object).find('.accordion-title').text(response.data.skill.skill);
+            $(object).find('.accordion-title').text(response.data.skill.name);
             $(object).find('.skill__description').text(response.data.skill.description);
             $(object).find('.skill__status--level').text(response.data.skill_status.status);
         }

--- a/resources/views/manager/components/assessment-summary.html.twig
+++ b/resources/views/manager/components/assessment-summary.html.twig
@@ -22,7 +22,7 @@
                     <ul class="skill-list">
                         {% for skill in skills %}
                             {% for criterion in job.criteria %}
-                                {% if skill == criterion.skill.skill %}
+                                {% if skill == criterion.skill.name %}
                                     <li class="{% if criterion.criteria_type.name == "essential" %}green{% else %}blue{% endif %}">{{ skill }} ({{ criterion.level_name|title }})</li>
                                 {% endif %}
                             {% endfor %}

--- a/resources/views/manager/components/screening-plan.html.twig
+++ b/resources/views/manager/components/screening-plan.html.twig
@@ -96,7 +96,7 @@
                 <td colspan="2">
                     <ul>
                         {% for criterion in job.criteria %}
-                            <li>{{ criterion.skill.skill }} ({% if criterion.criteria_type.name == "essential" %}Essential{% else %}Asset{% endif %}, {{ criterion.level_name|title }})</li>
+                            <li>{{ criterion.skill.name }} ({% if criterion.criteria_type.name == "essential" %}Essential{% else %}Asset{% endif %}, {{ criterion.level_name|title }})</li>
                         {% endfor %}
                     </ul>
                 </td>
@@ -110,7 +110,7 @@
                         <ul>
                             {% for skill in skills %}
                                 {% for criterion in job.criteria %}
-                                    {% if skill == criterion.skill.skill %}
+                                    {% if skill == criterion.skill.name %}
                                         <li>{{ skill }} ({% if criterion.criteria_type.name == "essential" %}Essential{% else %}Asset{% endif %}, {{ criterion.level_name|title }})</li>
                                     {% endif %}
                                 {% endfor %}
@@ -131,7 +131,7 @@
 
                     <tr>
                         <td>
-                            <h4>{{ criterion.skill.skill }}</h4>
+                            <h4>{{ criterion.skill.name }}</h4>
                             {{ criterion.skill.description }}
                         </td>
                         <td>
@@ -163,7 +163,7 @@
 
                     <tr>
                         <td>
-                            <h4>{{ criterion.skill.skill }}</h4>
+                            <h4>{{ criterion.skill.name }}</h4>
                             {{ criterion.skill.description }}
                         </td>
                         <td>

--- a/resources/views/manager/components/skill-assessment-builder.html.twig
+++ b/resources/views/manager/components/skill-assessment-builder.html.twig
@@ -14,7 +14,7 @@
 <div class="skill-assessment-builder__item flex-grid top {% if template == true %}template{% endif %}">
 
     <div class="box full">
-        <h4 class="skill-title">{{ criterion.skill.skill }}</h4>
+        <h4 class="skill-title">{{ criterion.skill.name }}</h4>
     </div>
 
     <div class="box small-1of5">

--- a/resources/views/manager/components/skill-assessment-preview.html.twig
+++ b/resources/views/manager/components/skill-assessment-preview.html.twig
@@ -1,7 +1,7 @@
 <div class="skill-assessment-preview__item flex-grid top {% if template == true %}template{% endif %}">
 
     <div class="box small-1of5">
-        <span class="skill-label">{{ criterion.skill.skill }}</span>
+        <span class="skill-label">{{ criterion.skill.name }}</span>
         <p class="skill-description">{{ criterion.skill.description }}</p>
     </div>
 

--- a/resources/views/manager/screening-plan.html.twig
+++ b/resources/views/manager/screening-plan.html.twig
@@ -96,7 +96,7 @@
 
                                 {% if criterion.criteria_type.name == "asset" %}
 
-                                    {% include "manager/components/skill-assessment-builder" %}
+                                    {% include "manager/components/skill-assessment-builder" with { 'skill_builder_l10n':screening_l10n.skill_builder } %}
 
                                     {% set assetCriteria = assetCriteria + 1 %}
 


### PR DESCRIPTION
Skill names were still being accessed as `skill.skill`, but `skill.name` should now be used.