### PR TITLE
Fix issue with Skill Declaration ajax update

### DIFF
--- a/app/Http/Controllers/SkillDeclarationController.php
+++ b/app/Http/Controllers/SkillDeclarationController.php
@@ -51,7 +51,7 @@ class SkillDeclarationController extends Controller
      * Create the particular skill declaration in storage.
      *
      * @param  \Illuminate\Http\Request $request Incoming request.
-     * @return \Illuminate\Http\RedirectResponse|string[]
+     * @return \Illuminate\Http\RedirectResponse|string
      */
     public function create(Request $request)
     {
@@ -79,7 +79,7 @@ class SkillDeclarationController extends Controller
      *
      * @param  \Illuminate\Http\Request     $request          Incoming request.
      * @param  \App\Models\SkillDeclaration $skillDeclaration Incoming Skill Declaration.
-     * @return \Illuminate\Http\RedirectResponse|string[]
+     * @return \Illuminate\Http\RedirectResponse|string
      */
     public function update(Request $request, SkillDeclaration $skillDeclaration)
     {
@@ -93,7 +93,7 @@ class SkillDeclarationController extends Controller
      *
      * @param  \Illuminate\Http\Request     $request          Incoming request.
      * @param  \App\Models\SkillDeclaration $skillDeclaration Incoming Skill Declaration.
-     * @return \Illuminate\Http\RedirectResponse|string[]
+     * @return \Illuminate\Http\RedirectResponse|string
      */
     protected function updateSkillDeclaration(Request $request, SkillDeclaration $skillDeclaration)
     {
@@ -136,7 +136,7 @@ class SkillDeclarationController extends Controller
      *
      * @param  \Illuminate\Http\Request     $request          Incoming request.
      * @param  \App\Models\SkillDeclaration $skillDeclaration Incoming Skill Declaration.
-     * @return \Illuminate\Http\Response|string[]
+     * @return \Illuminate\Http\RedirectResponse|string[]
      */
     public function destroy(Request $request, SkillDeclaration $skillDeclaration)
     {

--- a/app/Http/Controllers/SkillDeclarationController.php
+++ b/app/Http/Controllers/SkillDeclarationController.php
@@ -3,15 +3,11 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Lang;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Http\Request;
-use App\Models\Skill;
-use App\Models\Lookup\SkillLevel;
 use App\Models\Lookup\SkillStatus;
 use App\Models\SkillDeclaration;
 use App\Models\Applicant;
 use App\Http\Controllers\Controller;
-use App\Services\Validation\BulkSkillDeclarationValidator;
 use App\Services\Validation\SkillDeclarationValidator;
 
 class SkillDeclarationController extends Controller
@@ -20,10 +16,10 @@ class SkillDeclarationController extends Controller
     /**
      * Show the form for editing the logged-in applicant's skills
      *
-     * @param  Request $request
-     * @return \Illuminate\Http\RedirectResponse
+     * @param  Request $request Incoming request.
+     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
      */
-    public function editAuthenticated(Request $request): \Illuminate\Http\RedirectResponse
+    public function editAuthenticated(Request $request)
     {
         $applicant = $request->user()->applicant;
         return redirect(route('profile.skills.edit', $applicant));
@@ -54,10 +50,10 @@ class SkillDeclarationController extends Controller
     /**
      * Create the particular skill declaration in storage.
      *
-     * @param  \Illuminate\Http\Request $request
-     * @return \Illuminate\Http\Response
+     * @param  \Illuminate\Http\Request $request Incoming request.
+     * @return \Illuminate\Http\RedirectResponse|string[]
      */
-    public function create(Request $request): \Illuminate\Http\Response
+    public function create(Request $request)
     {
         $this->authorize('create', SkillDeclaration::class);
 
@@ -79,19 +75,26 @@ class SkillDeclarationController extends Controller
     }
 
     /**
-     * Update the particular skill declaration in storage.
+     * Check authorization and update the skill declaration.
      *
-     * @param  \Illuminate\Http\Request     $request
-     * @param  \App\Models\SkillDeclaration $skillDeclaration
-     * @return \Illuminate\Http\Response
+     * @param  \Illuminate\Http\Request     $request          Incoming request.
+     * @param  \App\Models\SkillDeclaration $skillDeclaration Incoming Skill Declaration.
+     * @return \Illuminate\Http\RedirectResponse|string[]
      */
-    public function update(Request $request, SkillDeclaration $skillDeclaration): \Illuminate\Http\Response
+    public function update(Request $request, SkillDeclaration $skillDeclaration)
     {
         $this->authorize('update', $skillDeclaration);
 
         return $this->updateSkillDeclaration($request, $skillDeclaration);
     }
 
+    /**
+     * Update the particular skill declaration in storage.
+     *
+     * @param  \Illuminate\Http\Request     $request          Incoming request.
+     * @param  \App\Models\SkillDeclaration $skillDeclaration Incoming Skill Declaration.
+     * @return \Illuminate\Http\RedirectResponse|string[]
+     */
     protected function updateSkillDeclaration(Request $request, SkillDeclaration $skillDeclaration)
     {
         //Fill variable values
@@ -131,11 +134,11 @@ class SkillDeclarationController extends Controller
     /**
      * Delete the particular skill declaration in storage.
      *
-     * @param  \Illuminate\Http\Request     $request
-     * @param  \App\Models\SkillDeclaration $skillDeclaration
-     * @return \Illuminate\Http\Response
+     * @param  \Illuminate\Http\Request     $request          Incoming request.
+     * @param  \App\Models\SkillDeclaration $skillDeclaration Incoming Skill Declaration.
+     * @return \Illuminate\Http\Response|string[]
      */
-    public function destroy(Request $request, SkillDeclaration $skillDeclaration): \Illuminate\Http\Response
+    public function destroy(Request $request, SkillDeclaration $skillDeclaration)
     {
         $this->authorize('delete', $skillDeclaration);
         $skillDeclaration->delete();

--- a/app/Models/SkillDeclaration.php
+++ b/app/Models/SkillDeclaration.php
@@ -6,9 +6,6 @@
  */
 
 namespace App\Models;
-use App\Models\Reference;
-use App\Models\WorkSample;
-use App\Models\WorkExperience;
 
 /**
  * Class SkillDeclaration
@@ -29,8 +26,12 @@ use App\Models\WorkExperience;
  * @property \Illuminate\Database\Eloquent\Collection $references
  * @property \Illuminate\Database\Eloquent\Collection $work_samples
  */
-class SkillDeclaration extends BaseModel {
+class SkillDeclaration extends BaseModel
+{
 
+    /**
+     * @var string[]
+     */
     protected $casts = [
         'skill_id' => 'int',
         'skill_status_id' => 'int',
@@ -38,68 +39,42 @@ class SkillDeclaration extends BaseModel {
         'applicant_id' => 'int',
         'description' => 'string'
     ];
+
+    /**
+     * @var string[]
+     */
     protected $fillable = [
         'description',
         'skill_level_id'
     ];
 
-    public function skill() {
+    public function skill()// phpcs:ignore
+    {
         return $this->belongsTo(\App\Models\Skill::class);
     }
 
-    public function skill_status() {
+    public function skill_status()// phpcs:ignore
+    {
         return $this->belongsTo(\App\Models\Lookup\SkillStatus::class);
     }
 
-    public function skill_level() {
+    public function skill_level()// phpcs:ignore
+    {
         return $this->belongsTo(\App\Models\Lookup\SkillLevel::class);
     }
 
-    public function applicant() {
+    public function applicant()// phpcs:ignore
+    {
         return $this->belongsTo(\App\Models\Applicant::class);
     }
 
-    public function references() {
+    public function references()// phpcs:ignore
+    {
         return $this->belongsToMany(\App\Models\Reference::class);
     }
 
-    public function work_samples() {
+    public function work_samples()// phpcs:ignore
+    {
         return $this->belongsToMany(\App\Models\WorkSample::class);
     }
-
-    // public function getWorkExperiencesAttribute() {
-    //     // Retrieve all work experiences belonging to the same applicant and skill
-    //     // as this object
-    //     $skill_id = $this->skill->id;
-    //     return WorkExperience::where('applicant_id', $this->applcant_id)
-    //         ->whereHas('skills', function($query) use ($skill_id){
-    //             $query->where('skills.id', $skill_id);
-    //         })->get();
-    // }
-    //
-    // public function getReferencesAttribute() {
-    //     // Retrieve all references belonging to the same applicant and skill
-    //     // as this object
-    //     $skill_id = $this->skill->id;
-    //     return Reference::where('applicant_id', $this->applcant_id)
-    //         ->whereHas('skills', function($query) use ($skill_id){
-    //             $query->where('skills.id', $skill_id);
-    //         })->get();
-    //     // $skill_id = $this->skill->id;
-    //     // return $this->hasManyThrough(\App\Models\Reference::class,\App\Models\Applicant::class)
-    //     //     ->whereHas('skills', function($query) use ($skill_id){
-    //     //         $query->where('skills.id', $skill_id);
-    //     //     })->get();
-    // }
-    //
-    // public function getWorkSamplesAttribute() {
-    //     // Retrieve all work samples belonging to the same applicant and skill
-    //     // as this object
-    //     $skill_id = $this->skill->id;
-    //     return WorkSample::where('applicant_id', $this->applcant_id)
-    //         ->whereHas('skills', function($query) use ($skill_id){
-    //             $query->where('skills.id', $skill_id);
-    //         })->get();
-    // }
-
 }

--- a/tests/Feature/SkillDeclarationControllerTest.php
+++ b/tests/Feature/SkillDeclarationControllerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\SkillDeclaration;
+
+class SkillDeclarationControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Run parent setup and provide reusable factories.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skillDeclaration = factory(SkillDeclaration::class)->create();
+    }
+
+    /**
+     * Ensure a skill declaration can be updated.
+     *
+     * @return void
+     */
+    public function testUpdateSkillDeclaration(): void
+    {
+        $oldDeclaration = clone $this->skillDeclaration;
+        $expected = 'This is a new sample skill declaration description';
+        $this->skillDeclaration->description = $expected;
+        $response = $this->actingAs($this->skillDeclaration->applicant->user)
+                            ->followingRedirects()
+                            ->json(
+                                'PUT',
+                                'skill-declarations/' . $this->skillDeclaration->id,
+                                $this->skillDeclaration->toArray()
+                            );
+        $response->assertStatus(200);
+        $this->assertDatabaseHas(
+            'skill_declarations',
+            $this->skillDeclaration->makeHidden(
+                [
+                    'created_at',
+                    'updated_at'
+                ]
+            )->attributesToArray()
+        );
+        $this->assertDatabaseMissing(
+            'skill_declarations',
+            $oldDeclaration->makeHidden(
+                [
+                    'created_at',
+                    'updated_at'
+                ]
+            )->attributesToArray()
+        );
+    }
+}


### PR DESCRIPTION
Relates to #984 

### Notes:
- Some of the documented return types for controller actions are incorrect/too specific
- We had a short period of time where PHP was formatting on save, causing return type hinting to be added to the controller methods based on the documented return types
- In cases where the typehinted return types were mixed or potentially different (in this case, when returning JSON from an ajax call instead of `\Illuminate\Http\Response` objects) PHP dies in a blaze of glory
