### PR TITLE
Remove phpcbf ruleset from vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,6 @@
         "**/vendor/**": true
     },
     "php.suggest.basic": false,
-    "phpcbf.standard": "./ruleset.xml",
     "phpcs.standard": "./ruleset.xml",
     "eslint.autoFixOnSave": true,
     "eslint.validate": [
@@ -22,7 +21,7 @@
     },
     "[typescript]": {
         "editor.formatOnPaste": true,
-    "editor.formatOnSave": true
+        "editor.formatOnSave": true
     },
     "[typescriptreact]": {
         "editor.formatOnPaste": true,


### PR DESCRIPTION
The extension being used for PHPCBF seems to require an absolute path to the ruleset file. For now it makes more sense to store it in the user settings.