### PR TITLE
Empty Applicant Profile Answers Handling for Manager portal

### DIFF
--- a/resources/lang/en/manager/applicant_profile.php
+++ b/resources/lang/en/manager/applicant_profile.php
@@ -20,6 +20,7 @@ return [
     'content' => [
         'whose_profile' => 'You are viewing :name\'s profile.',
         'no_applicant_answers' => 'The applicant hasn\'t answered any questions.',
+        'no_applicant_answer' => "The applicant has not answered this profile question.",
         'their_answer' => 'Their Answer:'
     ]
 ];

--- a/resources/lang/fr/manager/applicant_profile.php
+++ b/resources/lang/fr/manager/applicant_profile.php
@@ -20,6 +20,7 @@ return [
     'content' => [
         'whose_profile' => 'Voici le profil de :name.',
         'no_applicant_answers' => 'Le candidat n\'a répondu à aucune question.',
+        'no_applicant_answer' => "Le candidat n'a pas répondu à cette question de profil.",
         'their_answer' => 'Leur réponse :'
     ]
 ];

--- a/resources/views/manager/applicant_profile.html.twig
+++ b/resources/views/manager/applicant_profile.html.twig
@@ -48,7 +48,16 @@
 
 							<p>{{ question.applicant_profile_question.description }}</p>
 
-							<p><span class="bold">{{ profile.content.their_answer }}</span>{{ question.answer }}</p>
+
+							{% if question.answer is empty %}
+
+								<p><em>{{profile.content.no_applicant_answer}}</em></p>
+
+							{% else %}
+
+								<p><span class="bold">{{ profile.content.their_answer }}</span>{{ question.answer }}</p>
+
+							{% endif %}
 
 						</div>
 


### PR DESCRIPTION
Resolves #751 

All questions being empty already had a handler since I was there I added a handler for individual profile questions without answers. 