### PR TITLE
Remove phpcbf executable path from vscode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,6 @@
         "**/vendor/**": true
     },
     "php.suggest.basic": false,
-    "phpcbf.executablePath": "./vendor/bin/phpcbf",
     "phpcbf.standard": "./ruleset.xml",
     "phpcs.standard": "./ruleset.xml"
 }


### PR DESCRIPTION
This needs to be configured differently on different machines.