### PR TITLE
Fix failing unit tests comparing titles with html escaped characters

### DIFF
--- a/tests/Feature/JobControllerTest.php
+++ b/tests/Feature/JobControllerTest.php
@@ -65,7 +65,7 @@ class JobControllerTest extends TestCase
     {
         $response = $this->get('jobs/' . $this->publishedJob->id);
         $response->assertStatus(200);
-        $response->assertSee(Lang::get('applicant/job_post')['apply']['login_link_title']);
+        $response->assertSee(e(Lang::get('applicant/job_post')['apply']['login_link_title']));
     }
 
     /**
@@ -80,7 +80,7 @@ class JobControllerTest extends TestCase
         $response = $this->actingAs($applicant->user)
             ->get('jobs/' . $this->publishedJob->id);
         $response->assertStatus(200);
-        $response->assertSee(Lang::get('applicant/job_post')['apply']['apply_link_title']);
+        $response->assertSee(e(Lang::get('applicant/job_post')['apply']['apply_link_title']));
     }
 
     /**
@@ -94,8 +94,8 @@ class JobControllerTest extends TestCase
             ->get('manager/jobs');
         $response->assertStatus(200);
 
-        $response->assertSee($this->jobPoster->title);
-        $response->assertDontSee($this->otherJobPoster->title);
+        $response->assertSee(e($this->jobPoster->title));
+        $response->assertDontSeeText(e($this->otherJobPoster->title));
     }
 
     /**
@@ -135,11 +135,11 @@ class JobControllerTest extends TestCase
             ->get('manager/jobs/create');
         $response->assertStatus(200);
 
-        $response->assertSee('<h2 class="heading--01">' . Lang::get('manager/job_create')['title'] . '</h2>');
+        $response->assertSee(e(Lang::get('manager/job_create')['title']));
         $response->assertViewIs('manager.job_create');
 
-        $response->assertSee(Lang::get('manager/job_create', [], 'en')['questions']['00']);
-        $response->assertSee(Lang::get('manager/job_create', [], 'fr')['questions']['00']);
+        $response->assertSee(e(Lang::get('manager/job_create', [], 'en')['questions']['00']));
+        $response->assertSee(e(Lang::get('manager/job_create', [], 'fr')['questions']['00']));
     }
 
     /**
@@ -205,7 +205,7 @@ class JobControllerTest extends TestCase
         $response->assertStatus(200);
         $response->assertViewIs('applicant.job_post');
         $this->assertDatabaseHas('job_posters', $dbValues);
-        $response->assertSee(Lang::get('applicant/job_post')['apply']['edit_link_title']);
+        $response->assertSee(e(Lang::get('applicant/job_post')['apply']['edit_link_title']));
     }
 
     /**
@@ -221,13 +221,13 @@ class JobControllerTest extends TestCase
         $response->assertStatus(200);
         $response->assertViewIs('manager.job_create');
         // Check for a handful of properties
-        $response->assertSee($this->jobPoster->city);
-        $response->assertSee($this->jobPoster->education);
-        $response->assertSee($this->jobPoster->title);
-        $response->assertSee($this->jobPoster->impact);
-        $response->assertSee($this->jobPoster->branch);
-        $response->assertSee($this->jobPoster->division);
-        $response->assertSee($this->jobPoster->education);
+        $response->assertSee(e($this->jobPoster->city));
+        $response->assertSee(e($this->jobPoster->education));
+        $response->assertSee(e($this->jobPoster->title));
+        $response->assertSee(e($this->jobPoster->impact));
+        $response->assertSee(e($this->jobPoster->branch));
+        $response->assertSee(e($this->jobPoster->division));
+        $response->assertSee(e($this->jobPoster->education));
     }
 
         /**


### PR DESCRIPTION
Solution grabbed from https://stackoverflow.com/a/49613639