### PR TITLE
Allow admins to edit draft Job Posters

### DIFF
--- a/app/Http/Controllers/Admin/JobPosterCrudController.php
+++ b/app/Http/Controllers/Admin/JobPosterCrudController.php
@@ -60,10 +60,15 @@ class JobPosterCrudController extends CrudController
             'label' => 'Manager'
         ]);
         $this->crud->addColumn([
-            'name' => "submitted_applications_count",
-            'label' => "Applications",
-            'type' => "model_function",
-            'function_name' => 'submitted_applications_count',
+            'name' => 'submitted_applications_count',
+            'label' => 'Applications',
+            'type' => 'closure',
+            'function' =>
+                function ($entry) {
+                    return $entry->submitted_applications_count() > 0 ?
+                        '<a href="' . route('manager.jobs.applications', $entry->id) . '">' . $entry->submitted_applications_count() . ' (View <i class="fa fa-external-link"></i>)</a>' :
+                        $entry->submitted_applications_count();
+                }
         ]);
 
         $this->crud->addField([

--- a/app/Http/Controllers/Admin/JobPosterCrudController.php
+++ b/app/Http/Controllers/Admin/JobPosterCrudController.php
@@ -25,6 +25,9 @@ class JobPosterCrudController extends CrudController
             $this->crud->orderBy('close_date_time', 'desc');
         }
 
+        // Add the custom blade button found in public/vendor/backpack/crud/buttons/full-edit.blade.php
+        $this->crud->addButtonFromView('line', 'full_edit', 'full_edit', 'end');
+
         $this->crud->addColumn([
             'name' => 'title',
             'type' => 'text',
@@ -44,7 +47,7 @@ class JobPosterCrudController extends CrudController
             'name' => "status",
             'label' => "Status",
             'type' => "model_function",
-            'function_name' => 'displayStatus',
+            'function_name' => 'status',
         ]);
         $this->crud->addColumn([
             'name' => "published",
@@ -90,6 +93,8 @@ class JobPosterCrudController extends CrudController
 
     /**
      * Action for updating an existing Job Poster in the database.
+     *
+     * @param \Illuminate\Http\Request $request Incoming form request.
      *
      * @return \Illuminate\Http\RedirectResponse
      */

--- a/database/factories/JobPosterFactory.php
+++ b/database/factories/JobPosterFactory.php
@@ -20,6 +20,8 @@ $factory->define(JobPoster::class, function (Faker\Generator $faker) use ($faker
         'open_date_time' => $faker->dateTimeBetween('-1 months', 'now'),
         'close_date_time' => $faker->dateTimeBetween('now', '1 months'),
         'start_date_time' => $faker->dateTimeBetween('1 months', '2 months'),
+        'review_requested_at' => $faker->dateTimeBetween('-2 months', '-1 months'),
+        'published_at' => null,
         'department_id' => Department::inRandomOrder()->first()->id,
         'province_id' => Province::inRandomOrder()->first()->id,
         'salary_min' => $faker->numberBetween(60000, 80000),
@@ -54,7 +56,7 @@ $factory->define(JobPoster::class, function (Faker\Generator $faker) use ($faker
     ];
 });
 
-$factory->afterCreating(JobPoster::class, function ($jp) {
+$factory->afterCreating(JobPoster::class, function ($jp) : void {
     $jp->criteria()->saveMany(factory(Criteria::class, 5)->make([
         'job_poster_id' => $jp->id
     ]));
@@ -66,13 +68,16 @@ $factory->afterCreating(JobPoster::class, function ($jp) {
     ]));
 });
 
-$factory->state(JobPoster::class, 'published', [
-    'published' => true
-]);
-
-$factory->state(JobPoster::class, 'unpublished', [
-    'published' => false
-]);
+$factory->state(
+    JobPoster::class,
+    'published',
+    function (Faker\Generator $faker) {
+        return [
+            'published' => true,
+            'published_at' => $faker->dateTimeBetween('-1 months', '-3 weeks')
+        ];
+    }
+);
 
 $factory->state(
     JobPoster::class,
@@ -80,7 +85,22 @@ $factory->state(
     function (Faker\Generator $faker) {
         return [
             'published' => true,
+            'published_at' => $faker->dateTimeBetween('-1 months', '-3 weeks'),
             'close_date_time' => $faker->dateTimeBetween('-2 days', '-1 days'),
+        ];
+    }
+);
+
+$factory->state(
+    JobPoster::class,
+    'draft',
+    function (Faker\Generator $faker) {
+        return [
+            'published' => false,
+            'open_date_time' => $faker->dateTimeBetween('5 days', '10 days'),
+            'close_date_time' => $faker->dateTimeBetween('3 weeks', '5 weeks'),
+            'review_requested_at' => null,
+            'published_at' => null,
         ];
     }
 );
@@ -91,6 +111,8 @@ $factory->state(
     function (Faker\Generator $faker) {
         return [
             'published' => false,
+            'open_date_time' => $faker->dateTimeBetween('5 days', '10 days'),
+            'close_date_time' => $faker->dateTimeBetween('3 weeks', '5 weeks'),
             'review_requested_at' => $faker->dateTimeBetween('-2 days', '-1 days')
         ];
     }

--- a/database/seeds/DevSeeder.php
+++ b/database/seeds/DevSeeder.php
@@ -5,10 +5,9 @@ use App\Models\Manager;
 use App\Models\User;
 use App\Models\JobPoster;
 use App\Models\Applicant;
-use App\Models\UserRole;
 use App\Models\JobApplication;
 
-class DevSeeder extends Seeder
+class DevSeeder extends Seeder // phpcs:ignore
 {
     /**
      * This seeder uses this email for an admin user.
@@ -41,7 +40,7 @@ class DevSeeder extends Seeder
      *
      * @return void
      */
-    public function run()
+    public function run() : void
     {
         $adminUser = User::where('email', $this->adminEmail)->first();
         if ($adminUser === null) {
@@ -57,24 +56,26 @@ class DevSeeder extends Seeder
             ]));
         }
 
-        //Add new jobs to the test manager, along with applications if they've been open
-        $managerUser->manager->job_posters()->save(factory(JobPoster::class)->state('published')->create([
+        factory(JobPoster::class, 3)->state('published')->create([
             'manager_id' => $managerUser->manager->id
-        ]))->each(function ($job) : void {
-            $job->job_applications()->saveMany(factory(JobApplication::class, 10)->create([
+        ])->each(function ($job) : void {
+            $job->job_applications()->saveMany(factory(JobApplication::class, 5))->create([
                 'job_poster_id' => $job->id
-            ]));
+            ]);
         });
-        $managerUser->manager->job_posters()->save(factory(JobPoster::class)->state('unpublished')->create([
+        factory(JobPoster::class, 3)->state('closed')->create([
             'manager_id' => $managerUser->manager->id
-        ]));
-        $managerUser->manager->job_posters()->save(factory(JobPoster::class)->state('closed')->create([
-            'manager_id' => $managerUser->manager->id
-        ]))->each(function ($job) : void {
-            $job->job_applications()->saveMany(factory(JobApplication::class, 10)->create([
+        ])->each(function ($job) : void {
+            $job->job_applications()->saveMany(factory(JobApplication::class, 5))->create([
                 'job_poster_id' => $job->id
-            ]));
+            ]);
         });
+        factory(JobPoster::class, 3)->state('draft')->create([
+            'manager_id' => $managerUser->manager->id
+        ]);
+        factory(JobPoster::class, 3)->state('review_requested')->create([
+            'manager_id' => $managerUser->manager->id
+        ]);
 
         $applicantUser = User::where('email', $this->applicantEmail)->first();
         if ($applicantUser === null) {

--- a/resources/views/vendor/backpack/crud/buttons/full_edit.blade.php
+++ b/resources/views/vendor/backpack/crud/buttons/full_edit.blade.php
@@ -1,0 +1,3 @@
+@if ($crud->hasAccess('update') && $entry->status() === 'draft')
+<a href="{{ route('manager.jobs.edit', $entry->id) }} " class="btn btn-xs btn-default"><i class="fa fa-edit"></i> Full Edit</a>
+@endif

--- a/tests/Feature/JobControllerTest.php
+++ b/tests/Feature/JobControllerTest.php
@@ -11,16 +11,12 @@ use Illuminate\Support\Facades\Mail;
 use Jenssegers\Date\Date;
 
 use App\Models\Applicant;
-use App\Models\Criteria;
 use App\Models\Lookup\Department;
 use App\Models\JobPoster;
-use App\Models\JobPosterKeyTask;
-use App\Models\JobPosterQuestion;
 use App\Models\Lookup\LanguageRequirement;
 use App\Models\Manager;
 use App\Models\Lookup\Province;
 use App\Models\Lookup\SecurityClearance;
-use Doctrine\Common\Cache\VoidCache;
 use App\Mail\JobPosterReviewRequested;
 
 class JobControllerTest extends TestCase
@@ -41,14 +37,12 @@ class JobControllerTest extends TestCase
 
         $this->manager = factory(Manager::class)->create();
         $this->jobPoster = factory(JobPoster::class)
-            ->states('unpublished')
             ->create([
                 'manager_id' => $this->manager->id
             ]);
 
         $this->otherManager = factory(Manager::class)->create();
         $this->otherJobPoster = factory(JobPoster::class)
-            ->states('unpublished')
             ->create([
                 'manager_id' => $this->otherManager->id
             ]);

--- a/tests/Unit/JobPosterTest.php
+++ b/tests/Unit/JobPosterTest.php
@@ -9,11 +9,11 @@ use Illuminate\Support\Facades\Lang;
 use Jenssegers\Date\Date;
 
 use App\Models\JobPoster;
-use Doctrine\Common\Cache\VoidCache;
 
 class JobPosterTest extends TestCase
 {
     use WithFaker;
+    use RefreshDatabase;
 
     /**
      * Test that JobPoster->isOpen() behaves properly
@@ -28,7 +28,7 @@ class JobPosterTest extends TestCase
         $jobPoster->close_date_time = $this->faker->dateTimeBetween('-1 weeks', 'now');
         $this->assertFalse($jobPoster->isOpen());
 
-        $jobPoster = factory(JobPoster::class)->states('unpublished')->make();
+        $jobPoster = factory(JobPoster::class)->states('draft')->make();
         $this->assertFalse($jobPoster->isOpen());
     }
 
@@ -37,7 +37,7 @@ class JobPosterTest extends TestCase
      *
      * @return void
      */
-    public function testJobPosterIsClosed()
+    public function testJobPosterIsClosed() : void
     {
         $jobPoster = factory(JobPoster::class)->states('published')->make();
         $this->assertFalse($jobPoster->isClosed());
@@ -45,7 +45,7 @@ class JobPosterTest extends TestCase
         $jobPoster->close_date_time = $this->faker->dateTimeBetween('-1 weeks', '-5 minutes');
         $this->assertTrue($jobPoster->isClosed());
 
-        $jobPoster = factory(JobPoster::class)->states('unpublished')->make();
+        $jobPoster = factory(JobPoster::class)->states('draft')->make();
         $this->assertFalse($jobPoster->isClosed());
     }
 
@@ -54,9 +54,9 @@ class JobPosterTest extends TestCase
      *
      * @return void
      */
-    public function testJobPosterStatus()
+    public function testJobPosterStatus() : void
     {
-        $jobPoster = factory(JobPoster::class)->states('unpublished')->make();
+        $jobPoster = factory(JobPoster::class)->states('draft')->make();
         $this->assertEquals('draft', $jobPoster->status());
 
         $jobPoster = factory(JobPoster::class)->states('published')->make();
@@ -121,7 +121,7 @@ class JobPosterTest extends TestCase
     public function testJobPosterPublishedMutator() : void
     {
         // Open but not yet published
-        $jobPoster = factory(JobPoster::class)->states('unpublished')->make();
+        $jobPoster = factory(JobPoster::class)->make();
         $this->assertEquals(null, $jobPoster->published_at);
 
         $jobPoster->published = true;
@@ -132,10 +132,7 @@ class JobPosterTest extends TestCase
         $this->assertNotEquals($jobPoster->open_date_time, $jobPoster->published_at);
 
         // Not yet open and not yet published
-        $jobPoster = factory(JobPoster::class)->states('unpublished')->make([
-            'open_date_time' => $this->faker->dateTimeBetween('now', '1 weeks'),
-            'close_date_time' => $this->faker->dateTimeBetween('2 weeks', '4 weeks')
-        ]);
+        $jobPoster = factory(JobPoster::class)->states('review_requested')->make();
         $this->assertEquals(null, $jobPoster->published_at);
 
         $jobPoster->published = true;

--- a/tests/Unit/Policies/JobPolicyTest.php
+++ b/tests/Unit/Policies/JobPolicyTest.php
@@ -3,12 +3,10 @@
 namespace Tests\Unit\Policies;
 
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use App\Policies\JobPolicy;
 use App\Models\JobPoster;
-use App\Models\User;
 use App\Models\Applicant;
 use App\Models\Manager;
 
@@ -50,7 +48,7 @@ class JobPolicyTest extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -60,13 +58,22 @@ class JobPolicyTest extends TestCase
         $this->guest = null;
     }
 
-
-    protected function policy()
+    /**
+     * Provide a JobPolicy object on demand.
+     *
+     * @return JobPolicy
+     */
+    protected function policy() : JobPolicy
     {
         return new JobPolicy();
     }
 
-    public function testAnyoneCanViewOpenJob()
+    /**
+     * Test the policy around an open Job Poster.
+     *
+     * @return void
+     */
+    public function testAnyoneCanViewOpenJob() : void
     {
         $job = factory(JobPoster::class)->states('published')->make();
         $this->assertTrue($this->policy->view($this->guest, $job));
@@ -74,7 +81,12 @@ class JobPolicyTest extends TestCase
         $this->assertTrue($this->policy->view($this->manager, $job));
     }
 
-    public function testAnyoneCanViewClosedJob()
+    /**
+     * Test the policy around a closed Job Poster.
+     *
+     * @return void
+     */
+    public function testAnyoneCanViewClosedJob() : void
     {
         $job = factory(JobPoster::class)->states('closed')->make();
         $this->assertTrue($this->policy->view($this->guest, $job));
@@ -82,23 +94,38 @@ class JobPolicyTest extends TestCase
         $this->assertTrue($this->policy->view($this->manager, $job));
     }
 
-    public function testNoOneCanViewUnpublishedJob()
+    /**
+     * Test the policy around an unpublished Job Poster.
+     *
+     * @return void
+     */
+    public function testNoOneCanViewUnpublishedJob() : void
     {
-        $job = factory(JobPoster::class)->states('unpublished')->make();
+        $job = factory(JobPoster::class)->make();
         $this->assertFalse($this->policy->view($this->guest, $job));
         $this->assertFalse($this->policy->view($this->applicant, $job));
         $this->assertFalse($this->policy->view($this->manager, $job));
     }
 
-    public function testManagerCanViewOwnUnpublishedJob()
+    /**
+     * Ensure a manager can view their own unpublished Job Poster.
+     *
+     * @return void
+     */
+    public function testManagerCanViewOwnUnpublishedJob() : void
     {
-        $job = factory(JobPoster::class)->states('unpublished')->make([
+        $job = factory(JobPoster::class)->make([
             'manager_id' => $this->manager->manager->id
         ]);
         $this->assertTrue($this->policy->view($this->manager, $job));
     }
 
-    public function testManagerCanNotPublishJob()
+    /**
+     * Ensure a manager cannot publish their own Job Poster.
+     *
+     * @return void
+     */
+    public function testManagerCanNotPublishJob() : void
     {
         $job = factory(JobPoster::class)->states('published')->make([
             'manager_id' => $this->manager->manager->id
@@ -106,9 +133,14 @@ class JobPolicyTest extends TestCase
         $this->assertFalse($this->policy->update($this->manager, $job));
     }
 
-    public function testManagerCanUpdateDraftJob()
+    /**
+     * Ensure a manager can edit their own draft Job Poster.
+     *
+     * @return void
+     */
+    public function testManagerCanUpdateDraftJob() : void
     {
-        $job = factory(JobPoster::class)->states('unpublished')->make([
+        $job = factory(JobPoster::class)->make([
             'manager_id' => $this->manager->manager->id
         ]);
         $this->assertTrue($this->policy->update($this->manager, $job));


### PR DESCRIPTION
Added a link to the admin view for all Job Posters, did a bit of refactoring to the factory/seeder/unit tests.
Also added links from the Applications column to the applicant view for a given Job Poster.