### PR TITLE
Add custom crud trait that overrides isColumnNullable

### DIFF
--- a/app/CRUD/TalentCloudCrudTrait.php
+++ b/app/CRUD/TalentCloudCrudTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\CRUD;
+
+use Backpack\CRUD\CrudTrait;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Config;
+
+trait TalentCloudCrudTrait
+{
+    use CrudTrait;
+
+    /**
+     * Override for existing isColumnNullable static function on the CrudTrait. Current
+     * implementation doesn't allow for other custom column types outside of what's defined in
+     * Backpack.
+     *
+     * @param string $column_name Name of the column to check.
+     *
+     * @return boolean
+     */
+    public static function isColumnNullable(string $column_name) : bool
+    {
+        // create an instance of the model to be able to get the table name
+        $instance = new static();
+        $conn = DB::connection($instance->getConnectionName());
+        $table = Config::get('database.connections.'.Config::get('database.default').'.pr e fix').$instance->getTable();
+        // MongoDB columns are alway nullable
+        if ($conn->getConfig()['driver'] === 'mongodb') {
+            return true;
+        }
+        // register the enum, json, jsonb, and citext column types, because Doctrine doesn't support it
+        $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+        $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('json', 'json_array');
+        $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('jsonb', 'json_array');
+        $conn->getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('citext', 'string');
+        return !$conn->getDoctrineColumn($table, $column_name)->getNotnull();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -17,7 +17,7 @@ use Illuminate\Notifications\Notifiable;
 use App\Events\UserCreated;
 use App\Events\UserUpdated;
 use App\Notifications\ResetPasswordNotification;
-use \Backpack\CRUD\CrudTrait;
+use App\CRUD\TalentCloudCrudTrait as CrudTrait;
 
 /**
  * Class User
@@ -39,13 +39,13 @@ use \Backpack\CRUD\CrudTrait;
  */
 class User extends BaseModel implements
     // Laravel contracts for native login
-        AuthenticatableContract,
-        CanResetPasswordContract,
+    AuthenticatableContract,
+    CanResetPasswordContract,
     // Contract for use with Gates and Policies
-        AuthorizableContract
+    AuthorizableContract
     // Custom contract for use with openid login
-    //    \App\Services\Auth\Contracts\OidcAuthenticatable
-        {
+    // \App\Services\Auth\Contracts\OidcAuthenticatable
+{
 
     //Traits for Laravel basic authentication
     use Authenticatable, CanResetPassword;
@@ -59,7 +59,8 @@ class User extends BaseModel implements
     protected $casts = [
         'is_confirmed' => 'boolean',
         'is_priority' => 'boolean',
-        'user_role_id' => 'int'
+        'user_role_id' => 'int',
+        'email' => 'string',
     ];
     protected $fillable = [
         'name', 'email', 'password', 'is_priority'


### PR DESCRIPTION
I think I tracked it down to Backpack's custom static method `isColumnNullable`. Even though the field in question (email) wasn't editable in the view, it was still being referenced and throwing an error. I added a custom trait that extends the one provided by Backpack and added a `citext` mapping to it.

This should also allow us to override more mappings in the future, although we have to be mindful of maintaining this specific method ourselves.

See [this block of code](https://github.com/Laravel-Backpack/CRUD/blob/b5ca85f12f8f3b5a9e005cc31e820dc34ac8a2ed/src/CrudTrait.php#L54-L73) for the original implementation.