### PR TITLE
set z-index lower than sticky application progress header

### DIFF
--- a/resources/assets/sass/components/common/_forms.scss
+++ b/resources/assets/sass/components/common/_forms.scss
@@ -154,7 +154,7 @@
             top: .7rem;
             left: .55rem;
             transition: background 0s ease .1s, font-size .2s ease, top .2s ease;
-            z-index: 100;
+            z-index: 1;
         }
 
         .form__input {
@@ -294,7 +294,7 @@
             top: .7rem;
             left: .55rem;
             transition: background 0s ease .1s, font-size .2s ease, top .2s ease;
-            z-index: 100;
+            z-index: 1;
         }
 
         .form__input {
@@ -392,7 +392,7 @@
             color: rgba(50, 50, 50, 1);
             font-size: 12px;
             margin: 0 0 1rem 2rem;
-            z-index: 100;
+            z-index: 1;
         }
 
         .form__range-wrapper {
@@ -459,7 +459,7 @@
             top: -1rem;
             left: .55rem;
             transition: background 0s ease .1s, font-size .2s ease, top .2s ease;
-            z-index: 100;
+            z-index: 1;
         }
 
         .form__input {
@@ -532,7 +532,7 @@
             top: -1.15rem;
             left: .55rem;
             transition: background 0s ease .1s, font-size .2s ease, top .2s ease;
-            z-index: 100;
+            z-index: 1;
         }
 
         .form__select-wrapper {
@@ -622,7 +622,7 @@
             outline: none;
             padding: $unit calc(#{$unit} * 2);
             text-decoration: none;
-            z-index: 100;
+            z-index: 1;
 
             color: $palette--font-white;
             transition: none;
@@ -671,7 +671,7 @@
             top: -1.15rem;
             left: .55rem;
             transition: background 0s ease .1s, font-size .2s ease, top .2s ease;
-            z-index: 100;
+            z-index: 1;
         }
 
         .form__input {
@@ -744,7 +744,7 @@
             font-size: $font-scale--regular;
             line-height: 20px;
             margin: 0 0 calc(#{$unit} / 2);
-            z-index: 100;
+            z-index: 1;
         }
 
     }
@@ -792,7 +792,7 @@
         font-size: $font-scale--regular;
         line-height: 20px;
         margin: 0 0 calc(#{$unit} / 2);
-        z-index: 100;
+        z-index: 1;
     }
 
     .form__required {


### PR DESCRIPTION
Resolves #887 

### Notes:
- Quick fix for labels overlapping for application progress sticky header.
