### PR TITLE
Resolve 500 error during admin portal Job Poster creation

### DIFF
--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -16,7 +16,9 @@ use Carbon\Carbon;
 
 use App\Mail\JobPosterReviewRequested;
 
+use App\Models\Criteria;
 use App\Models\JobPoster;
+use App\Models\JobPosterKeyTask;
 use App\Models\JobPosterQuestion;
 use App\Models\Lookup\JobTerm;
 use App\Models\Lookup\Province;
@@ -27,7 +29,6 @@ use App\Models\Lookup\SkillLevel;
 use App\Models\Lookup\CriteriaType;
 use App\Models\Skill;
 use App\Models\Manager;
-use App\Models\JobPosterKeyTask;
 
 use App\Services\Validation\JobPosterValidator;
 use Jenssegers\Date\Date;

--- a/app/Utilities/HandleNullState.php
+++ b/app/Utilities/HandleNullState.php
@@ -4,29 +4,35 @@ use Twig_Extension;
 use Twig_SimpleFunction;
 use Twig_SimpleFilter;
 
-class HandleNullState extends Twig_Extension {
+class HandleNullState extends Twig_Extension
+{
     /**
      * Functions
      * @return array
      */
-    public function getFunctions() {
-      return [
-        new Twig_SimpleFunction('handleNullState', [$this, 'handleNullState']),
-      ];
+    public function getFunctions(): array
+    {
+        return [
+          new Twig_SimpleFunction('handleNullState', [$this, 'handleNullState']),
+        ];
     }
 
     /**
-     * This function checks if the argument is empty, if false then it will echo html for null state given, if true then return default html.
-     * @param string|int|float|null $output
-     * @param string $outputHtml
-     * @param string $nullStateHtml
+     * This function checks if the argument is empty, if false then it will echo html for null state given,
+     * if true then return default html.
+     *
+     * @param string|integer|float|null $output
+     * @param string|null               $outputHtml
+     * @param string                    $nullStateHtml
+     *
      * @return void
      */
-    public function handleNullState($output, string $outputHtml, string $nullStateHtml) {
-        if (!empty($output)) {
-          echo $outputHtml;
+    public function handleNullState($output, $outputHtml, string $nullStateHtml): void
+    {
+        if (!empty($output) && !empty($outputHtml)) {
+            echo $outputHtml;
         } else {
-          echo $nullStateHtml;
+            echo $nullStateHtml;
         }
     }
-  }
+}


### PR DESCRIPTION
Relates to #870 

There was no `use` statement for the Criteria model, causing problems with instantiation. Also had an error pop up with the `handleNullState` utility method so I added an additional logical check and removed the typing from the parameter.