### PR TITLE
Removed Job Poster Creation from Managers

### DIFF
--- a/app/Http/Controllers/Admin/ManagerCrudController.php
+++ b/app/Http/Controllers/Admin/ManagerCrudController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+
+class ManagerCrudController extends CrudController
+{
+    /**
+     * Prepare the admin interface by setting the associated
+     * model, setting the route, and adding custom columns/fields.
+     *
+     * @return void
+     */
+    public function setup() : void
+    {
+        $this->crud->setModel("App\Models\Manager");
+        $this->crud->setRoute("admin/manager");
+        $this->crud->setEntityNameStrings('manager', 'managers');
+
+        $this->crud->denyAccess('create');
+        $this->crud->denyAccess('delete');
+
+        $this->crud->addColumn([
+            'name' => 'user.name',
+            'type' => 'text',
+            'label' => 'Name'
+        ]);
+        $this->crud->addColumn([
+            'name' => 'user.email',
+            'type' => 'text',
+            'label' => 'Email'
+        ]);
+
+        $this->crud->removeButton('update');
+        $this->crud->addButtonFromView('line', 'create_job_poster', 'create_job_poster', 'beginning');
+    }
+}

--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -22,14 +22,11 @@ use App\Models\Lookup\JobTerm;
 use App\Models\Lookup\Province;
 use App\Models\Lookup\SecurityClearance;
 use App\Models\Lookup\LanguageRequirement;
-use App\Models\Lookup\CitizenshipDeclaration;
 use App\Models\Lookup\Department;
 use App\Models\Lookup\SkillLevel;
 use App\Models\Lookup\CriteriaType;
-use App\Models\Lookup\VeteranStatus;
-use App\Models\JobApplication;
-use App\Models\Criteria;
 use App\Models\Skill;
+use App\Models\Manager;
 use App\Models\JobPosterKeyTask;
 
 use App\Services\Validation\JobPosterValidator;
@@ -221,6 +218,33 @@ class JobController extends Controller
                 'skill_template' => Lang::get('common/skills'),
             ]
         );
+    }
+
+    /**
+     * Create a blank job poster for the specified manager
+     *
+     * @param Manager $manager
+     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory Job Create view
+     */
+    public function createAsManager(Manager $manager)
+    {
+        $jobPoster = new JobPoster();
+        $jobPoster->manager_id = $manager->id;
+        $managerEn = $manager->translate('en');
+        $managerFr = $manager->translate('fr');
+        $jobPoster->fill([
+            'department_id' => $manager->department_id,
+            'en' => [
+                'branch' => $managerEn->branch,
+                'division' => $managerEn->division,
+            ],
+            'fr' => [
+                'branch' => $managerFr->branch,
+                'division' => $managerFr->division,
+            ]
+        ]);
+        $jobPoster->save();
+        return redirect()->route('manager.jobs.edit', $jobPoster->id);
     }
 
     /**

--- a/app/Http/ViewComposers/MenuComposer.php
+++ b/app/Http/ViewComposers/MenuComposer.php
@@ -114,7 +114,8 @@ class MenuComposer
                 case 'manager.jobs.create':
                 case 'manager.jobs.edit':
                 case 'manager.jobs.update':
-                    $menu['items']['create_job']['active'] = true;
+                    //$menu['items']['create_job']['active'] = true;
+                    $menu['items']['jobs']['active'] = true; //TODO: restore when job poster builder complete
                     break;
                 case 'manager.profile':
                 case 'manager.profile.edit':
@@ -141,7 +142,8 @@ class MenuComposer
             //Set route links
             $menu['items']['home']['link'] = route('manager.home');
             $menu['items']['jobs']['link'] = route('manager.jobs.index');
-            $menu['items']['create_job']['link'] = route('manager.jobs.create');
+            //TODO: restore when job poster builder complete
+            //$menu['items']['create_job']['link'] = route('manager.jobs.create');
             $menu['items']['profile']['link'] = route('manager.profile');
 
             //Check if use is logged in, and remove invalid menu items

--- a/app/Models/Manager.php
+++ b/app/Models/Manager.php
@@ -6,7 +6,8 @@
  */
 
 namespace App\Models;
