### PR TITLE
Add skill_level langfiles back in

### DIFF
--- a/resources/lang/en/common/lookup/skill_level.php
+++ b/resources/lang/en/common/lookup/skill_level.php
@@ -4,8 +4,8 @@ return [
         "hard" => [
             "name" => "Basic",
             "description" =>
-                "You have the ability to accomplish basic tasks with steady supervision and clear direction. The tasks you’re assigned are clear and don’t involve significant complexity. Their impact is usually locally felt.\n".
-                "As you advance in this category, you should be developing the ability to accomplish tasks of moderate complexity with steady supervision. You will also need to be able to accomplish basic tasks with little or no supervision.\n".
+                "You have the ability to accomplish basic tasks with steady supervision and clear direction. The tasks you’re assigned are clear and don’t involve significant complexity. Their impact is usually locally felt.\n\n".
+                "As you advance in this category, you should be developing the ability to accomplish tasks of moderate complexity with steady supervision. You will also need to be able to accomplish basic tasks with little or no supervision.\n\n".
                 "This level is usually associated with tasks that form the bulk of the work for lower level positions, such as junior analysts or entry level developers.",
         ],
         "soft" => [
@@ -17,14 +17,14 @@ return [
         "hard" => [
             "name" => "Intermediate",
             "description" =>
-                "You have the ability to accomplish tasks of moderate complexity or moderate impact with supervision. The approach to the tasks, and how they are delivered, is determined by the supervisor. You contribute input and advice. You are able to advance the task, even in the face of small to moderate hurdles and complications.\n".
-                "As you advance in this category, you should be developing the ability to accomplish tasks of significant complexity or larger impact with steady supervision. You will also need to be able to accomplish tasks of moderate complexity or impact with little or no supervision.\n".
+                "You have the ability to accomplish tasks of moderate complexity or moderate impact with supervision. The approach to the tasks, and how they are delivered, is determined by the supervisor. You contribute input and advice. You are able to advance the task, even in the face of small to moderate hurdles and complications.\n\n".
+                "As you advance in this category, you should be developing the ability to accomplish tasks of significant complexity or larger impact with steady supervision. You will also need to be able to accomplish tasks of moderate complexity or impact with little or no supervision.\n\n".
                 "This level is usually associated with tasks that form the bulk of the work for mid-level positions, such as analysts or developers.",
         ],
         "soft" => [
             "name" => "Moderately in Evidence",
             "description" =>
-                "You’re able to consistently demonstrate this skill or attribute in the workplace, including under conditions of low-to-moderate stress or difficulty.\n".
+                "You’re able to consistently demonstrate this skill or attribute in the workplace, including under conditions of low-to-moderate stress or difficulty.\n\n".
                 "Your peers and supervisors are able to attest to the fact that you have been able to demonstrate this skill or attribute on a regular basis.",
         ],
     ],
@@ -32,14 +32,14 @@ return [
         "hard" => [
             "name" => "Advanced",
             "description" =>
-                "You have the ability to accomplish tasks of significant complexity or impact with supervision. You provide advice and input on the approach to the tasks, and how they are delivered, for the supervisor’s consideration. You are able to advance the task, even in the face of moderate to large hurdles and complications.\n".
-                "As you advance in this category, you should be developing the ability to accomplish tasks of significant complexity or larger impact with only light levels of supervision, where you are effectively the lead on the initiative. You may also take on a role of training others in this skills set or take on a light supervisory role for those at lower levels.\n".
+                "You have the ability to accomplish tasks of significant complexity or impact with supervision. You provide advice and input on the approach to the tasks, and how they are delivered, for the supervisor’s consideration. You are able to advance the task, even in the face of moderate to large hurdles and complications.\n\n".
+                "As you advance in this category, you should be developing the ability to accomplish tasks of significant complexity or larger impact with only light levels of supervision, where you are effectively the lead on the initiative. You may also take on a role of training others in this skills set or take on a light supervisory role for those at lower levels.\n\n".
                 "This level is usually associated with tasks that form the bulk of the work for higher level positions, such as senior analysts or senior developers.",
         ],
         "soft" => [
             "name" => "Strongly in Evidence",
             "description" =>
-                "You’re able to consistently demonstrate this skill or attribute in the workplace, including under conditions of high stress or difficulty.\n".
+                "You’re able to consistently demonstrate this skill or attribute in the workplace, including under conditions of high stress or difficulty.\n\n".
                 "Your peers and supervisors recognize this as a strength you demonstrate in the workplace.",
         ],
     ],
@@ -47,14 +47,14 @@ return [
         "hard" => [
             "name" => "Lead",
             "description" =>
-                "You have the ability to accomplish tasks of significant complexity or impact, where you call the shots and answer to the organization’s senior management for your decisions. You bring forward the tasks, the approach and the delivery plan for senior management consideration. You often supervise others (individuals or teams) in delivering tasks of high complexity or system wide impact. You are able to advance these tasks, even in the face of significant unforeseen hurdles and complications.\n".
-                "As you advance in this category, you should be developing the ability to assess others at more junior levels, becoming able to clearly identify the difference between beginner, intermediate and advanced tasks. You should be able to build teams, set direction and provide supervision.\n".
+                "You have the ability to accomplish tasks of significant complexity or impact, where you call the shots and answer to the organization’s senior management for your decisions. You bring forward the tasks, the approach and the delivery plan for senior management consideration. You often supervise others (individuals or teams) in delivering tasks of high complexity or system wide impact. You are able to advance these tasks, even in the face of significant unforeseen hurdles and complications.\n\n".
+                "As you advance in this category, you should be developing the ability to assess others at more junior levels, becoming able to clearly identify the difference between beginner, intermediate and advanced tasks. You should be able to build teams, set direction and provide supervision.\n\n".
                 "This level is usually associated with tasks that form the bulk of the work for management and executive level positions.",
         ],
         "soft" => [
             "name" => "Deep Level Demonstration",
             "description" =>
-                "This is a foundational part of who you are. You consistently demonstrate this skill or attribute, even under conditions of extreme stress or difficulty.\n".
+                "This is a foundational part of who you are. You consistently demonstrate this skill or attribute, even under conditions of extreme stress or difficulty.\n\n".
                 "Your peers and supervisors recognize this as a significant strength you demonstrate in the workplace, providing an example to others.",
         ],
     ],

--- a/resources/lang/en/common/lookup/skill_level.php
+++ b/resources/lang/en/common/lookup/skill_level.php
@@ -1,0 +1,61 @@
+<?php
+return [
+    "basic" => [
+        "hard" => [
+            "name" => "Basic",
+            "description" =>
+                "You have the ability to accomplish basic tasks with steady supervision and clear direction. The tasks you’re assigned are clear and don’t involve significant complexity. Their impact is usually locally felt.\n".
+                "As you advance in this category, you should be developing the ability to accomplish tasks of moderate complexity with steady supervision. You will also need to be able to accomplish basic tasks with little or no supervision.\n".
+                "This level is usually associated with tasks that form the bulk of the work for lower level positions, such as junior analysts or entry level developers.",
+        ],
+        "soft" => [
+            "name" => "In Early Development",
+            "description" => "You’re working on acquiring this skill or attribute. You are able to demonstrate it under favourable conditions (low stress, minimal difficulty) and can apply it in a work context intermittently.",
+        ],
+    ],
+    "intermediate" => [
+        "hard" => [
+            "name" => "Intermediate",
+            "description" =>
+                "You have the ability to accomplish tasks of moderate complexity or moderate impact with supervision. The approach to the tasks, and how they are delivered, is determined by the supervisor. You contribute input and advice. You are able to advance the task, even in the face of small to moderate hurdles and complications.\n".
+                "As you advance in this category, you should be developing the ability to accomplish tasks of significant complexity or larger impact with steady supervision. You will also need to be able to accomplish tasks of moderate complexity or impact with little or no supervision.\n".
+                "This level is usually associated with tasks that form the bulk of the work for mid-level positions, such as analysts or developers.",
+        ],
+        "soft" => [
+            "name" => "Moderately in Evidence",
+            "description" =>
+                "You’re able to consistently demonstrate this skill or attribute in the workplace, including under conditions of low-to-moderate stress or difficulty.\n".
+                "Your peers and supervisors are able to attest to the fact that you have been able to demonstrate this skill or attribute on a regular basis.",
+        ],
+    ],
+    "advanced" => [
+        "hard" => [
+            "name" => "Advanced",
+            "description" =>
+                "You have the ability to accomplish tasks of significant complexity or impact with supervision. You provide advice and input on the approach to the tasks, and how they are delivered, for the supervisor’s consideration. You are able to advance the task, even in the face of moderate to large hurdles and complications.\n".
+                "As you advance in this category, you should be developing the ability to accomplish tasks of significant complexity or larger impact with only light levels of supervision, where you are effectively the lead on the initiative. You may also take on a role of training others in this skills set or take on a light supervisory role for those at lower levels.\n".
+                "This level is usually associated with tasks that form the bulk of the work for higher level positions, such as senior analysts or senior developers.",
+        ],
+        "soft" => [
+            "name" => "Strongly in Evidence",
+            "description" =>
+                "You’re able to consistently demonstrate this skill or attribute in the workplace, including under conditions of high stress or difficulty.\n".
+                "Your peers and supervisors recognize this as a strength you demonstrate in the workplace.",
+        ],
+    ],
+    "expert" => [
+        "hard" => [
+            "name" => "Lead",
+            "description" =>
+                "You have the ability to accomplish tasks of significant complexity or impact, where you call the shots and answer to the organization’s senior management for your decisions. You bring forward the tasks, the approach and the delivery plan for senior management consideration. You often supervise others (individuals or teams) in delivering tasks of high complexity or system wide impact. You are able to advance these tasks, even in the face of significant unforeseen hurdles and complications.\n".
+                "As you advance in this category, you should be developing the ability to assess others at more junior levels, becoming able to clearly identify the difference between beginner, intermediate and advanced tasks. You should be able to build teams, set direction and provide supervision.\n".
+                "This level is usually associated with tasks that form the bulk of the work for management and executive level positions.",
+        ],
+        "soft" => [
+            "name" => "Deep Level Demonstration",
+            "description" =>
+                "This is a foundational part of who you are. You consistently demonstrate this skill or attribute, even under conditions of extreme stress or difficulty.\n".
+                "Your peers and supervisors recognize this as a significant strength you demonstrate in the workplace, providing an example to others.",
+        ],
+    ],
+];

--- a/resources/lang/fr/common/lookup/skill_level.php
+++ b/resources/lang/fr/common/lookup/skill_level.php
@@ -4,8 +4,8 @@ return [
         "hard" => [
             "name" => "Débutant",
             "description" =>
-                "Vous êtes capable d’accomplir des tâches de base avec une supervision régulière et une orientation claire. Les tâches qui vous sont assignées sont claires et ne sont pas très complexes. Elles ont généralement une incidence locale.\n".
-                "Au fur et à mesure que vous progressez dans cette catégorie, vous devriez être en mesure d’accomplir des tâches de complexité modérée avec une supervision régulière. Vous devriez aussi être en mesure d’accomplir des tâches de base avec peu ou pas de supervision.\n".
+                "Vous êtes capable d’accomplir des tâches de base avec une supervision régulière et une orientation claire. Les tâches qui vous sont assignées sont claires et ne sont pas très complexes. Elles ont généralement une incidence locale.\n\n".
+                "Au fur et à mesure que vous progressez dans cette catégorie, vous devriez être en mesure d’accomplir des tâches de complexité modérée avec une supervision régulière. Vous devriez aussi être en mesure d’accomplir des tâches de base avec peu ou pas de supervision.\n\n".
                 "Ce niveau est habituellement associé aux tâches qui constituent le gros du travail pour les postes de niveau inférieur, comme les analystes ou les développeurs de niveau débutant.",
         ],
         "soft" => [
@@ -17,14 +17,14 @@ return [
         "hard" => [
             "name" => "Intermédiaire",
             "description" =>
-                "Vous avez la capacité d’accomplir des tâches de complexité modérée ou d’incidence modérée avec supervision. C’est le superviseur qui détermine l’approche à préconiser pour effectuer les tâches, de même que la façon dont elles sont exécutées. Vous apportez des commentaires et des conseils. Vous êtes en mesure de faire progresser la tâche, même face à des obstacles et à des complications de petite à moyenne envergure.\n".
-                "Au fur et à mesure que vous progressez dans cette catégorie, vous devriez être en mesure d’accomplir des tâches d’une complexité importante ou ayant une incidence plus grande avec une supervision régulière. Vous devriez également être en mesure d’accomplir des tâches d’une complexité ou d’une incidence modérée avec peu ou pas de supervision.\n".
+                "Vous avez la capacité d’accomplir des tâches de complexité modérée ou d’incidence modérée avec supervision. C’est le superviseur qui détermine l’approche à préconiser pour effectuer les tâches, de même que la façon dont elles sont exécutées. Vous apportez des commentaires et des conseils. Vous êtes en mesure de faire progresser la tâche, même face à des obstacles et à des complications de petite à moyenne envergure.\n\n".
+                "Au fur et à mesure que vous progressez dans cette catégorie, vous devriez être en mesure d’accomplir des tâches d’une complexité importante ou ayant une incidence plus grande avec une supervision régulière. Vous devriez également être en mesure d’accomplir des tâches d’une complexité ou d’une incidence modérée avec peu ou pas de supervision.\n\n".
                 "Ce niveau est habituellement associé aux tâches qui constituent le gros du travail pour les postes de niveau intermédiaire, comme les analystes ou les développeurs.",
         ],
         "soft" => [
             "name" => "Modérément en évidence",
             "description" =>
-                "Vous êtes capable de démontrer cette compétence ou cet attribut de façon constante en milieu de travail, y compris lorsque les conditions de difficulté ou le niveau de stress sont bas ou modérés.\n".
+                "Vous êtes capable de démontrer cette compétence ou cet attribut de façon constante en milieu de travail, y compris lorsque les conditions de difficulté ou le niveau de stress sont bas ou modérés.\n\n".
                 "Vos pairs et vos superviseurs peuvent attester le fait que vous êtes capable de démontrer cette compétence ou cet attribut de façon régulière.",
         ],
     ],
@@ -32,14 +32,14 @@ return [
         "hard" => [
             "name" => "Avancé",
             "description" =>
-                "Vous avez la capacité d’accomplir des tâches d’une complexité ou d’une incidence importante avec supervision. Vous donnez des conseils et des commentaires au superviseur sur l’approche à employer pour effectuer les tâches et la façon dont elles sont exécutées. Vous êtes en mesure de faire progresser la tâche, même face à des obstacles et à des complications d’envergure moyenne à importante.\n".
-                "Au fur et à mesure que vous progressez dans cette catégorie, vous êtes être en mesure d’accomplir des tâches d’une complexité importante ou ayant une incidence plus grande avec seulement de légers niveaux de supervision, en étant effectivement le responsable de l’initiative. Vous pouvez également jouer un rôle de formation d’autres personnes dans cet ensemble de compétences ou assumer un rôle de supervision léger pour les personnes aux niveaux inférieurs.\n".
+                "Vous avez la capacité d’accomplir des tâches d’une complexité ou d’une incidence importante avec supervision. Vous donnez des conseils et des commentaires au superviseur sur l’approche à employer pour effectuer les tâches et la façon dont elles sont exécutées. Vous êtes en mesure de faire progresser la tâche, même face à des obstacles et à des complications d’envergure moyenne à importante.\n\n".
+                "Au fur et à mesure que vous progressez dans cette catégorie, vous êtes être en mesure d’accomplir des tâches d’une complexité importante ou ayant une incidence plus grande avec seulement de légers niveaux de supervision, en étant effectivement le responsable de l’initiative. Vous pouvez également jouer un rôle de formation d’autres personnes dans cet ensemble de compétences ou assumer un rôle de supervision léger pour les personnes aux niveaux inférieurs.\n\n".
                 "Ce niveau est habituellement associé à des tâches qui constituent la majeure partie du travail pour des postes de niveau supérieur, comme les analystes principaux ou les développeurs principaux.",
         ],
         "soft" => [
             "name" => "Fortement en évidence",
             "description" =>
-                "Vous êtes capable de démontrer cette compétence ou cet attribut de façon constante en milieu de travail, y compris lorsque les conditions de difficulté ou le niveau de stress sont élevés.\n".
+                "Vous êtes capable de démontrer cette compétence ou cet attribut de façon constante en milieu de travail, y compris lorsque les conditions de difficulté ou le niveau de stress sont élevés.\n\n".
                 "Vos pairs et vos superviseurs reconnaissent qu’il s’agit d’une force dont vous faites preuve en milieu de travail.",
         ],
     ],
@@ -47,14 +47,14 @@ return [
         "hard" => [
             "name" => "Responsable",
             "description" =>
-                "Vous êtes en mesure d’accomplir des tâches d’une complexité ou d’une incidence importante, où vous prenez les décisions et répondez de vos décisions auprès de la haute direction de l’organisation. Vous présentez les tâches, l’approche et le plan de réalisation à la haute direction. Vous supervisez souvent d’autres personnes (personnes ou équipes) dans l’exécution de tâches très complexes ou ayant une incidence sur l’ensemble du système. Vous êtes en mesure de faire progresser ces tâches, même face à des obstacles et à des complications importants et imprévus.\n".
-                "Au fur et à mesure que vous progressez dans cette catégorie, vous devriez être en mesure d’évaluer les autres à des niveaux plus subalternes, et de déterminer clairement la différence entre les tâches débutantes, intermédiaires et avancées. Vous devriez également être en mesure de pouvoir former des équipes, définir des orientations et assurer une supervision.\n".
+                "Vous êtes en mesure d’accomplir des tâches d’une complexité ou d’une incidence importante, où vous prenez les décisions et répondez de vos décisions auprès de la haute direction de l’organisation. Vous présentez les tâches, l’approche et le plan de réalisation à la haute direction. Vous supervisez souvent d’autres personnes (personnes ou équipes) dans l’exécution de tâches très complexes ou ayant une incidence sur l’ensemble du système. Vous êtes en mesure de faire progresser ces tâches, même face à des obstacles et à des complications importants et imprévus.\n\n".
+                "Au fur et à mesure que vous progressez dans cette catégorie, vous devriez être en mesure d’évaluer les autres à des niveaux plus subalternes, et de déterminer clairement la différence entre les tâches débutantes, intermédiaires et avancées. Vous devriez également être en mesure de pouvoir former des équipes, définir des orientations et assurer une supervision.\n\n".
                 "Ce niveau est habituellement associé aux tâches qui constituent la majeure partie du travail pour les postes de direction et de direction.",
         ],
         "soft" => [
             "name" => "Démonstration à un niveau profond",
             "description" =>
-                "Il s’agit d’une partie fondamentale de qui vous êtes. Vous démontrez cette compétence ou cet attribut de façon constante en milieu de travail, y compris lorsque les conditions de difficulté ou le niveau de stress sont extrêmes.\n".
+                "Il s’agit d’une partie fondamentale de qui vous êtes. Vous démontrez cette compétence ou cet attribut de façon constante en milieu de travail, y compris lorsque les conditions de difficulté ou le niveau de stress sont extrêmes.\n\n".
                 "Vos pairs et vos superviseurs reconnaissent qu’il s’agit d’une force importante dont vous faites preuve en milieu de travail, en donnant un exemple aux autres.",
         ],
     ],

--- a/resources/lang/fr/common/lookup/skill_level.php
+++ b/resources/lang/fr/common/lookup/skill_level.php
@@ -1,0 +1,61 @@
+<?php
+return [
+    "basic" => [
+        "hard" => [
+            "name" => "Basic",
+            "description" =>
+                "You have the ability to accomplish basic tasks with steady supervision and clear direction. The tasks you’re assigned are clear and don’t involve significant complexity. Their impact is usually locally felt.\n".
+                "As you advance in this category, you should be developing the ability to accomplish tasks of moderate complexity with steady supervision. You will also need to be able to accomplish basic tasks with little or no supervision.\n".
+                "This level is usually associated with tasks that form the bulk of the work for lower level positions, such as junior analysts or entry level developers.",
+        ],
+        "soft" => [
+            "name" => "In Early Development",
+            "description" => "You’re working on acquiring this skill or attribute. You are able to demonstrate it under favourable conditions (low stress, minimal difficulty) and can apply it in a work context intermittently.",
+        ],
+    ],
+    "intermediate" => [
+        "hard" => [
+            "name" => "Intermediate",
+            "description" =>
+                "You have the ability to accomplish tasks of moderate complexity or moderate impact with supervision. The approach to the tasks, and how they are delivered, is determined by the supervisor. You contribute input and advice. You are able to advance the task, even in the face of small to moderate hurdles and complications.\n".
+                "As you advance in this category, you should be developing the ability to accomplish tasks of significant complexity or larger impact with steady supervision. You will also need to be able to accomplish tasks of moderate complexity or impact with little or no supervision.\n".
+                "This level is usually associated with tasks that form the bulk of the work for mid-level positions, such as analysts or developers.",
+        ],
+        "soft" => [
+            "name" => "Moderately in Evidence",
+            "description" =>
+                "You’re able to consistently demonstrate this skill or attribute in the workplace, including under conditions of low-to-moderate stress or difficulty.\n".
+                "Your peers and supervisors are able to attest to the fact that you have been able to demonstrate this skill or attribute on a regular basis.",
+        ],
+    ],
+    "advanced" => [
+        "hard" => [
+            "name" => "Advanced",
+            "description" =>
+                "You have the ability to accomplish tasks of significant complexity or impact with supervision. You provide advice and input on the approach to the tasks, and how they are delivered, for the supervisor’s consideration. You are able to advance the task, even in the face of moderate to large hurdles and complications.\n".
+                "As you advance in this category, you should be developing the ability to accomplish tasks of significant complexity or larger impact with only light levels of supervision, where you are effectively the lead on the initiative. You may also take on a role of training others in this skills set or take on a light supervisory role for those at lower levels.\n".
+                "This level is usually associated with tasks that form the bulk of the work for higher level positions, such as senior analysts or senior developers.",
+        ],
+        "soft" => [
+            "name" => "Strongly in Evidence",
+            "description" =>
+                "You’re able to consistently demonstrate this skill or attribute in the workplace, including under conditions of high stress or difficulty.\n".
+                "Your peers and supervisors recognize this as a strength you demonstrate in the workplace.",
+        ],
+    ],
+    "expert" => [
+        "hard" => [
+            "name" => "Lead",
+            "description" =>
+                "You have the ability to accomplish tasks of significant complexity or impact, where you call the shots and answer to the organization’s senior management for your decisions. You bring forward the tasks, the approach and the delivery plan for senior management consideration. You often supervise others (individuals or teams) in delivering tasks of high complexity or system wide impact. You are able to advance these tasks, even in the face of significant unforeseen hurdles and complications.\n".
+                "As you advance in this category, you should be developing the ability to assess others at more junior levels, becoming able to clearly identify the difference between beginner, intermediate and advanced tasks. You should be able to build teams, set direction and provide supervision.\n".
+                "This level is usually associated with tasks that form the bulk of the work for management and executive level positions.",
+        ],
+        "soft" => [
+            "name" => "Deep Level Demonstration",
+            "description" =>
+                "This is a foundational part of who you are. You consistently demonstrate this skill or attribute, even under conditions of extreme stress or difficulty.\n".
+                "Your peers and supervisors recognize this as a significant strength you demonstrate in the workplace, providing an example to others.",
+        ],
+    ],
+];

--- a/resources/lang/fr/common/lookup/skill_level.php
+++ b/resources/lang/fr/common/lookup/skill_level.php
@@ -2,60 +2,60 @@
 return [
     "basic" => [
         "hard" => [
-            "name" => "Basic",
+            "name" => "Débutant",
             "description" =>
-                "You have the ability to accomplish basic tasks with steady supervision and clear direction. The tasks you’re assigned are clear and don’t involve significant complexity. Their impact is usually locally felt.\n".
-                "As you advance in this category, you should be developing the ability to accomplish tasks of moderate complexity with steady supervision. You will also need to be able to accomplish basic tasks with little or no supervision.\n".
-                "This level is usually associated with tasks that form the bulk of the work for lower level positions, such as junior analysts or entry level developers.",
+                "Vous êtes capable d’accomplir des tâches de base avec une supervision régulière et une orientation claire. Les tâches qui vous sont assignées sont claires et ne sont pas très complexes. Elles ont généralement une incidence locale.\n".
+                "Au fur et à mesure que vous progressez dans cette catégorie, vous devriez être en mesure d’accomplir des tâches de complexité modérée avec une supervision régulière. Vous devriez aussi être en mesure d’accomplir des tâches de base avec peu ou pas de supervision.\n".
+                "Ce niveau est habituellement associé aux tâches qui constituent le gros du travail pour les postes de niveau inférieur, comme les analystes ou les développeurs de niveau débutant.",
         ],
         "soft" => [
-            "name" => "In Early Development",
-            "description" => "You’re working on acquiring this skill or attribute. You are able to demonstrate it under favourable conditions (low stress, minimal difficulty) and can apply it in a work context intermittently.",
+            "name" => "Phase de développement précoce",
+            "description" => "Vous êtes en processus d’acquérir cette compétence ou cet attribut. Vous êtes capable de le démontrer dans des conditions favorables (peu de stress, difficulté minimale) et pouvez l’appliquer dans un contexte de travail de façon intermittente.",
         ],
     ],
     "intermediate" => [
         "hard" => [
-            "name" => "Intermediate",
+            "name" => "Intermédiaire",
             "description" =>
-                "You have the ability to accomplish tasks of moderate complexity or moderate impact with supervision. The approach to the tasks, and how they are delivered, is determined by the supervisor. You contribute input and advice. You are able to advance the task, even in the face of small to moderate hurdles and complications.\n".
-                "As you advance in this category, you should be developing the ability to accomplish tasks of significant complexity or larger impact with steady supervision. You will also need to be able to accomplish tasks of moderate complexity or impact with little or no supervision.\n".
-                "This level is usually associated with tasks that form the bulk of the work for mid-level positions, such as analysts or developers.",
+                "Vous avez la capacité d’accomplir des tâches de complexité modérée ou d’incidence modérée avec supervision. C’est le superviseur qui détermine l’approche à préconiser pour effectuer les tâches, de même que la façon dont elles sont exécutées. Vous apportez des commentaires et des conseils. Vous êtes en mesure de faire progresser la tâche, même face à des obstacles et à des complications de petite à moyenne envergure.\n".
+                "Au fur et à mesure que vous progressez dans cette catégorie, vous devriez être en mesure d’accomplir des tâches d’une complexité importante ou ayant une incidence plus grande avec une supervision régulière. Vous devriez également être en mesure d’accomplir des tâches d’une complexité ou d’une incidence modérée avec peu ou pas de supervision.\n".
+                "Ce niveau est habituellement associé aux tâches qui constituent le gros du travail pour les postes de niveau intermédiaire, comme les analystes ou les développeurs.",
         ],
         "soft" => [
-            "name" => "Moderately in Evidence",
+            "name" => "Modérément en évidence",
             "description" =>
-                "You’re able to consistently demonstrate this skill or attribute in the workplace, including under conditions of low-to-moderate stress or difficulty.\n".
-                "Your peers and supervisors are able to attest to the fact that you have been able to demonstrate this skill or attribute on a regular basis.",
+                "Vous êtes capable de démontrer cette compétence ou cet attribut de façon constante en milieu de travail, y compris lorsque les conditions de difficulté ou le niveau de stress sont bas ou modérés.\n".
+                "Vos pairs et vos superviseurs peuvent attester le fait que vous êtes capable de démontrer cette compétence ou cet attribut de façon régulière.",
         ],
     ],
     "advanced" => [
         "hard" => [
-            "name" => "Advanced",
+            "name" => "Avancé",
             "description" =>
-                "You have the ability to accomplish tasks of significant complexity or impact with supervision. You provide advice and input on the approach to the tasks, and how they are delivered, for the supervisor’s consideration. You are able to advance the task, even in the face of moderate to large hurdles and complications.\n".
-                "As you advance in this category, you should be developing the ability to accomplish tasks of significant complexity or larger impact with only light levels of supervision, where you are effectively the lead on the initiative. You may also take on a role of training others in this skills set or take on a light supervisory role for those at lower levels.\n".
-                "This level is usually associated with tasks that form the bulk of the work for higher level positions, such as senior analysts or senior developers.",
+                "Vous avez la capacité d’accomplir des tâches d’une complexité ou d’une incidence importante avec supervision. Vous donnez des conseils et des commentaires au superviseur sur l’approche à employer pour effectuer les tâches et la façon dont elles sont exécutées. Vous êtes en mesure de faire progresser la tâche, même face à des obstacles et à des complications d’envergure moyenne à importante.\n".
+                "Au fur et à mesure que vous progressez dans cette catégorie, vous êtes être en mesure d’accomplir des tâches d’une complexité importante ou ayant une incidence plus grande avec seulement de légers niveaux de supervision, en étant effectivement le responsable de l’initiative. Vous pouvez également jouer un rôle de formation d’autres personnes dans cet ensemble de compétences ou assumer un rôle de supervision léger pour les personnes aux niveaux inférieurs.\n".
+                "Ce niveau est habituellement associé à des tâches qui constituent la majeure partie du travail pour des postes de niveau supérieur, comme les analystes principaux ou les développeurs principaux.",
         ],
         "soft" => [
-            "name" => "Strongly in Evidence",
+            "name" => "Fortement en évidence",
             "description" =>
-                "You’re able to consistently demonstrate this skill or attribute in the workplace, including under conditions of high stress or difficulty.\n".
-                "Your peers and supervisors recognize this as a strength you demonstrate in the workplace.",
+                "Vous êtes capable de démontrer cette compétence ou cet attribut de façon constante en milieu de travail, y compris lorsque les conditions de difficulté ou le niveau de stress sont élevés.\n".
+                "Vos pairs et vos superviseurs reconnaissent qu’il s’agit d’une force dont vous faites preuve en milieu de travail.",
         ],
     ],
     "expert" => [
         "hard" => [
-            "name" => "Lead",
+            "name" => "Responsable",
             "description" =>
-                "You have the ability to accomplish tasks of significant complexity or impact, where you call the shots and answer to the organization’s senior management for your decisions. You bring forward the tasks, the approach and the delivery plan for senior management consideration. You often supervise others (individuals or teams) in delivering tasks of high complexity or system wide impact. You are able to advance these tasks, even in the face of significant unforeseen hurdles and complications.\n".
-                "As you advance in this category, you should be developing the ability to assess others at more junior levels, becoming able to clearly identify the difference between beginner, intermediate and advanced tasks. You should be able to build teams, set direction and provide supervision.\n".
-                "This level is usually associated with tasks that form the bulk of the work for management and executive level positions.",
+                "Vous êtes en mesure d’accomplir des tâches d’une complexité ou d’une incidence importante, où vous prenez les décisions et répondez de vos décisions auprès de la haute direction de l’organisation. Vous présentez les tâches, l’approche et le plan de réalisation à la haute direction. Vous supervisez souvent d’autres personnes (personnes ou équipes) dans l’exécution de tâches très complexes ou ayant une incidence sur l’ensemble du système. Vous êtes en mesure de faire progresser ces tâches, même face à des obstacles et à des complications importants et imprévus.\n".
+                "Au fur et à mesure que vous progressez dans cette catégorie, vous devriez être en mesure d’évaluer les autres à des niveaux plus subalternes, et de déterminer clairement la différence entre les tâches débutantes, intermédiaires et avancées. Vous devriez également être en mesure de pouvoir former des équipes, définir des orientations et assurer une supervision.\n".
+                "Ce niveau est habituellement associé aux tâches qui constituent la majeure partie du travail pour les postes de direction et de direction.",
         ],
         "soft" => [
-            "name" => "Deep Level Demonstration",
+            "name" => "Démonstration à un niveau profond",
             "description" =>
-                "This is a foundational part of who you are. You consistently demonstrate this skill or attribute, even under conditions of extreme stress or difficulty.\n".
-                "Your peers and supervisors recognize this as a significant strength you demonstrate in the workplace, providing an example to others.",
+                "Il s’agit d’une partie fondamentale de qui vous êtes. Vous démontrez cette compétence ou cet attribut de façon constante en milieu de travail, y compris lorsque les conditions de difficulté ou le niveau de stress sont extrêmes.\n".
+                "Vos pairs et vos superviseurs reconnaissent qu’il s’agit d’une force importante dont vous faites preuve en milieu de travail, en donnant un exemple aux autres.",
         ],
     ],
 ];


### PR DESCRIPTION
Missing langfile(s) causing issues in the assessment plan. Looks like they were removed for failing a lang unit test comparison, as we never had French translations.
