### PR TITLE
Move site stylesheet as high as possible in the head

### DIFF
--- a/resources/views/common/head.html.twig
+++ b/resources/views/common/head.html.twig
@@ -30,6 +30,15 @@
             content="{{ csrf_token() }}"
             name="csrf-token">
 
+{# Stylesheets #}
+
+    {# App #}
+
+    <link
+        href="{{ mix('/css/app.css') }}"
+        rel="stylesheet"
+        type="text/css"/>
+
 {# Google Fonts #}
 {#
     NOTE: Google Fonts does not support Subresource Integrity (SRI).
@@ -91,15 +100,6 @@
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#d03e3e">
     <meta name="msapplication-TileColor" content="#d03e3e">
     <meta name="theme-color" content="#ffffff">
-
-{# Stylesheets #}
-
-    {# App #}
-
-        <link
-            href="{{ mix('/css/app.css') }}"
-            rel="stylesheet"
-            type="text/css"/>
 
     </head>
 

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -23,10 +23,8 @@ mix
   .js("resources/assets/js/alerts.js", "public/js")
   .ts("resources/assets/js/components.tsx", "public/js")
   .sass("resources/assets/sass/app.scss", "public/css", {
-    implementation: require("node-sass"),
-    includePaths: [
-      "node_modules/@fortawesome/fontawesome-free/scss",
-    ]
+    implementation: sass,
+    includePaths: ["node_modules/@fortawesome/fontawesome-free/scss"]
   })
   .options({
     processCssUrls: false,


### PR DESCRIPTION
Relates to #818 

The site CSS file was being queued after about 5 different Javascript files, some of which are external to our server. Moving the CSS file as high as possible should eliminate flashes of unstyled content.