-use App\Models\TeamCulture;
+
+use App\CRUD\TalentCloudCrudTrait as CrudTrait;
 
 /**
  * Class Manager
@@ -52,6 +53,8 @@ use App\Models\TeamCulture;
 class Manager extends BaseModel {
 
     use \Dimsav\Translatable\Translatable;
+    // Trait for Backpack
+    use CrudTrait;
 
     public $translatedAttributes = ['about_me', 'greatest_accomplishment', 'branch',
         'division', 'position', 'work_experience', 'education','leadership_style',

--- a/app/Policies/JobPolicy.php
+++ b/app/Policies/JobPolicy.php
@@ -36,7 +36,8 @@ class JobPolicy extends BasePolicy
     public function create(User $user)
     {
         //Any manager can create a new job poster
-        return $user->user_role->name == 'manager';
+        //TODO: for now, only Admins can create posters. This will change soon.
+        return $user->hasRole('admin');
     }
 
     /**

--- a/resources/lang/en/manager/menu.php
+++ b/resources/lang/en/manager/menu.php
@@ -15,9 +15,10 @@ return [
         "jobs" => [
             "name" => "My Job Posters",
         ],
-        "create_job" => [
-            "name" => "Create Job Poster",
-        ],
+        //TODO: restore when job poster builder complete
+        // "create_job" => [
+        //     "name" => "Create Job Poster",
+        // ],
         "profile" => [
             "name" => "My Profile",
         ],

--- a/resources/lang/fr/manager/menu.php
+++ b/resources/lang/fr/manager/menu.php
@@ -15,9 +15,10 @@ return [
         "jobs" => [
             "name" => "Mes affiches d'emploi",
         ],
-        "create_job" => [
-            "name" => "Créer une affiche d'emploi",
-        ],
+        //TODO: restore when job poster builder complete
+        // "create_job" => [
+        //     "name" => "Créer une affiche d'emploi",
+        // ],
         "profile" => [
             "name" => "Mon profil",
         ],

--- a/resources/views/manager/job_index/layout.html.twig
+++ b/resources/views/manager/job_index/layout.html.twig
@@ -39,6 +39,7 @@
 
                     </div>
 
+                    {# TODO: Remove comment block when Managers can create jobs again
                     <div class="box med-1of2 new-poster-button-wrapper">
 
                         <a
@@ -49,6 +50,7 @@
                         </a>
 
                     </div>
+                    #}
 
                 </div>
 

--- a/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
@@ -3,3 +3,4 @@
 <li><a href='{{ backpack_url('skill') }}'><i class='fa fa-list'></i> <span>Skills</span></a></li>
 <li><a href='{{ backpack_url('job-poster') }}'><i class='fa fa-file'></i> <span>Job Posters</span></a></li>
 <li><a href='{{ backpack_url('user') }}'><i class='fa fa-user'></i> <span>Users</span></a></li>
+<li><a href='{{ backpack_url('manager') }}'><i class='fa fa-user'></i> <span>Managers</span></a></li>

--- a/resources/views/vendor/backpack/crud/buttons/create_job_poster.blade.php
+++ b/resources/views/vendor/backpack/crud/buttons/create_job_poster.blade.php
@@ -1,0 +1,1 @@
+<a href="{{ route('admin.jobs.create.as_manager', $entry->id) }} " class="btn btn-xs btn-default"><i class="fa fa-edit"></i>Create Job Poster</a>

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -15,4 +15,5 @@ Route::group([
     CRUD::resource('skill', 'SkillCrudController');
     CRUD::resource('job-poster', 'JobPosterCrudController');
     CRUD::resource('user', 'UserCrudController');
+    CRUD::resource('manager', 'ManagerCrudController');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -346,3 +346,17 @@ Route::group(
 );
 
 /** ALL NON-LOCALIZED ROUTES **/
+
+/* Non-Backpack Admin Portal =========================================================== */
+
+Route::group(
+    [
+        'prefix' => 'admin',
+        'middleware' => ['auth', 'role:admin']
+    ],
+    function (): void {
+        Route::get('jobs/create/as-manager/{manager}', 'JobController@createAsManager')
+            ->middleware('can:create,App\Models\JobPoster')
+            ->name('admin.jobs.create.as_manager');
+    }
+);

--- a/tests/Feature/JobControllerTest.php
+++ b/tests/Feature/JobControllerTest.php
@@ -221,7 +221,7 @@ class JobControllerTest extends TestCase
      */
     public function testCreateAsManager() : void
     {
-        $admin = factory(User::class)->state('admin')->create();
+        $admin = factory(User::class)->states('admin')->create();
         $newManager = factory(Manager::class)->create();
 
         $response = $this->actingAs($admin)
@@ -271,7 +271,7 @@ class JobControllerTest extends TestCase
      */
     public function testManagerCannotPublishJobThroughEditView() : void
     {
-        $job = factory(JobPoster::class)->state('draft')->create([
+        $job = factory(JobPoster::class)->states('draft')->create([
             'manager_id' => $this->manager->id
         ]);
         $jobEdit = $this->generateEditJobFormData();
@@ -312,7 +312,7 @@ class JobControllerTest extends TestCase
         $expectedCloseDate = $expectedCloseDateTime->format($dateFormat);
         $expectedCloseTime = $expectedCloseDateTime->format($timeFormat);
 
-        $job = factory(JobPoster::class)->state('draft')->create([
+        $job = factory(JobPoster::class)->states('draft')->create([
             'manager_id' => $this->manager->id
         ]);
 
@@ -324,7 +324,7 @@ class JobControllerTest extends TestCase
         $dbValues = array_slice($jobEdit, 0, 8);
 
         $response = $this->followingRedirects()
-            ->actingAs($this->manager)
+            ->actingAs($this->manager->user)
             ->post(route('manager.jobs.update', $job), $jobEdit);
 
         $this->assertDatabaseHas('job_posters', $dbValues);


### PR DESCRIPTION
Added a Managers page to the Admin portal, where admins can create a job poster for any manager. Removed the Create Job Poster menu item from the manager portal, and update permissions so Managers can update, but not create, job posters.
Resolves #817