### PR TITLE
Update PHP formatting in controllers

### DIFF
--- a/app/Http/Controllers/Admin/JobPosterCrudController.php
+++ b/app/Http/Controllers/Admin/JobPosterCrudController.php
@@ -14,8 +14,8 @@ class JobPosterCrudController extends CrudController
      */
     public function setup() : void
     {
-        $this->crud->setModel("App\Models\JobPoster");
-        $this->crud->setRoute("admin/job-poster");
+        $this->crud->setModel('App\Models\JobPoster');
+        $this->crud->setRoute('admin/job-poster');
         $this->crud->setEntityNameStrings('Job Poster', 'Job Posters');
 
         $this->crud->denyAccess('create');
@@ -44,15 +44,15 @@ class JobPosterCrudController extends CrudController
             'label' => 'Close Date'
         ]);
         $this->crud->addColumn([
-            'name' => "status",
-            'label' => "Status",
-            'type' => "model_function",
+            'name' => 'status',
+            'label' => 'Status',
+            'type' => 'model_function',
             'function_name' => 'status',
         ]);
         $this->crud->addColumn([
-            'name' => "published",
-            'label' => "Published",
-            'type' => "check",
+            'name' => 'published',
+            'label' => 'Published',
+            'type' => 'check',
         ]);
         $this->crud->addColumn([
             'name' => 'manager.user.name',
@@ -73,7 +73,7 @@ class JobPosterCrudController extends CrudController
 
         $this->crud->addField([
             'name' => 'title',
-            'label' => "Title",
+            'label' => 'Title',
             'type' => 'text',
             'attributes' => [
                 'readonly' => 'readonly'
@@ -99,7 +99,7 @@ class JobPosterCrudController extends CrudController
     /**
      * Action for updating an existing Job Poster in the database.
      *
-     * @param \Illuminate\Http\Request $request Incoming form request.
+     * @param  \Illuminate\Http\Request $request Incoming form request.
      *
      * @return \Illuminate\Http\RedirectResponse
      */

--- a/app/Http/Controllers/Admin/ManagerCrudController.php
+++ b/app/Http/Controllers/Admin/ManagerCrudController.php
@@ -14,8 +14,8 @@ class ManagerCrudController extends CrudController
      */
     public function setup() : void
     {
-        $this->crud->setModel("App\Models\Manager");
-        $this->crud->setRoute("admin/manager");
+        $this->crud->setModel('App\Models\Manager');
+        $this->crud->setRoute('admin/manager');
         $this->crud->setEntityNameStrings('manager', 'managers');
 
         $this->crud->denyAccess('create');
@@ -34,7 +34,7 @@ class ManagerCrudController extends CrudController
 
         $this->crud->removeButton('update');
         $this->crud->addButtonFromView('line', 'create_job_poster', 'create_job_poster', 'beginning');
-        // Add the custom blade button found in resources/views/vendor/backpack/crud/buttons/profile_edit.blade.php
+        // Add the custom blade button found in resources/views/vendor/backpack/crud/buttons/profile_edit.blade.php.
         $this->crud->addButtonFromView('line', 'profile_edit', 'profile_edit', 'end');
     }
 }

--- a/app/Http/Controllers/Admin/SkillCrudController.php
+++ b/app/Http/Controllers/Admin/SkillCrudController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Admin;
 use Backpack\CRUD\app\Http\Controllers\CrudController;
 use Illuminate\Support\Facades\App;
 use App\Models\Lookup\SkillType;
-// Validation
+// Validation.
 use App\Http\Requests\SkillCrudRequest as StoreRequest;
 use App\Http\Requests\SkillCrudRequest as UpdateRequest;
 
@@ -20,7 +20,7 @@ class SkillCrudController extends CrudController
     public function setup() : void
     {
         // Workaround for how the unique_translation validation
-        // works in App\Http\Requests\SkillCrudRequest
+        // works in App\Http\Requests\SkillCrudRequest.
         $locale = 'en';
         if (null !== $this->request->input('locale')) {
             $locale = $this->request->input('locale');
@@ -29,14 +29,14 @@ class SkillCrudController extends CrudController
 
         // Eloquent model to associate with this collection
         // of views and controller actions.
-        $this->crud->setModel("App\Models\Skill");
+        $this->crud->setModel('App\Models\Skill');
         // Custom backpack route.
-        $this->crud->setRoute("admin/skill");
+        $this->crud->setRoute('admin/skill');
         // Custom strings to display within the backpack UI,
         // things like Create Skill, Delete Skills, etc.
         $this->crud->setEntityNameStrings('Skill', 'Skills');
 
-        // Add custom columns to the Skill index view
+        // Add custom columns to the Skill index view.
         $this->crud->addColumn([
             'name' => 'name',
             'type' => 'text',
@@ -67,20 +67,20 @@ class SkillCrudController extends CrudController
             }
         ]);
 
-        // Add custom fields to the create/update views
+        // Add custom fields to the create/update views.
         $this->crud->addField([
             'name' => 'name',
             'type' => 'text',
-            'label' => "Name",
+            'label' => 'Name',
         ]);
         $this->crud->addField([
             'name' => 'description',
             'type' => 'textarea',
-            'label' => "Description"
+            'label' => 'Description'
         ]);
         $this->crud->addField([
             'name' => 'skill_type_id',
-            'label' => "Type",
+            'label' => 'Type',
             'type' => 'select_from_array',
             'options' => SkillType::all()->pluck('name', 'id')->toArray(),
             'allow_null' => false,
@@ -90,8 +90,7 @@ class SkillCrudController extends CrudController
     /**
      * Action for creating a new Skill in the database.
      *
-     * @param SkillCrudRequest $request Incoming form request.
-     *
+     * @param  \App\Http\Requests\SkillCrudRequest $request Incoming form request.
      * @return \Illuminate\Http\RedirectResponse
      */
     public function store(StoreRequest $request) // phpcs:ignore
@@ -102,8 +101,7 @@ class SkillCrudController extends CrudController
     /**
      * Action for creating a new Skill in the database.
      *
-     * @param SkillCrudRequest $request Incoming form request.
-     *
+     * @param  \App\Http\Requests\SkillCrudRequest $request Incoming form request.
      * @return \Illuminate\Http\RedirectResponse
      */
     public function update(UpdateRequest $request) // phpcs:ignore

--- a/app/Http/Controllers/Admin/UserCrudController.php
+++ b/app/Http/Controllers/Admin/UserCrudController.php
@@ -15,8 +15,8 @@ class UserCrudController extends CrudController
      */
     public function setup() : void
     {
-        $this->crud->setModel("App\Models\User");
-        $this->crud->setRoute("admin/user");
+        $this->crud->setModel('App\Models\User');
+        $this->crud->setRoute('admin/user');
         $this->crud->setEntityNameStrings('user', 'users');
 
         $this->crud->denyAccess('create');
@@ -55,19 +55,19 @@ class UserCrudController extends CrudController
 
         $this->crud->addField([
             'name' => 'name',
-            'label' => "Name",
+            'label' => 'Name',
             'type' => 'text',
             'attributes' => [
                 'readonly'=>'readonly'
             ]
         ]);
         $this->crud->addField([
-            'label' => "Role",
+            'label' => 'Role',
             'type' => 'select',
-            'name' => 'user_role_id', // the db column for the foreign key
-            'entity' => 'user_role', // the method that defines the relationship in your Model
-            'attribute' => 'name', // foreign key attribute that is shown to user
-            'model' => "App\Models\UserRole" // foreign key model
+            'name' => 'user_role_id', // The db column for the foreign key.
+            'entity' => 'user_role', // The method that defines the relationship in your Model.
+            'attribute' => 'name', // Foreign key attribute that is shown to user.
+            'model' => 'App\Models\UserRole' // Foreign key model.
         ]);
         $this->crud->addField([
             'name' => 'is_priority',
@@ -79,8 +79,7 @@ class UserCrudController extends CrudController
     /**
      * Action for updating an existing User in the database.
      *
-     * @param \Illuminate\Http\Request $request Incoming form request.
-     *
+     * @param  \Illuminate\Http\Request $request Incoming form request.
      * @return \Illuminate\Http\RedirectResponse
      */
     public function update($request) // phpcs:ignore

--- a/app/Http/Controllers/Api/JobApiController.php
+++ b/app/Http/Controllers/Api/JobApiController.php
@@ -25,7 +25,7 @@ class JobApiController extends Controller
      * with all criteria,
      * and with translation arrays in both languages.
      *
-     * @param  JobPoster $job Incoming Job Poster object.
+     * @param  \App\Models\JobPoster $job Incoming Job Poster object.
      * @return mixed[]
      */
     private function jobToArray(JobPoster $job)
@@ -62,7 +62,7 @@ class JobApiController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param  JobPoster $job Incoming Job Poster.
+     * @param  \App\Models\JobPoster $job Incoming Job Poster.
      * @return \Illuminate\Http\Response
      */
     public function show(JobPoster $job)

--- a/app/Http/Controllers/Api/JobApiController.php
+++ b/app/Http/Controllers/Api/JobApiController.php
@@ -11,9 +11,12 @@ use App\Http\Requests\UpdateJobPoster;
 
 class JobApiController extends Controller
 {
+    /**
+     * Class constructor
+     */
     public function __construct()
     {
-        // This applies the appropriate policy to each resource route
+        // This applies the appropriate policy to each resource route.
         $this->authorizeResource(JobPoster::class, 'job');
     }
 
@@ -22,7 +25,7 @@ class JobApiController extends Controller
      * with all criteria,
      * and with translation arrays in both languages.
      *
-     * @param JobPoster $job
+     * @param  JobPoster $job Incoming Job Poster object.
      * @return mixed[]
      */
     private function jobToArray(JobPoster $job)
@@ -42,24 +45,24 @@ class JobApiController extends Controller
      */
     public function index()
     {
-        //TODO: complete
+        // TODO: complete.
     }
 
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request $request Incoming request.
      * @return \Illuminate\Http\Response
      */
     public function store(Request $request)
     {
-        //TODO: complete
+        // TODO: complete.
     }
 
     /**
      * Display the specified resource.
      *
-     * @param JobPoster $job
+     * @param  JobPoster $job Incoming Job Poster.
      * @return \Illuminate\Http\Response
      */
     public function show(JobPoster $job)
@@ -70,8 +73,8 @@ class JobApiController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  App\Http\Requests\UpdateJobPoster  $request Validates input.
-     * @param  JobPoster $jobPoser
+     * @param  \App\Http\Requests\UpdateJobPoster $request Validates input.
+     * @param  \App\Models\JobPoster              $job     Incoming Job Poster.
      * @return \Illuminate\Http\Response
      */
     public function update(UpdateJobPoster $request, JobPoster $job)
@@ -79,7 +82,7 @@ class JobApiController extends Controller
         $data = $request->validated();
         JobPosterValidator::validateUnpublished($job);
         // Only values both in the JobPoster->fillable array,
-        //  and returned by UpdateJobPoster->validatedData(), will be set
+        // and returned by UpdateJobPoster->validatedData(), will be set.
         $job->fill($data);
         $job->save();
         return $this->jobToArray($job);
@@ -88,11 +91,11 @@ class JobApiController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param  int  $id
+     * @param  integer $id Job Poster ID.
      * @return \Illuminate\Http\Response
      */
     public function destroy($id)
     {
-        // TODO:
+        // TODO: complete.
     }
 }

--- a/app/Http/Controllers/Api/ManagerApiController.php
+++ b/app/Http/Controllers/Api/ManagerApiController.php
@@ -9,10 +9,12 @@ use App\Http\Requests\UpdateManager;
 
 class ManagerApiController extends Controller
 {
-
+    /**
+     * Class constructor.
+     */
     public function __construct()
     {
-        // This applies the appropriate policy to each resource route
+        // This applies the appropriate policy to each resource route.
         $this->authorizeResource(Manager::class, 'manager');
     }
 
@@ -23,24 +25,24 @@ class ManagerApiController extends Controller
      */
     public function index()
     {
-        //TODO:
+        // TODO: complete.
     }
 
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request $request Incoming Request.
      * @return \Illuminate\Http\Response
      */
     public function store(Request $request)
     {
-        //TODO:
+        // TODO: complete.
     }
 
     /**
      * Display the specified resource.
      *
-     * @param  \App\Models\Manager  $manager
+     * @param  \App\Models\Manager $manager Incoming Manager.
      * @return \Illuminate\Http\Response
      */
     public function show(Manager $manager)
@@ -51,8 +53,8 @@ class ManagerApiController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  App\Http\Requests\UpdateManager  $request
-     * @param  \App\Models\Manager  $manager
+     * @param  App\Http\Requests\UpdateManager $request Incoming Form Request.
+     * @param  \App\Models\Manager             $manager Incoming Manager.
      * @return \Illuminate\Http\Response
      */
     public function update(UpdateManager $request, Manager $manager)
@@ -66,11 +68,11 @@ class ManagerApiController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param  \App\Models\Manager  $manager
+     * @param  \App\Models\Manager $manager Incoming Manager.
      * @return \Illuminate\Http\Response
      */
     public function destroy(Manager $manager)
     {
-        //TODO:
+        // TODO: complete.
     }
 }

--- a/app/Http/Controllers/Api/ManagerApiController.php
+++ b/app/Http/Controllers/Api/ManagerApiController.php
@@ -53,8 +53,8 @@ class ManagerApiController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  App\Http\Requests\UpdateManager $request Incoming Form Request.
-     * @param  \App\Models\Manager             $manager Incoming Manager.
+     * @param  \App\Http\Requests\UpdateManager $request Incoming Form Request.
+     * @param  \App\Models\Manager              $manager Incoming Manager.
      * @return \Illuminate\Http\Response
      */
     public function update(UpdateManager $request, Manager $manager)

--- a/app/Http/Controllers/ApplicantProfileController.php
+++ b/app/Http/Controllers/ApplicantProfileController.php
@@ -3,8 +3,6 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Lang;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Auth\GuardHelpers;
 use Illuminate\Http\Request;
 use App\Models\Lookup\ApplicantProfileQuestion;
 use App\Models\Applicant;
@@ -15,14 +13,16 @@ use App\Services\Validation\Requests\UpdateApplicationProfileValidator;
 
 class ApplicantProfileController extends Controller
 {
-
+    /**
+     * @var string
+     */
     protected $answerFormInputName = 'applicantProfileAnswer';
 
     /**
      * Display the specified resource.
      *
-     * @param  Request               $request
-     * @param  \App\Models\Applicant $applicant
+     * @param  \Illuminate\Http\Request $request   Incoming Request object.
+     * @param  \App\Models\Applicant    $applicant Incoming Applicant object.
      * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
      */
     public function show(Request $request, Applicant $applicant)
@@ -42,7 +42,6 @@ class ApplicantProfileController extends Controller
             [
                 /* Localization Strings*/
                 'profile' => Lang::get('manager/applicant_profile'), // Change text
-
                 /* User Data */
                 'user' => $applicant->user,
                 'applicant' => $applicant,
@@ -54,10 +53,10 @@ class ApplicantProfileController extends Controller
     /**
      * Show the form for editing the logged-in applicant's profile
      *
-     * @param  Request $request
-     * @return \Illuminate\Http\RedirectResponse
+     * @param  Request $request Incoming request.
+     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
      */
-    public function editAuthenticated(Request $request): \Illuminate\Http\RedirectResponse
+    public function editAuthenticated(Request $request)
     {
         $applicant = $request->user()->applicant;
         return redirect(route('profile.about.edit', $applicant));
@@ -96,16 +95,15 @@ class ApplicantProfileController extends Controller
         return view(
             'applicant/profile_01_about',
             [
-            /* Localized strings*/
-            'profile' => $profileText,
-            /* Applicant Profile Questions */
-            'applicant_profile_questions' => $profileQuestionForms,
-            /* User Data */
-            'user' => $applicant->user,
-            'applicant' => $applicant,
-            'profile_photo_url' => '/images/user.png', //TODO: get real photos
-
-            'form_submit_action' => route('profile.about.update', $applicant)
+                /* Localized strings*/
+                'profile' => $profileText,
+                /* Applicant Profile Questions */
+                'applicant_profile_questions' => $profileQuestionForms,
+                /* User Data */
+                'user' => $applicant->user,
+                'applicant' => $applicant,
+                'profile_photo_url' => '/images/user.png', //TODO: get real photos
+                'form_submit_action' => route('profile.about.update', $applicant)
             ]
         );
     }
@@ -115,9 +113,9 @@ class ApplicantProfileController extends Controller
      *
      * @param  Request               $request   Incoming request.
      * @param  \App\Models\Applicant $applicant Applicant object to update.
-     * @return \Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
      */
-    public function update(Request $request, Applicant $applicant): \Illuminate\Http\RedirectResponse
+    public function update(Request $request, Applicant $applicant)
     {
         $questions = ApplicantProfileQuestion::all();
 
@@ -128,10 +126,11 @@ class ApplicantProfileController extends Controller
             $answerName = $this->answerFormInputName . '.' . $question->id;
             if ($request->has($answerName)) {
                 $answer = ApplicantProfileAnswer::where(
-                    ['applicant_id' => $applicant->id,
-                    'applicant_profile_question_id' => $question->id]
-                )
-                            ->first();
+                    [
+                        'applicant_id' => $applicant->id,
+                        'applicant_profile_question_id' => $question->id
+                    ]
+                )->first();
                 if ($answer == null) {
                     $answer = new ApplicantProfileAnswer();
                     $answer->applicant_id =$applicant->id;
@@ -145,9 +144,9 @@ class ApplicantProfileController extends Controller
         $input = $request->input();
         $applicant->fill(
             [
-            'tagline' => $input['tagline'],
-            'twitter_username' => $input['twitter_username'],
-            'linkedin_url' => $input['linkedin_url'],
+                'tagline' => $input['tagline'],
+                'twitter_username' => $input['twitter_username'],
+                'linkedin_url' => $input['linkedin_url'],
             ]
         );
         $applicant->save();
@@ -155,8 +154,8 @@ class ApplicantProfileController extends Controller
         $user = $applicant->user;
         $user->fill(
             [
-            'name' => $input['profile_name'],
-            'email' => $input['profile_email'], //TODO make changing email harder!
+                'name' => $input['profile_name'],
+                'email' => $input['profile_email'], //TODO make changing email harder!
             ]
         );
         if ($input['new_password']) {

--- a/app/Http/Controllers/ApplicantProfileController.php
+++ b/app/Http/Controllers/ApplicantProfileController.php
@@ -23,29 +23,31 @@ class ApplicantProfileController extends Controller
      *
      * @param  \Illuminate\Http\Request $request   Incoming Request object.
      * @param  \App\Models\Applicant    $applicant Incoming Applicant object.
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @return \Illuminate\Http\Response
      */
     public function show(Request $request, Applicant $applicant)
     {
-        //TODO:
-        //Josh, to loop through answers&question data, leverage this data structure:
-        // applicant
-        //     [applicant_profile_answers]
-        //         answer
-        //         applicant_profile_question
-        //             id
-        //             value // The question text
-        //             description // Question description text
+        /*
+         * TODO:
+         * Josh, to loop through answers&question data, leverage this data structure:
+         * applicant
+         *     [applicant_profile_answers]
+         *         answer
+         *         applicant_profile_question
+         *             id
+         *             value // The question text
+         *             description // Question description text
+         */
 
         return view(
             'manager/applicant_profile',
             [
-                /* Localization Strings*/
+                // Localization Strings.
                 'profile' => Lang::get('manager/applicant_profile'), // Change text
-                /* User Data */
+                // User Data.
                 'user' => $applicant->user,
                 'applicant' => $applicant,
-                'profile_photo_url' => '/images/user.png', //TODO: get real photos
+                'profile_photo_url' => '/images/user.png', // TODO: get real photos.
             ]
         );
     }
@@ -53,8 +55,8 @@ class ApplicantProfileController extends Controller
     /**
      * Show the form for editing the logged-in applicant's profile
      *
-     * @param  Request $request Incoming request.
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     * @param  \Illuminate\Http\Request $request Incoming request.
+     * @return \Illuminate\Http\Response
      */
     public function editAuthenticated(Request $request)
     {
@@ -65,9 +67,9 @@ class ApplicantProfileController extends Controller
     /**
      * Show the form for editing an applicant profile
      *
-     * @param  Request               $request   Incoming request object.
-     * @param  \App\Models\Applicant $applicant Applicant to view and edit.
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @param  \Illuminate\Http\Request $request   Incoming request object.
+     * @param  \App\Models\Applicant    $applicant Applicant to view and edit.
+     * @return \Illuminate\Http\Response
      */
     public function edit(Request $request, Applicant $applicant)
     {
@@ -95,14 +97,14 @@ class ApplicantProfileController extends Controller
         return view(
             'applicant/profile_01_about',
             [
-                /* Localized strings*/
+                // Localized strings.
                 'profile' => $profileText,
-                /* Applicant Profile Questions */
+                // Applicant Profile Questions.
                 'applicant_profile_questions' => $profileQuestionForms,
-                /* User Data */
+                // User Data.
                 'user' => $applicant->user,
                 'applicant' => $applicant,
-                'profile_photo_url' => '/images/user.png', //TODO: get real photos
+                'profile_photo_url' => '/images/user.png', // TODO: get real photos.
                 'form_submit_action' => route('profile.about.update', $applicant)
             ]
         );
@@ -111,9 +113,9 @@ class ApplicantProfileController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  Request               $request   Incoming request.
-     * @param  \App\Models\Applicant $applicant Applicant object to update.
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     * @param  \Illuminate\Http\Request $request   Incoming request.
+     * @param  \App\Models\Applicant    $applicant Applicant object to update.
+     * @return \Illuminate\Http\Response
      */
     public function update(Request $request, Applicant $applicant)
     {
@@ -155,11 +157,11 @@ class ApplicantProfileController extends Controller
         $user->fill(
             [
                 'name' => $input['profile_name'],
-                'email' => $input['profile_email'], //TODO make changing email harder!
+                'email' => $input['profile_email'], // TODO make changing email harder!
             ]
         );
         if ($input['new_password']) {
-            $user->password =  Hash::make($input['new_password']); //TODO: change password in seperate form!
+            $user->password =  Hash::make($input['new_password']); // TODO: change password in seperate form!
         }
         $user->save();
 

--- a/app/Http/Controllers/ApplicationByJobController.php
+++ b/app/Http/Controllers/ApplicationByJobController.php
@@ -28,7 +28,7 @@ class ApplicationByJobController extends Controller
     /**
      * Display a listing of the applications for given jobPoster.
      *
-     * @param  JobPoster $jobPoster Incoming JobPoster object.
+     * @param  \App\Models\JobPoster $jobPoster Incoming JobPoster object.
      * @return \Illuminate\Http\Response
      */
     public function index(JobPoster $jobPoster)
@@ -55,8 +55,8 @@ class ApplicationByJobController extends Controller
     /**
      * Return the current applicant's application for a given Job Poster.
      *
-     * @param  JobPoster $jobPoster Incoming JobPoster object.
-     * @return mixed|App\Models\JobApplication
+     * @param  \App\Models\JobPoster $jobPoster Incoming JobPoster object.
+     * @return mixed|\App\Models\JobApplication
      */
     protected function getApplicationFromJob(JobPoster $jobPoster)
     {

--- a/app/Http/Controllers/ApplicationByJobController.php
+++ b/app/Http/Controllers/ApplicationByJobController.php
@@ -29,7 +29,7 @@ class ApplicationByJobController extends Controller
      * Display a listing of the applications for given jobPoster.
      *
      * @param  JobPoster $jobPoster Incoming JobPoster object.
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @return \Illuminate\Http\Response
      */
     public function index(JobPoster $jobPoster)
     {
@@ -38,14 +38,14 @@ class ApplicationByJobController extends Controller
                 'veteran_status',
                 'citizenship_declaration',
                 'application_review',
-                "applicant.user",
-                "job_poster.criteria",
+                'applicant.user',
+                'job_poster.criteria',
             ])
             ->get();
         return view('manager/review_applications', [
-            /*Localization Strings*/
+            // Localization Strings.
             'jobs_l10n' => Lang::get('manager/job_index'),
-            /* Data */
+            // Data.
             'job' => $jobPoster,
             'applications' => $applications,
             'review_statuses' => ReviewStatus::all()
@@ -61,7 +61,7 @@ class ApplicationByJobController extends Controller
     protected function getApplicationFromJob(JobPoster $jobPoster)
     {
         $application = JobApplication::where('applicant_id', Auth::user()->applicant->id)
-        ->where('job_poster_id', $jobPoster->id)->first();
+            ->where('job_poster_id', $jobPoster->id)->first();
         if ($application == null) {
             $application = new JobApplication();
             $application->job_poster_id = $jobPoster->id;
@@ -76,21 +76,21 @@ class ApplicationByJobController extends Controller
      * Show the form for editing Application basics for the specified job.
      *
      * @param  \App\Models\JobPoster $jobPoster Incoming Job Poster object.
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @return \Illuminate\Http\Response
      */
     public function editBasics(JobPoster $jobPoster)
     {
         $applicant = Auth::user()->applicant;
         $application = $this->getApplicationFromJob($jobPoster);
 
-        //Ensure user has permissions to view and update application
+        // Ensure user has permissions to view and update application.
         $this->authorize('view', $application);
         $this->authorize('update', $application);
 
         return view(
             'applicant/application_post_01',
             [
-                /* Application Template Data */
+                // Application Template Data.
                 'application_step' => 1,
                 'application_template' => Lang::get('applicant/application_template'),
                 'language_options' => PreferredLanguage::all(),
@@ -99,12 +99,12 @@ class ApplicationByJobController extends Controller
                 'preferred_language_template' => Lang::get('common/preferred_language'),
                 'citizenship_declaration_template' => Lang::get('common/citizenship_declaration'),
                 'veteran_status_template' => Lang::get('common/veteran_status'),
-                /* Job Data */
+                // Job Data.
                 'job' => $jobPoster,
-                /* Applicant Data */
+                // Applicant Data.
                 'applicant' => $applicant,
                 'job_application' => $application,
-                /* Submission */
+                // Submission.
                 'form_submit_action' => route('job.application.update.1', $jobPoster)
             ]
         );
@@ -113,30 +113,30 @@ class ApplicationByJobController extends Controller
     /**
      * Show the form for editing Application Experience for the specified job.
      *
-     * @param \App\Models\JobPoster $jobPoster Incoming Job Poster object.
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @param  \App\Models\JobPoster $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Http\Response
      */
     public function editExperience(JobPoster $jobPoster)
     {
         $applicant = Auth::user()->applicant;
         $application = $this->getApplicationFromJob($jobPoster);
 
-        //Ensure user has permissions to view and update application
+        // Ensure user has permissions to view and update application.
         $this->authorize('view', $application);
         $this->authorize('update', $application);
 
         return view(
             'applicant/application_post_02',
             [
-                /* Application Template Data */
+                // Application Template Data.
                 'application_step' => 2,
-                'application_template' => Lang::get("applicant/application_template"),
-                /* Job Data */
+                'application_template' => Lang::get('applicant/application_template'),
+                // Job Data.
                 'job' => $jobPoster,
-                /* Applicant Data */
+                // Applicant Data.
                 'applicant' => $applicant,
                 'job_application' => $application,
-                /* Submission */
+                // Submission.
                 'form_submit_action' => route('job.application.update.2', $jobPoster)
             ]
         );
@@ -145,15 +145,15 @@ class ApplicationByJobController extends Controller
     /**
      * Show the form for editing Application Essential Skills for the specified job.
      *
-     * @param \App\Models\JobPoster $jobPoster Incoming Job Poster object.
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @param  \App\Models\JobPoster $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Http\Response
      */
     public function editEssentialSkills(JobPoster $jobPoster)
     {
         $applicant = Auth::user()->applicant;
         $application = $this->getApplicationFromJob($jobPoster);
 
-        //Ensure user has permissions to view and update application
+        // Ensure user has permissions to view and update application.
         $this->authorize('view', $application);
         $this->authorize('update', $application);
 
@@ -169,19 +169,19 @@ class ApplicationByJobController extends Controller
         return view(
             'applicant/application_post_03',
             [
-                /* Application Template Data */
+                // Application Template Data.
                 'application_step' => 3,
                 'application_template' => Lang::get('applicant/application_template'),
-                /* Job Data */
+                // Job Data.
                 'job' => $jobPoster,
-                /* Skills Data */
+                // Skills Data.
                 'skills' => Skill::all(),
                 'skill_template' => Lang::get('common/skills'),
                 'criteria' => $criteria,
-                /* Applicant Data */
+                // Applicant Data.
                 'applicant' => $applicant,
                 'job_application' => $application,
-                /* Submission */
+                // Submission.
                 'form_submit_action' => route('job.application.update.3', $jobPoster)
             ]
         );
@@ -190,15 +190,15 @@ class ApplicationByJobController extends Controller
     /**
      * Show the form for editing Application Asset Skills for the specified job.
      *
-     * @param \App\Models\JobPoster $jobPoster Incoming Job Poster object.
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @param  \App\Models\JobPoster $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Http\Response
      */
     public function editAssetSkills(JobPoster $jobPoster)
     {
         $applicant = Auth::user()->applicant;
         $application = $this->getApplicationFromJob($jobPoster);
 
-        //Ensure user has permissions to view and update application
+        // Ensure user has permissions to view and update application.
         $this->authorize('view', $application);
         $this->authorize('update', $application);
 
@@ -214,19 +214,19 @@ class ApplicationByJobController extends Controller
         return view(
             'applicant/application_post_04',
             [
-                /* Application Template Data */
+                // Application Template Data.
                 'application_step' => 4,
                 'application_template' => Lang::get('applicant/application_template'),
-                /* Job Data */
+                // Job Data.
                 'job' => $jobPoster,
-                /* Skills Data */
+                // Skills Data.
                 'skills' => Skill::all(),
                 'skill_template' => Lang::get('common/skills'),
                 'criteria' => $criteria,
-                /* Applicant Data */
+                // Applicant Data.
                 'applicant' => $applicant,
                 'job_application' => $application,
-                /* Submission */
+                // Submission.
                 'form_submit_action' => route('job.application.update.4', $jobPoster)
             ]
         );
@@ -235,8 +235,8 @@ class ApplicationByJobController extends Controller
     /**
      * Show the Application Preview for the application for the specified job.
      *
-     * @param \App\Models\JobPoster $jobPoster Incoming Job Poster object.
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @param  \App\Models\JobPoster $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Http\Response
      */
     public function preview(JobPoster $jobPoster)
     {
@@ -256,19 +256,19 @@ class ApplicationByJobController extends Controller
         return view(
             'applicant/application_post_05',
             [
-                /* Application Template Data */
+                // Application Template Data.
                 'application_step' => 5,
                 'application_template' => Lang::get('applicant/application_template'),
                 'preferred_language_template' => Lang::get('common/preferred_language'),
                 'citizenship_declaration_template' => Lang::get('common/citizenship_declaration'),
                 'veteran_status_template' => Lang::get('common/veteran_status'),
-                /* Job Data */
+                // Job Data.
                 'job' => $jobPoster,
-                /* Skills Data */
+                // Skills Data.
                 'skills' => Skill::all(),
                 'skill_template' => Lang::get('common/skills'),
                 'criteria' => $criteria,
-                /* Applicant Data */
+                // Applicant Data.
                 'applicant' => $applicant,
                 'job_application' => $application,
             ]
@@ -278,8 +278,8 @@ class ApplicationByJobController extends Controller
     /**
      * Show the Confirm Submit page for the application for the specified job.
      *
-     * @param \App\Models\JobPoster $jobPoster Incoming Job Poster object.
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @param  \App\Models\JobPoster $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Http\Response
      */
     public function confirm(JobPoster $jobPoster)
     {
@@ -291,13 +291,13 @@ class ApplicationByJobController extends Controller
         return view(
             'applicant/application_post_06',
             [
-                /* Application Template Data */
+                // Application Template Data.
                 'application_step' => 6,
                 'application_template' => Lang::get('applicant/application_template'),
-                /* Used by tracker partial */
+                // Used by tracker partial.
                 'job' => $jobPoster,
                 'job_application' => $application,
-                /* Submission */
+                // Submission.
                 'form_submit_action' => route('job.application.submit', $jobPoster)
             ]
         );
@@ -306,28 +306,28 @@ class ApplicationByJobController extends Controller
     /**
      * Show the application submission information.
      *
-     * @param \App\Models\JobPoster $jobPoster Incoming Job Poster object.
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @param  \App\Models\JobPoster $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Http\Response
      */
     public function complete(JobPoster $jobPoster)
     {
-        /* Include Applicant Data */
+        // Include Applicant Data.
         $applicant = Auth::user()->applicant;
-        /* Include Application Data */
+        // Include Application Data.
         $application = $this->getApplicationFromJob($jobPoster);
 
-        // Ensure user has permissions to view application
+        // Ensure user has permissions to view application.
         $this->authorize('view', $application);
 
-        /* Return the Completion View */
+        // Return the Completion View.
         return view(
             'applicant/application_post_complete',
             [
-                /* Application Template Data */
+                // Application Template Data.
                 'application_template' => Lang::get('applicant/application_template'),
-                /* Job Data */
+                // Job Data.
                 'job' => $jobPoster,
-                /* Applicant Data */
+                // Applicant Data.
                 'applicant' => $applicant,
                 'job_application' => $application
             ]
@@ -337,16 +337,16 @@ class ApplicationByJobController extends Controller
     /**
      * Update the Application Basics in storage for the specified job.
      *
-     * @param \Illuminate\Http\Request $request   Incoming Request object.
-     * @param \App\Models\JobPoster    $jobPoster Incoming Job Poster object.
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     * @param  \Illuminate\Http\Request $request   Incoming Request object.
+     * @param  \App\Models\JobPoster    $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Http\Response
      */
     public function updateBasics(Request $request, JobPoster $jobPoster)
     {
         $applicant = Auth::user()->applicant;
         $application = $this->getApplicationFromJob($jobPoster);
 
-        //Ensure user has permissions to update this application
+        // Ensure user has permissions to update this application.
         $this->authorize('update', $application);
 
         $application->fill([
@@ -375,7 +375,7 @@ class ApplicationByJobController extends Controller
             $answerObj->save();
         }
 
-        // Redirect to correct page
+        // Redirect to correct page.
         switch ($request->input('submit')) {
             case 'save_and_quit':
             case 'previous':
@@ -393,19 +393,19 @@ class ApplicationByJobController extends Controller
     /**
      * Update the Application Basics in storage for the specified job.
      *
-     * @param \Illuminate\Http\Request $request   Incoming Request object.
-     * @param \App\Models\JobPoster    $jobPoster Incoming Job Poster object.
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     * @param  \Illuminate\Http\Request $request   Incoming Request object.
+     * @param  \App\Models\JobPoster    $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Http\Response
      */
     public function updateExperience(Request $request, JobPoster $jobPoster)
     {
         $applicant = Auth::user()->applicant;
         $application = $this->getApplicationFromJob($jobPoster);
 
-        // Ensure user has permissions to update this application
+        // Ensure user has permissions to update this application.
         $this->authorize('update', $application);
 
-        // Record that the user has saved their experience for this application
+        // Record that the user has saved their experience for this application.
         $application->experience_saved = true;
         $application->save();
 
@@ -420,7 +420,7 @@ class ApplicationByJobController extends Controller
             'degrees.new.*.end_date'       => 'required|date',
         ]);
 
-        // Save new degrees
+        // Save new degrees.
         if (isset($degrees['new'])) {
             foreach ($degrees['new'] as $degreeInput) {
                 $degree = new Degree();
@@ -437,10 +437,10 @@ class ApplicationByJobController extends Controller
             }
         }
 
-        // Update old degrees
+        // Update old degrees.
         if (isset($degrees['old'])) {
             foreach ($degrees['old'] as $id => $degreeInput) {
-                //Ensure this degree belongs to this applicant
+                // Ensure this degree belongs to this applicant.
                 $degree = $applicant->degrees->firstWhere('id', $id);
                 if ($degree != null) {
                     $degree->fill([
@@ -468,7 +468,7 @@ class ApplicationByJobController extends Controller
             'courses.new.*.end_date'         => 'required|date',
         ]);
 
-        // Save new courses
+        // Save new courses.
         if (isset($courses['new'])) {
             foreach ($courses['new'] as $courseInput) {
                 $course = new Course();
@@ -484,10 +484,10 @@ class ApplicationByJobController extends Controller
             }
         }
 
-        // Update old courses
+        // Update old courses.
         if (isset($courses['old'])) {
             foreach ($courses['old'] as $id => $courseInput) {
-                // Ensure this course belongs to this applicant
+                // Ensure this course belongs to this applicant.
                 $course = $applicant->courses->firstWhere('id', $id);
                 if ($course != null) {
                     $course->fill([
@@ -514,7 +514,7 @@ class ApplicationByJobController extends Controller
             'work_experiences.new.*.end_date'    => 'required|date',
         ]);
 
-        // Save new work_experiences
+        // Save new work_experiences.
         if (isset($work_experiences['new'])) {
             foreach ($work_experiences['new'] as $workExperienceInput) {
                 $workExperience = new WorkExperience();
@@ -530,10 +530,10 @@ class ApplicationByJobController extends Controller
             }
         }
 
-        // Update old work_experiences
+        // Update old work_experiences.
         if (isset($work_experiences['old'])) {
             foreach ($work_experiences['old'] as $id => $workExperienceInput) {
-                //Ensure this work_experience belongs to this applicant
+                // Ensure this work_experience belongs to this applicant.
                 $workExperience = $applicant->work_experiences->firstWhere('id', $id);
                 if ($workExperience != null) {
                     $workExperience->fill([
@@ -550,7 +550,7 @@ class ApplicationByJobController extends Controller
             }
         }
 
-        // Redirect to correct page
+        // Redirect to correct page.
         switch ($request->input('submit')) {
             case 'save_and_quit':
                 return redirect()->route('applications.index');
@@ -570,22 +570,22 @@ class ApplicationByJobController extends Controller
     /**
      * Update the Application Essential Skills in storage for the specified job.
      *
-     * @param \Illuminate\Http\Request $request   Incoming Request object.
-     * @param \App\Models\JobPoster    $jobPoster Incoming Job Poster object.
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     * @param  \Illuminate\Http\Request $request   Incoming Request object.
+     * @param  \App\Models\JobPoster    $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Http\Response
      */
     public function updateEssentialSkills(Request $request, JobPoster $jobPoster)
     {
         $applicant = Auth::user()->applicant;
         $application = $this->getApplicationFromJob($jobPoster);
 
-        // Ensure user has permissions to update this application
+        // Ensure user has permissions to update this application.
         $this->authorize('update', $application);
 
         $skillDeclarations = $request->input('skill_declarations');
         $claimedStatusId = SkillStatus::where('name', 'claimed')->firstOrFail()->id;
 
-        // Save new skill declarartions
+        // Save new skill declarartions.
         if (isset($skillDeclarations['new'])) {
             foreach ($skillDeclarations['new'] as $skillType => $typeInput) {
                 foreach ($typeInput as $criterion_id => $skillDeclarationInput) {
@@ -608,14 +608,14 @@ class ApplicationByJobController extends Controller
             }
         }
 
-        // Update old declarations
+        // Update old declarations.
         if (isset($skillDeclarations['old'])) {
             foreach ($skillDeclarations['old'] as $skillType => $typeInput) {
                 foreach ($typeInput as $id => $skillDeclarationInput) {
-                    // Ensure this declaration belongs to this applicant
+                    // Ensure this declaration belongs to this applicant.
                     $skillDeclaration = $applicant->skill_declarations->firstWhere('id', $id);
                     if ($skillDeclaration != null) {
-                        // skill_id and skill_status cannot be changed
+                        // skill_id and skill_status cannot be changed.
                         $skillDeclaration->fill([
                             'description' => $skillDeclarationInput['description'],
                             'skill_level_id' => isset($skillDeclarationInput['skill_level_id']) ? $skillDeclarationInput['skill_level_id'] : null,
@@ -634,7 +634,7 @@ class ApplicationByJobController extends Controller
             }
         }
 
-        // Redirect to correct page
+        // Redirect to correct page.
         switch ($request->input('submit')) {
             case 'save_and_quit':
                 return redirect()->route('applications.index');
@@ -654,22 +654,22 @@ class ApplicationByJobController extends Controller
     /**
      * Update the Application Asset Skills in storage for the specified job.
      *
-     * @param \Illuminate\Http\Request $request   Incoming Request object.
-     * @param \App\Models\JobPoster    $jobPoster Incoming Job Poster object.
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     * @param  \Illuminate\Http\Request $request   Incoming Request object.
+     * @param  \App\Models\JobPoster    $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Http\Response
      */
     public function updateAssetSkills(Request $request, JobPoster $jobPoster)
     {
         $applicant = Auth::user()->applicant;
         $application = $this->getApplicationFromJob($jobPoster);
 
-        // Ensure user has permissions to update this application
+        // Ensure user has permissions to update this application.
         $this->authorize('update', $application);
 
         $skillDeclarations = $request->input('skill_declarations');
         $claimedStatusId = SkillStatus::where('name', 'claimed')->firstOrFail()->id;
 
-        // Save new skill declarartions
+        // Save new skill declarartions.
         if (isset($skillDeclarations['new'])) {
             foreach ($skillDeclarations['new'] as $skillType => $typeInput) {
                 foreach ($typeInput as $criterion_id => $skillDeclarationInput) {
@@ -692,14 +692,14 @@ class ApplicationByJobController extends Controller
             }
         }
 
-        // Update old declarations
+        // Update old declarations.
         if (isset($skillDeclarations['old'])) {
             foreach ($skillDeclarations['old'] as $skillType => $typeInput) {
                 foreach ($typeInput as $id => $skillDeclarationInput) {
-                    // Ensure this declaration belongs to this applicant
+                    // Ensure this declaration belongs to this applicant.
                     $skillDeclaration = $applicant->skill_declarations->firstWhere('id', $id);
                     if ($skillDeclaration != null) {
-                        // skill_id and skill_status cannot be changed
+                        // skill_id and skill_status cannot be changed.
                         $skillDeclaration->fill([
                             'description' => $skillDeclarationInput['description'],
                             'skill_level_id' => isset($skillDeclarationInput['skill_level_id']) ? $skillDeclarationInput['skill_level_id'] : null,
@@ -718,7 +718,7 @@ class ApplicationByJobController extends Controller
             }
         }
 
-        // Redirect to correct page
+        // Redirect to correct page.
         switch ($request->input('submit')) {
             case 'save_and_quit':
                 return redirect()->route('applications.index');
@@ -738,20 +738,20 @@ class ApplicationByJobController extends Controller
     /**
      * Submit the Application for the specified job.
      *
-     * @param \Illuminate\Http\Request $request   Incoming Request object.
-     * @param \App\Models\JobPoster    $jobPoster Incoming Job Poster object.
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     * @param  \Illuminate\Http\Request $request   Incoming Request object.
+     * @param  \App\Models\JobPoster    $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Http\Response
      */
     public function submit(Request $request, JobPoster $jobPoster)
     {
         $applicant = Auth::user()->applicant;
         $application = $this->getApplicationFromJob($jobPoster);
 
-        // Ensure user has permissions to update this application
+        // Ensure user has permissions to update this application.
         $this->authorize('update', $application);
 
-        // Only complete submission if submit button was pressed
-        if ($request->input('submit') == "submit") {
+        // Only complete submission if submit button was pressed.
+        if ($request->input('submit') == 'submit') {
             $request->validate([
                 'submission_signature' => [
                     'required',
@@ -765,7 +765,7 @@ class ApplicationByJobController extends Controller
                 ]
             ]);
 
-            // Save any final info
+            // Save any final info.
             $application->fill([
                 'submission_signature' => $request->input('submission_signature'),
                 'submission_date' => $request->input('submission_date'),
@@ -774,13 +774,13 @@ class ApplicationByJobController extends Controller
             $validator = new ApplicationValidator();
             $validator->validate($application);
 
-            // Change status to 'submitted'
+            // Change status to 'submitted'.
             $application->application_status_id = ApplicationStatus::where('name', 'submitted')->firstOrFail()->id;
         }
 
         $application->save();
 
-        // Redirect to correct page
+        // Redirect to correct page.
         switch ($request->input('submit')) {
             case 'save_and_quit':
                 return redirect()->route('applications.index');

--- a/app/Http/Controllers/ApplicationByJobController.php
+++ b/app/Http/Controllers/ApplicationByJobController.php
@@ -8,7 +8,6 @@ use App\Models\Lookup\ApplicationStatus;
 use App\Models\Lookup\VeteranStatus;
 use App\Models\Lookup\PreferredLanguage;
 use App\Models\Lookup\CitizenshipDeclaration;
-use App\Models\Applicant;
 use App\Models\JobPoster;
 use App\Models\JobApplication;
 use App\Models\JobApplicationAnswer;
@@ -16,7 +15,6 @@ use App\Models\SkillDeclaration;
 use App\Models\Skill;
 use App\Models\Lookup\SkillStatus;
 use App\Models\Degree;
-use App\Models\Lookup\CriteriaType;
 use App\Models\Criteria;
 use App\Models\Course;
 use App\Models\WorkExperience;
@@ -25,14 +23,14 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use App\Models\Lookup\ReviewStatus;
 
-
 class ApplicationByJobController extends Controller
 {
     /**
-    * Display a listing of the applications for given jobPoster.
-    *
-    * @return \Illuminate\Http\Response
-    */
+     * Display a listing of the applications for given jobPoster.
+     *
+     * @param  JobPoster $jobPoster Incoming JobPoster object.
+     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     */
     public function index(JobPoster $jobPoster)
     {
         $applications = $jobPoster->submitted_applications()
@@ -47,7 +45,6 @@ class ApplicationByJobController extends Controller
         return view('manager/review_applications', [
             /*Localization Strings*/
             'jobs_l10n' => Lang::get('manager/job_index'),
-
             /* Data */
             'job' => $jobPoster,
             'applications' => $applications,
@@ -55,7 +52,14 @@ class ApplicationByJobController extends Controller
         ]);
     }
 
-    protected function getApplicationFromJob(JobPoster $jobPoster) {
+    /**
+     * Return the current applicant's application for a given Job Poster.
+     *
+     * @param  JobPoster $jobPoster Incoming JobPoster object.
+     * @return mixed|App\Models\JobApplication
+     */
+    protected function getApplicationFromJob(JobPoster $jobPoster)
+    {
         $application = JobApplication::where('applicant_id', Auth::user()->applicant->id)
         ->where('job_poster_id', $jobPoster->id)->first();
         if ($application == null) {
@@ -69,96 +73,84 @@ class ApplicationByJobController extends Controller
     }
 
     /**
-    * Show the form for editing Application basics for the specified job.
-    *
-    * @param  \App\Models\JobPoster  $jobPoster
-    * @return \Illuminate\Http\Response
-    */
-    public function edit_basics(JobPoster $jobPoster)
+     * Show the form for editing Application basics for the specified job.
+     *
+     * @param  \App\Models\JobPoster $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     */
+    public function editBasics(JobPoster $jobPoster)
     {
-
         $applicant = Auth::user()->applicant;
-
         $application = $this->getApplicationFromJob($jobPoster);
 
         //Ensure user has permissions to view and update application
         $this->authorize('view', $application);
         $this->authorize('update', $application);
 
-        return view('applicant/application_post_01', [
-
-            /* Application Template Data */
-            "application_step" => 1,
-            "application_template" => Lang::get("applicant/application_template"),
-            "language_options" => PreferredLanguage::all(),
-            "citizenship_options" => CitizenshipDeclaration::all(),
-            "veteran_options" => VeteranStatus::all(),
-            "preferred_language_template" => Lang::get('common/preferred_language'),
-            "citizenship_declaration_template" => Lang::get('common/citizenship_declaration'),
-            "veteran_status_template" => Lang::get('common/veteran_status'),
-
-            /* Job Data */
-            "job" => $jobPoster,
-
-            /* Applicant Data */
-            "applicant" => $applicant,
-            "job_application" => $application,
-
-            /* Submission */
-            "form_submit_action" => route('job.application.update.1', $jobPoster)
-
-        ]);
-
+        return view(
+            'applicant/application_post_01',
+            [
+                /* Application Template Data */
+                'application_step' => 1,
+                'application_template' => Lang::get('applicant/application_template'),
+                'language_options' => PreferredLanguage::all(),
+                'citizenship_options' => CitizenshipDeclaration::all(),
+                'veteran_options' => VeteranStatus::all(),
+                'preferred_language_template' => Lang::get('common/preferred_language'),
+                'citizenship_declaration_template' => Lang::get('common/citizenship_declaration'),
+                'veteran_status_template' => Lang::get('common/veteran_status'),
+                /* Job Data */
+                'job' => $jobPoster,
+                /* Applicant Data */
+                'applicant' => $applicant,
+                'job_application' => $application,
+                /* Submission */
+                'form_submit_action' => route('job.application.update.1', $jobPoster)
+            ]
+        );
     }
 
     /**
-    * Show the form for editing Application Experience for the specified job.
-    *
-    * @param  \App\Models\JobPoster  $jobPoster
-    * @return \Illuminate\Http\Response
-    */
-    public function edit_experience(JobPoster $jobPoster)
+     * Show the form for editing Application Experience for the specified job.
+     *
+     * @param \App\Models\JobPoster $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     */
+    public function editExperience(JobPoster $jobPoster)
     {
-
         $applicant = Auth::user()->applicant;
-
         $application = $this->getApplicationFromJob($jobPoster);
 
         //Ensure user has permissions to view and update application
         $this->authorize('view', $application);
         $this->authorize('update', $application);
 
-        return view('applicant/application_post_02', [
-
-            /* Application Template Data */
-            "application_step" => 2,
-            "application_template" => Lang::get("applicant/application_template"),
-
-            /* Job Data */
-            "job" => $jobPoster,
-
-            /* Applicant Data */
-            "applicant" => $applicant,
-            "job_application" => $application,
-
-            /* Submission */
-            "form_submit_action" => route('job.application.update.2', $jobPoster)
-
-        ]);
-
+        return view(
+            'applicant/application_post_02',
+            [
+                /* Application Template Data */
+                'application_step' => 2,
+                'application_template' => Lang::get("applicant/application_template"),
+                /* Job Data */
+                'job' => $jobPoster,
+                /* Applicant Data */
+                'applicant' => $applicant,
+                'job_application' => $application,
+                /* Submission */
+                'form_submit_action' => route('job.application.update.2', $jobPoster)
+            ]
+        );
     }
 
     /**
-    * Show the form for editing Application Essential Skills for the specified job.
-    *
-    * @param  \App\Models\JobPoster  $jobPoster
-    * @return \Illuminate\Http\Response
-    */
-    public function edit_essential_skills(JobPoster $jobPoster)
+     * Show the form for editing Application Essential Skills for the specified job.
+     *
+     * @param \App\Models\JobPoster $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     */
+    public function editEssentialSkills(JobPoster $jobPoster)
     {
-
         $applicant = Auth::user()->applicant;
-
         $application = $this->getApplicationFromJob($jobPoster);
 
         //Ensure user has permissions to view and update application
@@ -166,50 +158,44 @@ class ApplicationByJobController extends Controller
         $this->authorize('update', $application);
 
         $criteria = [
-            'essential' => $jobPoster->criteria->filter(function($value, $key) {
+            'essential' => $jobPoster->criteria->filter(function ($value, $key) {
                 return $value->criteria_type->name == 'essential';
             }),
-            'asset' => $jobPoster->criteria->filter(function($value, $key) {
+            'asset' => $jobPoster->criteria->filter(function ($value, $key) {
                 return $value->criteria_type->name == 'asset';
             }),
         ];
 
-        return view('applicant/application_post_03', [
-
-            /* Application Template Data */
-            "application_step" => 3,
-            "application_template" => Lang::get("applicant/application_template"),
-
-            /* Job Data */
-            "job" => $jobPoster,
-
-            /* Skills Data */
-            "skills" => Skill::all(),
-            "skill_template" => Lang::get("common/skills"),
-            "criteria" => $criteria,
-
-            /* Applicant Data */
-            "applicant" => $applicant,
-            "job_application" => $application,
-
-            /* Submission */
-            "form_submit_action" => route('job.application.update.3', $jobPoster)
-
-        ]);
-
+        return view(
+            'applicant/application_post_03',
+            [
+                /* Application Template Data */
+                'application_step' => 3,
+                'application_template' => Lang::get('applicant/application_template'),
+                /* Job Data */
+                'job' => $jobPoster,
+                /* Skills Data */
+                'skills' => Skill::all(),
+                'skill_template' => Lang::get('common/skills'),
+                'criteria' => $criteria,
+                /* Applicant Data */
+                'applicant' => $applicant,
+                'job_application' => $application,
+                /* Submission */
+                'form_submit_action' => route('job.application.update.3', $jobPoster)
+            ]
+        );
     }
 
     /**
-    * Show the form for editing Application Asset Skills for the specified job.
-    *
-    * @param  \App\Models\JobPoster  $jobPoster
-    * @return \Illuminate\Http\Response
-    */
-    public function edit_asset_skills(JobPoster $jobPoster)
+     * Show the form for editing Application Asset Skills for the specified job.
+     *
+     * @param \App\Models\JobPoster $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     */
+    public function editAssetSkills(JobPoster $jobPoster)
     {
-
         $applicant = Auth::user()->applicant;
-
         $application = $this->getApplicationFromJob($jobPoster);
 
         //Ensure user has permissions to view and update application
@@ -217,157 +203,145 @@ class ApplicationByJobController extends Controller
         $this->authorize('update', $application);
 
         $criteria = [
-            'essential' => $jobPoster->criteria->filter(function($value, $key) {
+            'essential' => $jobPoster->criteria->filter(function ($value, $key) {
                 return $value->criteria_type->name == 'essential';
             }),
-            'asset' => $jobPoster->criteria->filter(function($value, $key) {
+            'asset' => $jobPoster->criteria->filter(function ($value, $key) {
                 return $value->criteria_type->name == 'asset';
             }),
         ];
 
-        return view('applicant/application_post_04', [
-
-            /* Application Template Data */
-            "application_step" => 4,
-            "application_template" => Lang::get("applicant/application_template"),
-
-            /* Job Data */
-            "job" => $jobPoster,
-
-            /* Skills Data */
-            "skills" => Skill::all(),
-            "skill_template" => Lang::get("common/skills"),
-            "criteria" => $criteria,
-
-            /* Applicant Data */
-            "applicant" => $applicant,
-            "job_application" => $application,
-
-            /* Submission */
-            "form_submit_action" => route('job.application.update.4', $jobPoster)
-
-        ]);
+        return view(
+            'applicant/application_post_04',
+            [
+                /* Application Template Data */
+                'application_step' => 4,
+                'application_template' => Lang::get('applicant/application_template'),
+                /* Job Data */
+                'job' => $jobPoster,
+                /* Skills Data */
+                'skills' => Skill::all(),
+                'skill_template' => Lang::get('common/skills'),
+                'criteria' => $criteria,
+                /* Applicant Data */
+                'applicant' => $applicant,
+                'job_application' => $application,
+                /* Submission */
+                'form_submit_action' => route('job.application.update.4', $jobPoster)
+            ]
+        );
     }
 
     /**
-    * Show the Application Preview for the application for the specified job.
-    *
-    * @param  \App\Models\JobPoster  $jobPoster
-    * @return \Illuminate\Http\Response
-    */
-    public function preview(JobPoster $jobPoster) {
-
+     * Show the Application Preview for the application for the specified job.
+     *
+     * @param \App\Models\JobPoster $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     */
+    public function preview(JobPoster $jobPoster)
+    {
         $applicant = Auth::user()->applicant;
-
         $application = $this->getApplicationFromJob($jobPoster);
 
         $this->authorize('view', $application);
-
         $criteria = [
-            'essential' => $jobPoster->criteria->filter(function($value, $key) {
+            'essential' => $jobPoster->criteria->filter(function ($value, $key) {
                 return $value->criteria_type->name == 'essential';
             }),
-            'asset' => $jobPoster->criteria->filter(function($value, $key) {
+            'asset' => $jobPoster->criteria->filter(function ($value, $key) {
                 return $value->criteria_type->name == 'asset';
             }),
         ];
 
-        return view('applicant/application_post_05', [
-
-            /* Application Template Data */
-            "application_step" => 5,
-            "application_template" => Lang::get("applicant/application_template"),
-            "preferred_language_template" => Lang::get('common/preferred_language'),
-            "citizenship_declaration_template" => Lang::get('common/citizenship_declaration'),
-            "veteran_status_template" => Lang::get('common/veteran_status'),
-
-            /* Job Data */
-            "job" => $jobPoster,
-
-            /* Skills Data */
-            "skills" => Skill::all(),
-            "skill_template" => Lang::get("common/skills"),
-            "criteria" => $criteria,
-
-            /* Applicant Data */
-            "applicant" => $applicant,
-            "job_application" => $application,
-        ]);
+        return view(
+            'applicant/application_post_05',
+            [
+                /* Application Template Data */
+                'application_step' => 5,
+                'application_template' => Lang::get('applicant/application_template'),
+                'preferred_language_template' => Lang::get('common/preferred_language'),
+                'citizenship_declaration_template' => Lang::get('common/citizenship_declaration'),
+                'veteran_status_template' => Lang::get('common/veteran_status'),
+                /* Job Data */
+                'job' => $jobPoster,
+                /* Skills Data */
+                'skills' => Skill::all(),
+                'skill_template' => Lang::get('common/skills'),
+                'criteria' => $criteria,
+                /* Applicant Data */
+                'applicant' => $applicant,
+                'job_application' => $application,
+            ]
+        );
     }
 
     /**
-    * Show the Confirm Submit page for the application for the specified job.
-    *
-    * @param  \App\Models\JobPoster  $jobPoster
-    * @return \Illuminate\Http\Response
-    */
+     * Show the Confirm Submit page for the application for the specified job.
+     *
+     * @param \App\Models\JobPoster $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     */
     public function confirm(JobPoster $jobPoster)
     {
-
         $applicant = Auth::user()->applicant;
-
         $application = $this->getApplicationFromJob($jobPoster);
 
         $this->authorize('update', $application);
 
-        return view('applicant/application_post_06', [
-            /* Application Template Data */
-            "application_step" => 6,
-            "application_template" => Lang::get("applicant/application_template"),
-
-            /* Used by tracker partial */
-            "job" => $jobPoster,
-            "job_application" => $application,
-
-            /* Submission */
-            "form_submit_action" => route('job.application.submit', $jobPoster)
-        ]);
+        return view(
+            'applicant/application_post_06',
+            [
+                /* Application Template Data */
+                'application_step' => 6,
+                'application_template' => Lang::get('applicant/application_template'),
+                /* Used by tracker partial */
+                'job' => $jobPoster,
+                'job_application' => $application,
+                /* Submission */
+                'form_submit_action' => route('job.application.submit', $jobPoster)
+            ]
+        );
     }
 
     /**
-    * Show the application submission information.
-    *
-    * @param  \App\Models\JobPoster  $jobPoster
-    * @return \Illuminate\Http\Response
-    */
-    public function complete(JobPoster $jobPoster) {
-
+     * Show the application submission information.
+     *
+     * @param \App\Models\JobPoster $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     */
+    public function complete(JobPoster $jobPoster)
+    {
         /* Include Applicant Data */
-
         $applicant = Auth::user()->applicant;
-
         /* Include Application Data */
-
         $application = $this->getApplicationFromJob($jobPoster);
 
-        //Ensure user has permissions to view application
+        // Ensure user has permissions to view application
         $this->authorize('view', $application);
 
         /* Return the Completion View */
-
-        return view('applicant/application_post_complete', [
-
-            /* Application Template Data */
-            "application_template" => Lang::get("applicant/application_template"),
-
-            /* Job Data */
-            "job" => $jobPoster,
-
-            /* Applicant Data */
-            "applicant" => $applicant,
-            "job_application" => $application
-
-        ]);
+        return view(
+            'applicant/application_post_complete',
+            [
+                /* Application Template Data */
+                'application_template' => Lang::get('applicant/application_template'),
+                /* Job Data */
+                'job' => $jobPoster,
+                /* Applicant Data */
+                'applicant' => $applicant,
+                'job_application' => $application
+            ]
+        );
     }
 
     /**
-    * Update the Application Basics in storage for the specified job.
-    *
-    * @param  \Illuminate\Http\Request  $request
-    * @param  \App\Models\JobPoster  $jobPoster
-    * @return \Illuminate\Http\Response
-    */
-    public function update_basics(Request $request, JobPoster $jobPoster)
+     * Update the Application Basics in storage for the specified job.
+     *
+     * @param \Illuminate\Http\Request $request   Incoming Request object.
+     * @param \App\Models\JobPoster    $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     */
+    public function updateBasics(Request $request, JobPoster $jobPoster)
     {
         $applicant = Auth::user()->applicant;
         $application = $this->getApplicationFromJob($jobPoster);
@@ -385,7 +359,7 @@ class ApplicationByJobController extends Controller
 
         $questions = $jobPoster->job_poster_questions;
         $questionsInput = $request->input('questions');
-        foreach($questions as $question) {
+        foreach ($questions as $question) {
             $answer = null;
             if (isset($questionsInput[$question->id])) {
                 $answer = $questionsInput[$question->id];
@@ -401,35 +375,34 @@ class ApplicationByJobController extends Controller
             $answerObj->save();
         }
 
-        //Redirect to correct page
-        switch($request->input('submit')) {
+        // Redirect to correct page
+        switch ($request->input('submit')) {
             case 'save_and_quit':
             case 'previous':
-            return redirect()->route('applications.index');
-            break;
+                return redirect()->route('applications.index');
+                break;
             case 'save_and_continue':
             case 'next':
-            return redirect()->route('job.application.edit.2', $jobPoster);
-            break;
+                return redirect()->route('job.application.edit.2', $jobPoster);
+                break;
             default:
-            return redirect()->back()->withInput();
-            break;
+                return redirect()->back()->withInput();
         }
     }
 
     /**
-    * Update the Application Basics in storage for the specified job.
-    *
-    * @param  \Illuminate\Http\Request  $request
-    * @param  \App\Models\JobPoster  $jobPoster
-    * @return \Illuminate\Http\Response
-    */
-    public function update_experience(Request $request, JobPoster $jobPoster)
+     * Update the Application Basics in storage for the specified job.
+     *
+     * @param \Illuminate\Http\Request $request   Incoming Request object.
+     * @param \App\Models\JobPoster    $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     */
+    public function updateExperience(Request $request, JobPoster $jobPoster)
     {
         $applicant = Auth::user()->applicant;
         $application = $this->getApplicationFromJob($jobPoster);
 
-        //Ensure user has permissions to update this application
+        // Ensure user has permissions to update this application
         $this->authorize('update', $application);
 
         // Record that the user has saved their experience for this application
@@ -438,7 +411,7 @@ class ApplicationByJobController extends Controller
 
         $degrees = $request->input('degrees');
 
-        $validatedDegreeData = $request->validate([
+        $request->validate([
             'degrees.new.*.degree_type_id' => 'required',
             'degrees.new.*.area_of_study'  => 'required',
             'degrees.new.*.institution'    => 'required',
@@ -447,9 +420,9 @@ class ApplicationByJobController extends Controller
             'degrees.new.*.end_date'       => 'required|date',
         ]);
 
-        //Save new degrees
+        // Save new degrees
         if (isset($degrees['new'])) {
-            foreach($degrees['new'] as $degreeInput) {
+            foreach ($degrees['new'] as $degreeInput) {
                 $degree = new Degree();
                 $degree->applicant_id = $applicant->id;
                 $degree->fill([
@@ -464,9 +437,9 @@ class ApplicationByJobController extends Controller
             }
         }
 
-        //Update old degrees
+        // Update old degrees
         if (isset($degrees['old'])) {
-            foreach($degrees['old'] as $id=>$degreeInput) {
+            foreach ($degrees['old'] as $id => $degreeInput) {
                 //Ensure this degree belongs to this applicant
                 $degree = $applicant->degrees->firstWhere('id', $id);
                 if ($degree != null) {
@@ -480,14 +453,14 @@ class ApplicationByJobController extends Controller
                     ]);
                     $degree->save();
                 } else {
-                    Log::warning('Applicant '.$applicant->id.' attempted to update degree with invalid id '.$id);
+                    Log::warning("Applicant $applicant->id attempted to update degree with invalid id: $id");
                 }
             }
         }
 
         $courses = $request->input('courses');
 
-        $validatedCourseData = $request->validate([
+        $request->validate([
             'courses.new.*.name'             => 'required',
             'courses.new.*.institution'      => 'required',
             'courses.new.*.course_status_id' => 'required',
@@ -495,9 +468,9 @@ class ApplicationByJobController extends Controller
             'courses.new.*.end_date'         => 'required|date',
         ]);
 
-        //Save new courses
+        // Save new courses
         if (isset($courses['new'])) {
-            foreach($courses['new'] as $courseInput) {
+            foreach ($courses['new'] as $courseInput) {
                 $course = new Course();
                 $course->applicant_id = $applicant->id;
                 $course->fill([
@@ -511,10 +484,10 @@ class ApplicationByJobController extends Controller
             }
         }
 
-        //Update old courses
+        // Update old courses
         if (isset($courses['old'])) {
-            foreach($courses['old'] as $id=>$courseInput) {
-                //Ensure this course belongs to this applicant
+            foreach ($courses['old'] as $id => $courseInput) {
+                // Ensure this course belongs to this applicant
                 $course = $applicant->courses->firstWhere('id', $id);
                 if ($course != null) {
                     $course->fill([
@@ -526,14 +499,14 @@ class ApplicationByJobController extends Controller
                     ]);
                     $course->save();
                 } else {
-                    Log::warning('Applicant '.$applicant->id.' attempted to update course with invalid id '.$id);
+                    Log::warning("Applicant $applicant->id attempted to update course with invalid id: $id");
                 }
             }
         }
 
         $work_experiences = $request->input('work_experiences');
 
-        $validatedWorkData = $request->validate([
+        $request->validate([
             'work_experiences.new.*.role'        => 'required',
             'work_experiences.new.*.company'     => 'required',
             'work_experiences.new.*.description' => 'required',
@@ -541,9 +514,9 @@ class ApplicationByJobController extends Controller
             'work_experiences.new.*.end_date'    => 'required|date',
         ]);
 
-        //Save new work_experiences
+        // Save new work_experiences
         if (isset($work_experiences['new'])) {
-            foreach($work_experiences['new'] as $workExperienceInput) {
+            foreach ($work_experiences['new'] as $workExperienceInput) {
                 $workExperience = new WorkExperience();
                 $workExperience->applicant_id = $applicant->id;
                 $workExperience->fill([
@@ -557,9 +530,9 @@ class ApplicationByJobController extends Controller
             }
         }
 
-        //Update old work_experiences
+        // Update old work_experiences
         if (isset($work_experiences['old'])) {
-            foreach($work_experiences['old'] as $id=>$workExperienceInput) {
+            foreach ($work_experiences['old'] as $id => $workExperienceInput) {
                 //Ensure this work_experience belongs to this applicant
                 $workExperience = $applicant->work_experiences->firstWhere('id', $id);
                 if ($workExperience != null) {
@@ -572,51 +545,50 @@ class ApplicationByJobController extends Controller
                     ]);
                     $workExperience->save();
                 } else {
-                    Log::warning('Applicant '.$applicant->id.' attempted to update work_experience with invalid id '.$id);
+                    Log::warning("Applicant $applicant->id attempted to update work_experience with invalid id: $id");
                 }
             }
         }
 
-        //Redirect to correct page
-        switch($request->input('submit')) {
+        // Redirect to correct page
+        switch ($request->input('submit')) {
             case 'save_and_quit':
-            return redirect()->route('applications.index');
-            break;
+                return redirect()->route('applications.index');
+                break;
             case 'save_and_continue':
             case 'next':
-            return redirect()->route('job.application.edit.3', $jobPoster);
-            break;
+                return redirect()->route('job.application.edit.3', $jobPoster);
+                break;
             case 'previous':
-            return redirect()->route('job.application.edit.1', $jobPoster);
-            break;
+                return redirect()->route('job.application.edit.1', $jobPoster);
+                break;
             default:
-            return redirect()->back()->withInput();
-            break;
+                return redirect()->back()->withInput();
         }
     }
 
     /**
-    * Update the Application Essential Skills in storage for the specified job.
-    *
-    * @param  \Illuminate\Http\Request  $request
-    * @param  \App\Models\JobPoster  $jobPoster
-    * @return \Illuminate\Http\Response
-    */
-    public function update_essential_skills(Request $request, JobPoster $jobPoster)
+     * Update the Application Essential Skills in storage for the specified job.
+     *
+     * @param \Illuminate\Http\Request $request   Incoming Request object.
+     * @param \App\Models\JobPoster    $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     */
+    public function updateEssentialSkills(Request $request, JobPoster $jobPoster)
     {
         $applicant = Auth::user()->applicant;
         $application = $this->getApplicationFromJob($jobPoster);
 
-        //Ensure user has permissions to update this application
+        // Ensure user has permissions to update this application
         $this->authorize('update', $application);
 
         $skillDeclarations = $request->input('skill_declarations');
         $claimedStatusId = SkillStatus::where('name', 'claimed')->firstOrFail()->id;
 
-        //Save new skill declarartions
+        // Save new skill declarartions
         if (isset($skillDeclarations['new'])) {
-            foreach($skillDeclarations['new'] as $skillType => $typeInput) {
-                foreach($typeInput as $criterion_id=>$skillDeclarationInput) {
+            foreach ($skillDeclarations['new'] as $skillType => $typeInput) {
+                foreach ($typeInput as $criterion_id => $skillDeclarationInput) {
                     $skillDeclaration = new SkillDeclaration();
                     $skillDeclaration->applicant_id = $applicant->id;
                     $skillDeclaration->skill_id = Criteria::find($criterion_id)->skill->id;
@@ -636,14 +608,14 @@ class ApplicationByJobController extends Controller
             }
         }
 
-        //Update old declarations
+        // Update old declarations
         if (isset($skillDeclarations['old'])) {
-            foreach($skillDeclarations['old'] as $skillType => $typeInput) {
-                foreach($typeInput as $id=>$skillDeclarationInput) {
-                    //Ensure this declaration belongs to this applicant
+            foreach ($skillDeclarations['old'] as $skillType => $typeInput) {
+                foreach ($typeInput as $id => $skillDeclarationInput) {
+                    // Ensure this declaration belongs to this applicant
                     $skillDeclaration = $applicant->skill_declarations->firstWhere('id', $id);
                     if ($skillDeclaration != null) {
-                        //skill_id and skill_status cannot be changed
+                        // skill_id and skill_status cannot be changed
                         $skillDeclaration->fill([
                             'description' => $skillDeclarationInput['description'],
                             'skill_level_id' => isset($skillDeclarationInput['skill_level_id']) ? $skillDeclarationInput['skill_level_id'] : null,
@@ -656,52 +628,51 @@ class ApplicationByJobController extends Controller
                         $sampleIds = $this->getRelativeIds($skillDeclarationInput, 'samples');
                         $skillDeclaration->work_samples()->sync($sampleIds);
                     } else {
-                        Log::warning('Applicant '.$applicant->id.' attempted to update skill declaration with invalid id '.$id);
+                        Log::warning("Applicant $applicant->id attempted to update skill declaration with invalid id: $id");
                     }
                 }
             }
         }
 
-        //Redirect to correct page
-        switch($request->input('submit')) {
+        // Redirect to correct page
+        switch ($request->input('submit')) {
             case 'save_and_quit':
-            return redirect()->route('applications.index');
-            break;
+                return redirect()->route('applications.index');
+                break;
             case 'save_and_continue':
             case 'next':
-            return redirect()->route('job.application.edit.4', $jobPoster);
-            break;
+                return redirect()->route('job.application.edit.4', $jobPoster);
+                break;
             case 'previous':
-            return redirect()->route('job.application.edit.2', $jobPoster);
-            break;
+                return redirect()->route('job.application.edit.2', $jobPoster);
+                break;
             default:
-            return redirect()->back()->withInput();
-            break;
+                return redirect()->back()->withInput();
         }
     }
 
     /**
-    * Update the Application Asset Skills in storage for the specified job.
-    *
-    * @param  \Illuminate\Http\Request  $request
-    * @param  \App\Models\JobPoster  $jobPoster
-    * @return \Illuminate\Http\Response
-    */
-    public function update_asset_skills(Request $request, JobPoster $jobPoster)
+     * Update the Application Asset Skills in storage for the specified job.
+     *
+     * @param \Illuminate\Http\Request $request   Incoming Request object.
+     * @param \App\Models\JobPoster    $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     */
+    public function updateAssetSkills(Request $request, JobPoster $jobPoster)
     {
         $applicant = Auth::user()->applicant;
         $application = $this->getApplicationFromJob($jobPoster);
 
-        //Ensure user has permissions to update this application
+        // Ensure user has permissions to update this application
         $this->authorize('update', $application);
 
         $skillDeclarations = $request->input('skill_declarations');
         $claimedStatusId = SkillStatus::where('name', 'claimed')->firstOrFail()->id;
 
-        //Save new skill declarartions
+        // Save new skill declarartions
         if (isset($skillDeclarations['new'])) {
-            foreach($skillDeclarations['new'] as $skillType => $typeInput) {
-                foreach($typeInput as $criterion_id=>$skillDeclarationInput) {
+            foreach ($skillDeclarations['new'] as $skillType => $typeInput) {
+                foreach ($typeInput as $criterion_id => $skillDeclarationInput) {
                     $skillDeclaration = new SkillDeclaration();
                     $skillDeclaration->applicant_id = $applicant->id;
                     $skillDeclaration->skill_id = Criteria::find($criterion_id)->skill->id;
@@ -721,14 +692,14 @@ class ApplicationByJobController extends Controller
             }
         }
 
-        //Update old declarations
+        // Update old declarations
         if (isset($skillDeclarations['old'])) {
-            foreach($skillDeclarations['old'] as $skillType => $typeInput) {
-                foreach($typeInput as $id=>$skillDeclarationInput) {
-                    //Ensure this declaration belongs to this applicant
+            foreach ($skillDeclarations['old'] as $skillType => $typeInput) {
+                foreach ($typeInput as $id => $skillDeclarationInput) {
+                    // Ensure this declaration belongs to this applicant
                     $skillDeclaration = $applicant->skill_declarations->firstWhere('id', $id);
                     if ($skillDeclaration != null) {
-                        //skill_id and skill_status cannot be changed
+                        // skill_id and skill_status cannot be changed
                         $skillDeclaration->fill([
                             'description' => $skillDeclarationInput['description'],
                             'skill_level_id' => isset($skillDeclarationInput['skill_level_id']) ? $skillDeclarationInput['skill_level_id'] : null,
@@ -741,48 +712,46 @@ class ApplicationByJobController extends Controller
                         $sampleIds = $this->getRelativeIds($skillDeclarationInput, 'samples');
                         $skillDeclaration->work_samples()->sync($sampleIds);
                     } else {
-                        Log::warning('Applicant '.$applicant->id.' attempted to update skill declaration with invalid id '.$id);
+                        Log::warning("Applicant $applicant->id attempted to update skill declaration with invalid id: $id");
                     }
                 }
             }
         }
 
-        //Redirect to correct page
-        switch($request->input('submit')) {
+        // Redirect to correct page
+        switch ($request->input('submit')) {
             case 'save_and_quit':
-            return redirect()->route('applications.index');
-            break;
+                return redirect()->route('applications.index');
+                break;
             case 'save_and_continue':
             case 'next':
-            return redirect()->route('job.application.edit.5', $jobPoster);
-            break;
+                return redirect()->route('job.application.edit.5', $jobPoster);
+                break;
             case 'previous':
-            return redirect()->route('job.application.edit.3', $jobPoster);
-            break;
+                return redirect()->route('job.application.edit.3', $jobPoster);
+                break;
             default:
-            return redirect()->back()->withInput();
-            break;
+                return redirect()->back()->withInput();
         }
     }
 
     /**
-    * Submit the Application for the specified job.
-    *
-    * @param  \Illuminate\Http\Request  $request
-    * @param  \App\Models\JobPoster  $jobPoster
-    * @return \Illuminate\Http\Response
-    */
+     * Submit the Application for the specified job.
+     *
+     * @param \Illuminate\Http\Request $request   Incoming Request object.
+     * @param \App\Models\JobPoster    $jobPoster Incoming Job Poster object.
+     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     */
     public function submit(Request $request, JobPoster $jobPoster)
     {
         $applicant = Auth::user()->applicant;
         $application = $this->getApplicationFromJob($jobPoster);
 
-        //Ensure user has permissions to update this application
+        // Ensure user has permissions to update this application
         $this->authorize('update', $application);
 
-        //Only complete submission if submit button was pressed
+        // Only complete submission if submit button was pressed
         if ($request->input('submit') == "submit") {
-
             $request->validate([
                 'submission_signature' => [
                     'required',
@@ -796,7 +765,7 @@ class ApplicationByJobController extends Controller
                 ]
             ]);
 
-            //Save any final info
+            // Save any final info
             $application->fill([
                 'submission_signature' => $request->input('submission_signature'),
                 'submission_date' => $request->input('submission_date'),
@@ -805,26 +774,25 @@ class ApplicationByJobController extends Controller
             $validator = new ApplicationValidator();
             $validator->validate($application);
 
-            //Change status to 'submitted'
+            // Change status to 'submitted'
             $application->application_status_id = ApplicationStatus::where('name', 'submitted')->firstOrFail()->id;
         }
 
         $application->save();
 
-        //Redirect to correct page
-        switch($request->input('submit')) {
+        // Redirect to correct page
+        switch ($request->input('submit')) {
             case 'save_and_quit':
-            return redirect()->route('applications.index');
-            break;
+                return redirect()->route('applications.index');
+                break;
             case 'submit':
-            return redirect()->route('job.application.complete', $jobPoster);
-            break;
+                return redirect()->route('job.application.complete', $jobPoster);
+                break;
             case 'previous':
-            return redirect()->route('job.application.edit.4', $jobPoster);
-            break;
+                return redirect()->route('job.application.edit.4', $jobPoster);
+                break;
             default:
-            return redirect()->back()->withInput();
-            break;
+                return redirect()->back()->withInput();
         }
     }
 }

--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -31,7 +31,6 @@ class ApplicationController extends Controller
         );
     }
 
-
     /**
      * Display specified application
      *

--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -20,76 +20,77 @@ class ApplicationController extends Controller
     public function index()
     {
         $applications = Auth::user()->applicant->job_applications;
-        return view('applicant/application_index', [
-            "application_index" => Lang::get('applicant/application_index'),
-            "applications" => $applications,
-            "departments_template" => Lang::get('common/lookup/departments'),
-            "manager_profile_photo" => '/images/user.png', //TODO: get real photo
-        ]);
+        return view(
+            'applicant/application_index',
+            [
+                'application_index' => Lang::get('applicant/application_index'),
+                'applications' => $applications,
+                'departments_template' => Lang::get('common/lookup/departments'),
+                'manager_profile_photo' => '/images/user.png', // TODO: get real photo.
+            ]
+        );
     }
 
 
     /**
      * Display specified application
      *
-     * @param  \App\Models\JobApplication  $application
+     * @param  \App\Models\JobApplication $application Incoming Application object.
      * @return \Illuminate\Http\Response
      */
     public function show(JobApplication $application)
     {
         $criteria = [
-            'essential' => $application->job_poster->criteria->filter(function($value, $key) {
+            'essential' => $application->job_poster->criteria->filter(function ($value, $key) {
                 return $value->criteria_type->name == 'essential';
             }),
-            'asset' => $application->job_poster->criteria->filter(function($value, $key) {
+            'asset' => $application->job_poster->criteria->filter(function ($value, $key) {
                 return $value->criteria_type->name == 'asset';
             }),
         ];
 
-        //Display slightly different views on different portals
+        // Display slightly different views on different portals.
         $view = WhichPortal::isManagerPortal() ?
             'manager/application_post' :
             'applicant/application_preview';
 
         if (WhichPortal::isManagerPortal()) {
-            //Load things required for review component
-            $application->load(['veteran_status', 'citizenship_declaration', 'application_review', "applicant.user"]);
+            // Load things required for review component.
+            $application->load(['veteran_status', 'citizenship_declaration', 'application_review', 'applicant.user']);
         }
 
-        return view($view, [
-            /* Localized strings*/
-            'post' => Lang::get('manager/application_post'), // Change text
-
-
-            /* Application Template Data */
-                "application_template" => Lang::get("applicant/application_template"),
-                "application_preview" => true,
-                "preferred_language_template" => Lang::get('common/preferred_language'),
-                "citizenship_declaration_template" => Lang::get('common/citizenship_declaration'),
-                "veteran_status_template" => Lang::get('common/veteran_status'),
-
-            /* Job Data */
-                "job" => $application->job_poster,
-
-            /* Skills Data */
-                "skills" => Skill::all(),
-                "skill_template" => Lang::get("common/skills"),
+        return view(
+            $view,
+            [
+                // Localized strings.
+                'post' => Lang::get('manager/application_post'), // Change text
+                // Application Template Data.
+                'application_template' => Lang::get('applicant/application_template'),
+                'application_preview' => true,
+                'preferred_language_template' => Lang::get('common/preferred_language'),
+                'citizenship_declaration_template' => Lang::get('common/citizenship_declaration'),
+                'veteran_status_template' => Lang::get('common/veteran_status'),
+                // Job Data.
+                'job' => $application->job_poster,
+                // Skills Data.
+                'skills' => Skill::all(),
+                'skill_template' => Lang::get('common/skills'),
                 'reference_template' => Lang::get('common/references'),
                 'sample_template' => Lang::get('common/work_samples'),
-                "criteria" => $criteria,
-
-            /* Applicant Data */
-                "applicant" => $application->applicant,
-                "job_application" => $application,
-                "review_statuses" => ReviewStatus::all(),
-        ]);
+                'criteria' => $criteria,
+                // Applicant Data.
+                'applicant' => $application->applicant,
+                'job_application' => $application,
+                'review_statuses' => ReviewStatus::all(),
+            ]
+        );
     }
 
     /**
      * Delete the particular resource from storage.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\JobApplication  $application
+     * @param  \Illuminate\Http\Request   $request     Incoming Request object.
+     * @param  \App\Models\JobApplication $application Incoming Application object.
      * @return \Illuminate\Http\Response
      */
     public function destroy(Request $request, JobApplication $application)
@@ -98,13 +99,12 @@ class ApplicationController extends Controller
 
         $application->delete();
 
-        if($request->ajax()) {
+        if ($request->ajax()) {
             return [
-                "message" => 'Application deleted'
+                'message' => 'Application deleted'
             ];
         }
 
         return redirect()->back();
     }
-
 }

--- a/app/Http/Controllers/ApplicationReviewController.php
+++ b/app/Http/Controllers/ApplicationReviewController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Models\ApplicationReview;
 use App\Models\JobApplication;
 use App\Models\Lookup\ReviewStatus;
-use App\Models\Lookup\ReviewDecision;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 
@@ -14,8 +13,8 @@ class ApplicationReviewController extends Controller
     /**
      * Update the review for the specified application.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\JobApplication  $application
+     * @param  \Illuminate\Http\Request   $request     Incoming Request.
+     * @param  \App\Models\JobApplication $application Incoming Application.
      * @return \Illuminate\Http\Response
      */
     public function updateForApplication(Request $request, JobApplication $application)

--- a/app/Http/Controllers/AssessmentController.php
+++ b/app/Http/Controllers/AssessmentController.php
@@ -7,7 +7,6 @@ use App\Models\Criteria;
 use App\Models\Lookup\AssessmentType;
 
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class AssessmentController extends Controller
 {
@@ -15,7 +14,7 @@ class AssessmentController extends Controller
      * Store a newly created resource in storage.
      *
      * @param  \Illuminate\Http\Request $request Incoming request.
-     * @return mixed
+     * @return \Illuminate\Http\Response
      */
     public function store(Request $request)
     {
@@ -31,7 +30,7 @@ class AssessmentController extends Controller
                 'criterion_id' => $criterion_id,
                 'assessment_type_id' => $assessment_type_id
             ]);
-            // Check that this user is allowed to create an Assessment for this criterion
+            // Check that this user is allowed to create an Assessment for this criterion.
             $this->authorize('update', $assessment);
 
             $assessment->save();
@@ -53,7 +52,7 @@ class AssessmentController extends Controller
      * Display the specified resource.
      *
      * @param  \App\Models\Assessment $assessment Incoming object.
-     * @return mixed
+     * @return \Illuminate\Http\Response
      */
     public function show(Assessment $assessment)
     {
@@ -68,7 +67,7 @@ class AssessmentController extends Controller
      *
      * @param  \Illuminate\Http\Request $request    Incoming request.
      * @param  \App\Models\Assessment   $assessment Incoming object.
-     * @return mixed
+     * @return \Illuminate\Http\Response
      */
     public function update(Request $request, Assessment $assessment)
     {
@@ -99,7 +98,7 @@ class AssessmentController extends Controller
      * Remove the specified resource from storage.
      *
      * @param  \App\Models\Assessment $assessment Incoming object.
-     * @return mixed
+     * @return \Illuminate\Http\Response
      */
     public function destroy(Assessment $assessment)
     {

--- a/app/Http/Controllers/AssessmentPlanController.php
+++ b/app/Http/Controllers/AssessmentPlanController.php
@@ -17,7 +17,7 @@ class AssessmentPlanController extends Controller
      * RatingGuideQuestions, and RatingGuideAnswers associated with a job,
      * as an array.
      *
-     * @param JobPoster $jobPoster Job Poster to retrieve assessment plan for.
+     * @param  \App\Models\JobPoster $jobPoster Job Poster to retrieve assessment plan for.
      * @return mixed[]
      */
     public function getForJob(JobPoster $jobPoster)

--- a/app/Http/Controllers/AssessmentPlanController.php
+++ b/app/Http/Controllers/AssessmentPlanController.php
@@ -32,21 +32,21 @@ class AssessmentPlanController extends Controller
             // TODO: getTranslationsArray probably makes DB calls every loop. Find a way to profile & optimize.
             $criteriaTranslated[] = array_merge($criterion->toArray(), $criterion->getTranslationsArray());
         }
-        $criteriaIds = $criteria->pluck("id");
-        $assessments = Assessment::whereIn("criterion_id", $criteriaIds)->get();
+        $criteriaIds = $criteria->pluck('id');
+        $assessments = Assessment::whereIn('criterion_id', $criteriaIds)->get();
         // Check for newly created assessment plan, and initialize any empty criteria to have the
         // "Narrative Review" option set.
-        $assessmentCriteriaIds = $assessments->pluck("criterion_id");
+        $assessmentCriteriaIds = $assessments->pluck('criterion_id');
         $emptyAssessments = array_diff($criteriaIds->toArray(), $assessmentCriteriaIds->toArray());
         if (!empty($emptyAssessments)) {
-            $narrativeReview = AssessmentType::where("key", "narrative_assessment")->first();
+            $narrativeReview = AssessmentType::where('key', 'narrative_assessment')->first();
             foreach ($emptyAssessments as $criterionId) {
                 Assessment::create([
                     'criterion_id' => $criterionId,
                     'assessment_type_id' => $narrativeReview->id
                 ]);
             }
-            $assessments = Assessment::whereIn("criterion_id", $criteriaIds)->get();
+            $assessments = Assessment::whereIn('criterion_id', $criteriaIds)->get();
         }
         $questions = RatingGuideQuestion::where('job_poster_id', $jobPoster->id)->get();
         $answers = RatingGuideAnswer::whereIn('rating_guide_question_id', $questions->pluck('id'))->get();

--- a/app/Http/Controllers/AssessmentPlanNotificationController.php
+++ b/app/Http/Controllers/AssessmentPlanNotificationController.php
@@ -2,11 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\JobPoster;
-use App\Models\Lookup\AssessmentType;
-
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use App\Models\AssessmentPlanNotification;
 
 class AssessmentPlanNotificationController extends Controller
@@ -48,7 +44,7 @@ class AssessmentPlanNotificationController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Illuminate\Http\Request        $request             Incoming request.
+     * @param  \Illuminate\Http\Request               $request                    Incoming request.
      * @param  \App\Models\AssessmentPlanNotification $assessmentPlanNotification Incoming object.
      * @throws \InvalidArgumentException For missing $question.
      * @return mixed

--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -5,9 +5,15 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use Facades\App\Services\WhichPortal;
 
-class AuthController extends Controller {
-
-    protected function auth_routes() {
+class AuthController extends Controller
+{
+    /**
+     * Sets the route namespace based on the logged in user.
+     *
+     * @return mixed[]
+     */
+    protected function auth_routes()
+    {
         if (WhichPortal::isManagerPortal()) {
             $routes = [
                 'login' => route('manager.login'),
@@ -31,5 +37,4 @@ class AuthController extends Controller {
         }
         return $routes;
     }
-
 }

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -40,7 +40,7 @@ class LoginController extends AuthController
     /**
      * Where to redirect users after login.
      *
-     * @var string
+     * @return string
      */
     protected function redirectTo()
     {
@@ -76,7 +76,7 @@ class LoginController extends AuthController
      * OVERRIDE
      * Log the user out of the application.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request $request Incoming Request object.
      * @return \Illuminate\Http\Response
      */
     public function logout(Request $request)
@@ -85,7 +85,7 @@ class LoginController extends AuthController
 
         $request->session()->invalidate();
 
-        //This causes logout to redirect to the same page as login
+        // This causes logout to redirect to the same page as login.
         return redirect($this->redirectPath());
     }
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -32,7 +32,7 @@ class RegisterController extends AuthController
     /**
      * Where to redirect users after registration.
      *
-     * @var string
+     * @return string
      */
     protected function redirectTo()
     {
@@ -66,7 +66,7 @@ class RegisterController extends AuthController
     /**
      * Get a validator for an incoming registration request.
      *
-     * @param  array  $data
+     * @param  array $data Incoming registration data.
      * @return \Illuminate\Contracts\Validation\Validator
      */
     protected function validator(array $data)
@@ -79,15 +79,15 @@ class RegisterController extends AuthController
                 'min:8',
                 new PasswordFormatRule,
                 'confirmed'
-           ],
-       ]);
+            ],
+        ]);
     }
 
     /**
      * Create a new user instance after a valid registration.
      *
-     * @param  array  $data
-     * @return \App\Models\user
+     * @param  array $data Incoming User data.
+     * @return \App\Models\User
      */
     protected function create(array $data)
     {
@@ -96,7 +96,7 @@ class RegisterController extends AuthController
         $user->email = $data['email'];
         $user->password = Hash::make($data['password']);
 
-        //Default to applicant role
+        // Default to applicant role.
         $user->user_role()->associate(UserRole::where('name', 'applicant')->first());
 
         $user->save();
@@ -104,21 +104,15 @@ class RegisterController extends AuthController
         $user->applicant()->save(new Applicant());
 
         return $user;
-
-        // return User::create([
-        //     'name' => $data['name'],
-        //     'email' => $data['email'],
-        //     'password' => Hash::make($data['password']),
-        // ]);
     }
 
     /**
      * OVERRIDE
      * The user has been registered.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  mixed  $user
-     * @return mixed
+     * @param  \Illuminate\Http\Request $request Incoming Request.
+     * @param  mixed                    $user    Incoming User data.
+     * @return \Illuminate\Http\Response
      */
     protected function registered(Request $request, $user)
     {

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -27,7 +27,7 @@ class ResetPasswordController extends AuthController
     /**
      * Where to redirect users after resetting their password.
      *
-     * @var string
+     * @return string
      */
     protected function redirectTo()
     {
@@ -50,9 +50,9 @@ class ResetPasswordController extends AuthController
      *
      * If no token is present, display the link request form.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string|null  $token
-     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     * @param  \Illuminate\Http\Request $request Incoming Request.
+     * @param  string|null              $token   Validation token.
+     * @return \Illuminate\Http\Response
      */
     public function showResetForm(Request $request, $token = null)
     {
@@ -80,7 +80,7 @@ class ResetPasswordController extends AuthController
                 'min:8',
                 new PasswordFormatRule,
                 'confirmed'
-           ],
+            ],
         ];
     }
 

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -11,7 +11,8 @@ class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
 
-    public function getRelativeIds($input, $relativeType) {
+    public function getRelativeIds($input, $relativeType)
+    {
         $relativeIds = [];
         if (isset($input['relatives'])) {
             $relatives = $input['relatives'];
@@ -24,26 +25,29 @@ class Controller extends BaseController
         return $relativeIds;
     }
 
-    public function shiftFirstLevelArrayKeysToBottom(array $nestedArray) {
+    public function shiftFirstLevelArrayKeysToBottom(array $nestedArray)
+    {
         $expandedArray = $this->expandNestedArraysIntoKeyListAndValue($nestedArray);
         $rotatedArray = $this->rotateKeys($expandedArray, 1);
         $mergedArray = $this->mergeExpandedTrees($rotatedArray);
         return $mergedArray;
     }
 
-    protected function addKeyAsFinalIndex($finalKey, $array) {
+    protected function addKeyAsFinalIndex($finalKey, $array)
+    {
         if (!is_array($array)) {
             return [$finalKey => $array];
         } else {
             $newArray = [];
-            foreach($array as $key => $value) {
+            foreach ($array as $key => $value) {
                 $newArray[$key] = $this->addKeyAsFinalIndex($finalKey, $value);
             }
             return $newArray;
         }
     }
 
-    protected function expandNestedArraysIntoKeyListAndValue($nestedArray) {
+    protected function expandNestedArraysIntoKeyListAndValue($nestedArray)
+    {
         if (!is_array($nestedArray)) {
             $expandedArray = [
                 [
@@ -54,9 +58,9 @@ class Controller extends BaseController
             return $expandedArray;
         } else {
             $expandedArray = [];
-            foreach($nestedArray as $key => $value) {
+            foreach ($nestedArray as $key => $value) {
                 $subArray = $this->expandNestedArraysIntoKeyListAndValue($value);
-                foreach($subArray as $item) {
+                foreach ($subArray as $item) {
                     array_unshift($item['keys'], $key);
                     $expandedArray[] = $item;
                 }
@@ -65,29 +69,30 @@ class Controller extends BaseController
         }
     }
 
-    protected function mergeExpandedTrees($expandedArray) {
+    protected function mergeExpandedTrees($expandedArray)
+    {
         $mergedArray = [];
-        foreach($expandedArray as $item) {
+        foreach ($expandedArray as $item) {
             $tail = &$mergedArray;
             $size = count($item['keys']);
             $i = 0;
-            foreach($item['keys'] as $key) {
+            foreach ($item['keys'] as $key) {
                 $i = ($i + 1);
-                //Check if this is the last key
+                // Check if this is the last key.
                 if ($i == ($size)) {
                     if (!isset($tail[$key])) {
                         $tail[$key] = $item['value'];
-                    } else if (!is_array($tail[$key])) {
+                    } elseif (!is_array($tail[$key])) {
                         $value = $tail[$key];
                         $tail[$key] = [$value, $item['value']];
                     } else {
                         array_push($tail[$key], $item['value']);
                     }
                 } else {
-                    //If this is not the last key, it needs to contain an array
+                    // If this is not the last key, it needs to contain an array.
                     if (!isset($tail[$key])) {
                         $tail[$key] = [];
-                    } else if (!is_array($tail[$key])) {
+                    } elseif (!is_array($tail[$key])) {
                         $value = $tail[$key];
                         $tail[$key] = [$value];
                     }
@@ -98,9 +103,10 @@ class Controller extends BaseController
         return $mergedArray;
     }
 
-    protected function rotateKeys($expandedArray, $steps) {
+    protected function rotateKeys($expandedArray, $steps)
+    {
         $rotatedArray = [];
-        foreach($expandedArray as $item) {
+        foreach ($expandedArray as $item) {
             for ($i=0; $i<$steps; $i++) {
                 array_push($item['keys'], array_shift($item['keys']));
             }

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -10,8 +10,8 @@ class CourseController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\Course  $course
+     * @param  \Illuminate\Http\Request $request Incoming Request.
+     * @param  \App\Models\Course       $course  Incoming Course.
      * @return \Illuminate\Http\Response
      */
     public function destroy(Request $request, Course $course)
@@ -19,9 +19,9 @@ class CourseController extends Controller
         $this->authorize('delete', $course);
         $course->delete();
 
-        if($request->ajax()) {
+        if ($request->ajax()) {
             return [
-                "message" => "Course delete",
+                'message' => 'Course delete',
             ];
         }
 

--- a/app/Http/Controllers/DegreeController.php
+++ b/app/Http/Controllers/DegreeController.php
@@ -10,8 +10,8 @@ class DegreeController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\Degree  $degree
+     * @param  \Illuminate\Http\Request $request Incoming Request.
+     * @param  \App\Models\Degree       $degree  Incoming Degree.
      * @return \Illuminate\Http\Response
      */
     public function destroy(Request $request, Degree $degree)

--- a/app/Http/Controllers/ExperienceController.php
+++ b/app/Http/Controllers/ExperienceController.php
@@ -9,8 +9,6 @@ use App\Models\Degree;
 use App\Models\Applicant;
 use App\Models\Course;
 use App\Models\WorkExperience;
-use App\Models\Lookup\DegreeType;
-use App\Models\Lookup\CourseStatus;
 use App\Http\Controllers\Controller;
 
 class ExperienceController extends Controller
@@ -18,10 +16,10 @@ class ExperienceController extends Controller
     /**
      * Show the form for editing the logged-in applicant's experience
      *
-     * @param  Request $request
-     * @return \Illuminate\Http\RedirectResponse
+     * @param  \Illuminate\Http\Request $request Incoming Request.
+     * @return \Illuminate\Http\Response
      */
-    public function editAuthenticated(Request $request): \Illuminate\Http\RedirectResponse
+    public function editAuthenticated(Request $request)
     {
         $applicant = $request->user()->applicant;
         return redirect(route('profile.experience.edit', $applicant));
@@ -30,10 +28,9 @@ class ExperienceController extends Controller
     /**
     * Show the form for editing the applicant's experience
     *
-    * @param \Illuminate\Http\Request $request   Incoming request object.
-    * @param \App\Models\Applicant    $applicant Incoming applicant object.
-    *
-    * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+    * @param  \Illuminate\Http\Request $request   Incoming request object.
+    * @param  \App\Models\Applicant    $applicant Incoming applicant object.
+    * @return \Illuminate\Http\Response
     */
     public function edit(Request $request, Applicant $applicant)
     {
@@ -48,8 +45,8 @@ class ExperienceController extends Controller
     /**
      * Update the applicant's profile in storage.
      *
-     * @param  \Illuminate\Http\Request $request
-     * @param  \App\Models\Applicant    $applicant
+     * @param  \Illuminate\Http\Request $request   Incoming Request.
+     * @param  \App\Models\Applicant    $applicant Incoming Applicant.
      * @return \Illuminate\Http\Response
      */
     public function update(Request $request, Applicant $applicant)
@@ -58,7 +55,7 @@ class ExperienceController extends Controller
 
         $degrees = $input['degrees'];
 
-        $validatedDegreeData = $request->validate([
+        $request->validate([
             'degrees.new.*.degree_type_id' => 'required',
             'degrees.new.*.area_of_study'  => 'required',
             'degrees.new.*.institution'    => 'required',
@@ -67,18 +64,18 @@ class ExperienceController extends Controller
             'degrees.new.*.end_date'       => 'required|date',
         ]);
 
-        //Delete old degrees that weren't resubmitted
-        //Note: this must be done before adding new degrees, so we don't delete
-        // them right after adding them
+        // Delete old degrees that weren't resubmitted.
+        // Note: this must be done before adding new degrees, so we don't delete
+        // them right after adding them.
         foreach ($applicant->degrees as $oldDegree) {
-            //Check if no degrees were resubmitted, or if this specific one wasn't
+            // Check if no degrees were resubmitted, or if this specific one wasn't.
             if (!isset($degrees['old']) ||
             !isset($degrees['old'][$oldDegree->id])) {
                 $oldDegree->delete();
             }
         }
 
-        //Save new degrees
+        // Save new degrees.
         if (isset($degrees['new'])) {
             foreach ($degrees['new'] as $degreeInput) {
                 $degree = new Degree();
@@ -95,10 +92,10 @@ class ExperienceController extends Controller
             }
         }
 
-        //Update old degrees
+        // Update old degrees.
         if (isset($degrees['old'])) {
             foreach ($degrees['old'] as $id => $degreeInput) {
-                //Ensure this degree belongs to this applicant
+                // Ensure this degree belongs to this applicant.
                 $degree = $applicant->degrees->firstWhere('id', $id);
                 if ($degree != null) {
                     $degree->fill([
@@ -111,14 +108,14 @@ class ExperienceController extends Controller
                     ]);
                     $degree->save();
                 } else {
-                    Log::warning('Applicant '.$applicant->id.' attempted to update degree with invalid id '.$id);
+                    Log::warning("Applicant $applicant->id attempted to update degree with invalid id: $id");
                 }
             }
         }
 
         $courses = $input['courses'];
 
-        $validatedCourseData = $request->validate([
+        $request->validate([
             'courses.new.*.name'             => 'required',
             'courses.new.*.institution'      => 'required',
             'courses.new.*.course_status_id' => 'required',
@@ -126,18 +123,18 @@ class ExperienceController extends Controller
             'courses.new.*.end_date'         => 'required|date',
         ]);
 
-        //Delete old courses that weren't resubmitted
-        //Note: this must be done before adding new ones, so we don't delete
-        // them right after adding them
+        // Delete old courses that weren't resubmitted.
+        // Note: this must be done before adding new ones, so we don't delete
+        // them right after adding them.
         foreach ($applicant->courses as $oldCourse) {
-            //Check if no courses were resubmitted, or if this specific one wasn't
+            // Check if no courses were resubmitted, or if this specific one wasn't.
             if (!isset($courses['old']) ||
             !isset($courses['old'][$oldCourse->id])) {
                 $oldCourse->delete();
             }
         }
 
-        //Save new courses
+        // Save new courses.
         if (isset($courses['new'])) {
             foreach ($courses['new'] as $courseInput) {
                 $course = new Course();
@@ -153,10 +150,10 @@ class ExperienceController extends Controller
             }
         }
 
-        //Update old courses
+        // Update old courses.
         if (isset($courses['old'])) {
             foreach ($courses['old'] as $id => $courseInput) {
-                //Ensure this course belongs to this applicant
+                // Ensure this course belongs to this applicant.
                 $course = $applicant->courses->firstWhere('id', $id);
                 if ($course != null) {
                     $course->fill([
@@ -168,14 +165,14 @@ class ExperienceController extends Controller
                     ]);
                     $course->save();
                 } else {
-                    Log::warning('Applicant '.$applicant->id.' attempted to update course with invalid id '.$id);
+                    Log::warning("Applicant $applicant->id attempted to update course with invalid id: $id");
                 }
             }
         }
 
         $work_experiences = $input['work_experiences'];
 
-        $validatedWorkData = $request->validate([
+        $request->validate([
             'work_experiences.new.*.role'        => 'required',
             'work_experiences.new.*.company'     => 'required',
             'work_experiences.new.*.description' => 'required',
@@ -183,18 +180,18 @@ class ExperienceController extends Controller
             'work_experiences.new.*.end_date'    => 'required|date',
         ]);
 
-        //Delete old work_experiences that weren't resubmitted
-        //Note: this must be done before adding new ones, so we don't delete
-        // them right after adding them
+        // Delete old work_experiences that weren't resubmitted.
+        // Note: this must be done before adding new ones, so we don't delete
+        // them right after adding them.
         foreach ($applicant->work_experiences as $oldWorkExperience) {
-            //Check if no work_experiences were resubmitted, or if this specific one wasn't
+            // Check if no work_experiences were resubmitted, or if this specific one wasn't.
             if (!isset($work_experiences['old']) ||
             !isset($work_experiences['old'][$oldWorkExperience->id])) {
                 $oldWorkExperience->delete();
             }
         }
 
-        //Save new work_experiences
+        // Save new work_experiences.
         if (isset($work_experiences['new'])) {
             foreach ($work_experiences['new'] as $workExperienceInput) {
                 $workExperience = new WorkExperience();
@@ -210,10 +207,10 @@ class ExperienceController extends Controller
             }
         }
 
-        //Update old work_experiences
+        // Update old work_experiences.
         if (isset($work_experiences['old'])) {
             foreach ($work_experiences['old'] as $id => $workExperienceInput) {
-                //Ensure this work_experience belongs to this applicant
+                // Ensure this work_experience belongs to this applicant.
                 $workExperience = $applicant->work_experiences->firstWhere('id', $id);
                 if ($workExperience != null) {
                     $workExperience->fill([
@@ -225,7 +222,7 @@ class ExperienceController extends Controller
                     ]);
                     $workExperience->save();
                 } else {
-                    Log::warning('Applicant '.$applicant->id.' attempted to update work_experience with invalid id '.$id);
+                    Log::warning("Applicant $applicant->id attempted to update work_experience with invalid id: $id");
                 }
             }
         }

--- a/app/Http/Controllers/HomepageController.php
+++ b/app/Http/Controllers/HomepageController.php
@@ -2,15 +2,14 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Lang;
 use App\Http\Controllers\Controller;
 
 class HomepageController extends Controller
 {
     /**
-     * Show the applicant home page
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * Show the applicant home page.
+     * @return \Illuminate\Http\Response
      */
     public function applicant()
     {
@@ -21,16 +20,16 @@ class HomepageController extends Controller
     }
 
     /**
-     * Show the manager home page
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * Show the manager home page.
+     * @return \Illuminate\Http\Response
      */
     public function manager()
     {
         return view('manager/home', [
-            "hero" => [
-                "hero_logo" => "/images/logo_tc_colour.png",
-                "hero_logo_alt" => Lang::get('manager/home_hero')['logo_alt_text'],
-                "hero_tagline" => Lang::get('manager/home_hero')['tagline']
+            'hero' => [
+                'hero_logo' => '/images/logo_tc_colour.png',
+                'hero_logo_alt' => Lang::get('manager/home_hero')['logo_alt_text'],
+                'hero_tagline' => Lang::get('manager/home_hero')['tagline']
             ]
         ]);
     }

--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -88,9 +88,8 @@ class JobController extends Controller
     /**
      * Submit the Job Poster for review.
      *
-     * @param \Illuminate\Http\Request $request   Incoming request object.
-     * @param \App\Models\JobPoster    $jobPoster Job Poster object.
-     *
+     * @param  \Illuminate\Http\Request $request   Incoming request object.
+     * @param  \App\Models\JobPoster    $jobPoster Job Poster object.
      * @return \Illuminate\Http\Response
      */
     public function submitForReview(Request $request, JobPoster $jobPoster)

--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -6,10 +6,7 @@ use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
-use Illuminate\View\View;
 use App\Http\Controllers\Controller;
 
 use Carbon\Carbon;
@@ -40,7 +37,7 @@ class JobController extends Controller
     /**
      * Display a listing of JobPosters.
      *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @return \Illuminate\Http\Response
      */
     public function index()
     {
@@ -71,7 +68,7 @@ class JobController extends Controller
     /**
      * Display a listing of a manager's JobPosters.
      *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @return \Illuminate\Http\Response
      */
     public function managerIndex()
     {
@@ -81,10 +78,9 @@ class JobController extends Controller
             ->get();
 
         return view('manager/job_index', [
-            /*Localization Strings*/
+            // Localization Strings.
             'jobs_l10n' => Lang::get('manager/job_index'),
-
-            /* Data */
+            // Data.
             'jobs' => $jobs,
         ]);
     }
@@ -95,18 +91,18 @@ class JobController extends Controller
      * @param \Illuminate\Http\Request $request   Incoming request object.
      * @param \App\Models\JobPoster    $jobPoster Job Poster object.
      *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @return \Illuminate\Http\Response
      */
     public function submitForReview(Request $request, JobPoster $jobPoster)
     {
-        // Update review request timestamp
+        // Update review request timestamp.
         $jobPoster->review_requested_at = new Date();
         $jobPoster->save();
 
         // Refresh model instance with updated DB values.
         $jobPoster = JobPoster::withCount('submitted_applications')->where('id', $jobPoster->id)->first();
 
-        // Send email
+        // Send email.
         $reviewer_email = config('mail.reviewer_email');
         if (isset($reviewer_email)) {
             Mail::to($reviewer_email)->send(new JobPosterReviewRequested($jobPoster, Auth::user()));
@@ -115,7 +111,7 @@ class JobController extends Controller
         }
 
         return view('manager/job_index/job', [
-            /*Localization Strings*/
+            // Localization Strings.
             'jobs_l10n' => Lang::get('manager/job_index'),
             'job' => $jobPoster
         ]);
@@ -124,12 +120,11 @@ class JobController extends Controller
     /**
      * Delete a draft Job Poster.
      *
-     * @param \Illuminate\Http\Request $request   Incoming request object.
-     * @param \App\Models\JobPoster    $jobPoster Job Poster object.
-     *
-     * @return void
+     * @param  \Illuminate\Http\Request $request   Incoming request object.
+     * @param  \App\Models\JobPoster    $jobPoster Job Poster object.
+     * @return \Illuminate\Http\Response
      */
-    public function destroy(Request $request, JobPoster $jobPoster) : void
+    public function destroy(Request $request, JobPoster $jobPoster)
     {
         $jobPoster->delete();
     }
@@ -137,10 +132,9 @@ class JobController extends Controller
     /**
      * Display the specified job poster.
      *
-     * @param \Illuminate\Http\Request $request   Incoming request object.
-     * @param \App\Models\JobPoster    $jobPoster Job Poster object.
-     *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @param  \Illuminate\Http\Request $request   Incoming request object.
+     * @param  \App\Models\JobPoster    $jobPoster Job Poster object.
+     * @return \Illuminate\Http\Response
      */
     public function show(Request $request, JobPoster $jobPoster)
     {
@@ -153,7 +147,7 @@ class JobController extends Controller
 
         $user = Auth::user();
 
-        //TODO: Improve workplace photos, and reference them in template direction from WorkEnvironment model
+        // TODO: Improve workplace photos, and reference them in template direction from WorkEnvironment model.
         $workplacePhotos = [];
         foreach ($jobPoster->manager->work_environment->workplace_photo_captions as $photoCaption) {
             $workplacePhotos[] = [
@@ -162,8 +156,7 @@ class JobController extends Controller
             ];
         }
 
-        //TODO: replace route('manager.show',manager.id) in templates with link using slug
-
+        // TODO: replace route('manager.show',manager.id) in templates with link using slug.
         $criteria = [
             'essential' => $jobPoster->criteria->filter(
                 function ($value, $key) {
@@ -211,7 +204,7 @@ class JobController extends Controller
             [
                 'job_post' => $jobLang,
                 'manager' => $jobPoster->manager,
-                'manager_profile_photo_url' => '/images/user.png', //TODO get real photo
+                'manager_profile_photo_url' => '/images/user.png', // TODO get real photo.
                 'team_culture' => $jobPoster->manager->team_culture,
                 'work_environment' => $jobPoster->manager->work_environment,
                 'workplace_photos' => $workplacePhotos,
@@ -226,9 +219,8 @@ class JobController extends Controller
     /**
      * Create a blank job poster for the specified manager
      *
-     * @param Manager $manager Incoming Manager object.
-     *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory Job Create view
+     * @param  \App\Models\Manager $manager Incoming Manager object.
+     * @return \Illuminate\Http\Response Job Create view
      */
     public function createAsManager(Manager $manager)
     {
@@ -248,9 +240,8 @@ class JobController extends Controller
     /**
      * Display the form for creating a new Job Poster
      *
-     * @param \Illuminate\Http\Request $request Incoming request object.
-     *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory Job Create view
+     * @param  \Illuminate\Http\Request $request Incoming request object.
+     * @return \Illuminate\Http\Response Job Create view
      */
     public function create(Request $request)
     {
@@ -260,10 +251,9 @@ class JobController extends Controller
     /**
      * Display the form for editing an existing Job Poster
      *
-     * @param \Illuminate\Http\Request $request   Incoming request object.
-     * @param \App\Models\JobPoster    $jobPoster Job Poster object.
-     *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory Job Create view
+     * @param  \Illuminate\Http\Request $request   Incoming request object.
+     * @param  \App\Models\JobPoster    $jobPoster Job Poster object.
+     * @return \Illuminate\Http\Response
      */
     public function edit(Request $request, JobPoster $jobPoster)
     {
@@ -273,10 +263,9 @@ class JobController extends Controller
     /**
      * Get the manager from the request object and check if creating or editing
      *
-     * @param \Illuminate\Http\Request $request   Incoming request object.
-     * @param \App\Models\JobPoster    $jobPoster Optional Job Poster object.
-     *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory Job Create view
+     * @param  \Illuminate\Http\Request $request   Incoming request object.
+     * @param  \App\Models\JobPoster    $jobPoster Optional Job Poster object.
+     * @return \Illuminate\Http\Response
      */
     public function populateCreateView(Request $request, JobPoster $jobPoster = null)
     {
@@ -365,10 +354,9 @@ class JobController extends Controller
         return view(
             'manager/job_create',
             [
-                /*Localization Strings*/
+                // Localization Strings.
                 'job_l10n' => Lang::get('manager/job_create'),
-
-                /* Data */
+                // Data.
                 'job' => Lang::get($jobHeading),
                 'manager' => $manager,
                 'provinces' => Province::all(),
@@ -387,15 +375,14 @@ class JobController extends Controller
     /**
      * Create a new resource in storage
      *
-     * @param \Illuminate\Http\Request $request   Incoming request object.
-     * @param \App\Models\JobPoster    $jobPoster Optional Job Poster object.
-     *
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse A redirect to the Job Index
+     * @param  \Illuminate\Http\Request $request   Incoming request object.
+     * @param  \App\Models\JobPoster    $jobPoster Optional Job Poster object.
+     * @return \Illuminate\Http\Response
      */
     public function store(Request $request, JobPoster $jobPoster = null)
     {
         // Don't allow edits for published Job Posters
-        // Also check auth while we're at it
+        // Also check auth while we're at it.
         if (isset($jobPoster)) {
             $this->authorize('update', $jobPoster);
             JobPosterValidator::validateUnpublished($jobPoster);
@@ -426,9 +413,8 @@ class JobController extends Controller
     /**
      * Fill Job Poster model's properties and save
      *
-     * @param mixed[]               $input     Field values.
-     * @param \App\Models\JobPoster $jobPoster Job Poster object.
-     *
+     * @param  mixed[]               $input     Field values.
+     * @param  \App\Models\JobPoster $jobPoster Job Poster object.
      * @return void
      */
     protected function fillAndSaveJobPoster(array $input, JobPoster $jobPoster) : void
@@ -473,10 +459,9 @@ class JobController extends Controller
     /**
      * Fill Job Poster's tasks and save
      *
-     * @param mixed[]               $input     Field values.
-     * @param \App\Models\JobPoster $jobPoster Job Poster object.
-     * @param boolean               $replace   Remove existing relationships.
-     *
+     * @param  mixed[]               $input     Field values.
+     * @param  \App\Models\JobPoster $jobPoster Job Poster object.
+     * @param  boolean               $replace   Remove existing relationships.
      * @return void
      */
     protected function fillAndSaveJobPosterTasks(array $input, JobPoster $jobPoster, bool $replace) : void
@@ -509,10 +494,9 @@ class JobController extends Controller
     /**
      * Fill Job Poster's questions and save
      *
-     * @param mixed[]               $input     Field values.
-     * @param \App\Models\JobPoster $jobPoster Job Poster object.
-     * @param boolean               $replace   Remove existing relationships.
-     *
+     * @param  mixed[]               $input     Field values.
+     * @param  \App\Models\JobPoster $jobPoster Job Poster object.
+     * @param  boolean               $replace   Remove existing relationships.
      * @return void
      */
     protected function fillAndSaveJobPosterQuestions(array $input, JobPoster $jobPoster, bool $replace) : void
@@ -547,9 +531,8 @@ class JobController extends Controller
     /**
      * Fill Job Poster's criteria and save
      *
-     * @param mixed[]               $input     Field values.
-     * @param \App\Models\JobPoster $jobPoster Job Poster object.
-     *
+     * @param  mixed[]               $input     Field values.
+     * @param  \App\Models\JobPoster $jobPoster Job Poster object.
      * @return void
      */
     protected function fillAndSaveJobPosterCriteria(array $input, JobPoster $jobPoster) : void
@@ -593,17 +576,17 @@ class JobController extends Controller
     /**
      * Process intput representing a single criteria from Job Poster form.
      *
-     * @param JobPoster    $jobPoster
-     * @param string       $criteriaType
-     * @param array        $criteriaInput
-     * @param integer|null $criteriaId
-     * @return Criteria
+     * @param  \App\Models\JobPoster $jobPoster     Incoming Job Poster.
+     * @param  string                $criteriaType  Type of Criteria.
+     * @param  array                 $criteriaInput Criteria data.
+     * @param  integer|null          $criteriaId    Criteria ID.
+     * @return \App\Models\Criteria
      */
-    protected function processCriteriaForm(JobPoster $jobPoster, string $criteriaType, array $criteriaInput, ?int $criteriaId): Criteria
+    protected function processCriteriaForm(JobPoster $jobPoster, string $criteriaType, array $criteriaInput, ?int $criteriaId)
     {
         $skillId = $criteriaInput['skill_id'];
 
-        //If no description was provided, use the default skill description
+        // If no description was provided, use the default skill description.
         $descriptionEn = $criteriaInput['description']['en'] ?
             $criteriaInput['description']['en'] : Skill::find($skillId)->getTranslation('description', 'en');
         $descriptionFr = $criteriaInput['description']['fr'] ?
@@ -633,12 +616,12 @@ class JobController extends Controller
     /**
      * Create a Job Criteria
      *
-     * @param JobPoster $jobPoster
-     * @param integer   $skillId
-     * @param array     $data
-     * @return Criteria
+     * @param  \App\Models\JobPoster $jobPoster Incoming Job Poster.
+     * @param  integer               $skillId   Skill ID.
+     * @param  array                 $data      Criteria data.
+     * @return \App\Models\Criteria
      */
-    protected function createCriteria(JobPoster $jobPoster, int $skillId, array $data): Criteria
+    protected function createCriteria(JobPoster $jobPoster, int $skillId, array $data)
     {
         $criteria = new Criteria();
         $criteria->job_poster_id = $jobPoster->id;
@@ -658,8 +641,8 @@ class JobController extends Controller
     /**
      * Update an existing Job Criteria
      *
-     * @param Criteria $criteria
-     * @param array    $data
+     * @param  \App\Models\Criteria $criteria Incoming Critera.
+     * @param  array                $data     Skill data.
      * @return void
      */
     protected function updateCriteria(Criteria $criteria, array $data): void
@@ -681,7 +664,7 @@ class JobController extends Controller
     /**
      * Delete existing Job Criteria
      *
-     * @param Criteria $criteria
+     * @param  \App\Models\Criteria $criteria Incoming Criteria.
      * @return void
      */
     protected function deleteCriteria(Criteria $criteria): void
@@ -692,21 +675,21 @@ class JobController extends Controller
         );
         $notification->save();
 
-        // Delete assessments related to this criteria
-        Assessment::where("criterion_id", $criteria->id)->delete();
+        // Delete assessments related to this criteria.
+        Assessment::where('criterion_id', $criteria->id)->delete();
         $criteria->delete();
     }
 
     /**
      * Create a new AssessmentPlanNotification for a modification to a Criteria
      *
-     * @param string       $type            Can be CREATE, UPDATE or DELETE.
-     * @param Criteria     $criteria
-     * @param integer|null $newSkillId      Only used for UPDATE type notifications.
-     * @param integer|null $newSkillLevelId Only used for UPDATE type notifications.
-     * @return AssessmentPlanNotification
+     * @param  string               $type            Can be CREATE, UPDATE or DELETE.
+     * @param  \App\Models\Criteria $criteria        Incoming Criteria.
+     * @param  integer|null         $newSkillId      Only used for UPDATE type notifications.
+     * @param  integer|null         $newSkillLevelId Only used for UPDATE type notifications.
+     * @return \App\Models\AssessmentPlanNotification
      */
-    protected function makeAssessmentPlanNotification(string $type, Criteria $criteria, $newSkillId = null, $newSkillLevelId = null): AssessmentPlanNotification
+    protected function makeAssessmentPlanNotification(string $type, Criteria $criteria, $newSkillId = null, $newSkillLevelId = null)
     {
         $notification = new AssessmentPlanNotification();
         $notification->job_poster_id = $criteria->job_poster_id;

--- a/app/Http/Controllers/ManagerProfileController.php
+++ b/app/Http/Controllers/ManagerProfileController.php
@@ -7,54 +7,54 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Models\Lookup\Frequency;
 use App\Models\Lookup\Department;
-use App\Models\WorkEnvironment;
-use App\Models\TeamCulture;
 use App\Models\Manager;
 
-class ManagerProfileController extends Controller {
+class ManagerProfileController extends Controller
+{
 
     /**
      * Show a manager profile
      *
-     * @param  Request  $request
-     * @param  \App\Models\Manager  $manager
+     * @param  \Illuminate\Http\Request $request Incoming Request.
+     * @param  \App\Models\Manager      $manager Incoming Manager.
      * @return \Illuminate\Http\Response
      */
-    public function show(Request $request, Manager $manager) {
+    public function show(Request $request, Manager $manager)
+    {
         $manager_profile = Lang::get('applicant/manager_profile');
 
         $manager_profile_sections = [
             [
-                "title" => $manager_profile['section_titles']['approach'],
-                "questions" => [
+                'title' => $manager_profile['section_titles']['approach'],
+                'questions' => [
                     [
-                        "title" => $manager_profile['questions']['leadership_style'],
-                        "answer" => $manager->leadership_style
+                        'title' => $manager_profile['questions']['leadership_style'],
+                        'answer' => $manager->leadership_style
                     ],
                     [
-                        "title" => $manager_profile['questions']['employee_expectations'],
-                        "answer" => $manager->expectations
+                        'title' => $manager_profile['questions']['employee_expectations'],
+                        'answer' => $manager->expectations
                     ],
                     [
-                        "title" => $manager_profile['questions']['employee_learning'],
-                        "answer" => $manager->employee_learning
+                        'title' => $manager_profile['questions']['employee_learning'],
+                        'answer' => $manager->employee_learning
                     ]
                 ]
             ],
             [
-                "title" => $manager_profile['section_titles']['about_me'],
-                "questions" => [
+                'title' => $manager_profile['section_titles']['about_me'],
+                'questions' => [
                     [
-                        "title" => $manager_profile['questions']['career_journey'],
-                        "answer" => $manager->career_journey
+                        'title' => $manager_profile['questions']['career_journey'],
+                        'answer' => $manager->career_journey
                     ],
                     [
-                        "title" => $manager_profile['questions']['learning_path'],
-                        "answer" => $manager->learning_path
+                        'title' => $manager_profile['questions']['learning_path'],
+                        'answer' => $manager->learning_path
                     ],
                     [
-                        "title" => $manager_profile['questions']['about_me'],
-                        "answer" => $manager->about_me
+                        'title' => $manager_profile['questions']['about_me'],
+                        'answer' => $manager->about_me
                     ]
                 ]
             ]
@@ -62,21 +62,21 @@ class ManagerProfileController extends Controller {
 
 
         return view('applicant/manager', [
-            "manager_profile" => $manager_profile,
+            'manager_profile' => $manager_profile,
             'urls' => Lang::get('common/urls'),
             'manager' => $manager,
-            'manager_profile_photo_url' => '/images/user.png', //TODO get real photo
-            "manager_profile_sections" => $manager_profile_sections,
+            'manager_profile_photo_url' => '/images/user.png', // TODO get real photo.
+            'manager_profile_sections' => $manager_profile_sections,
         ]);
     }
 
     /**
      * Show the form for editing the logged-in manager's profile
      *
-     * @param  Request $request
-     * @return \Illuminate\Http\RedirectResponse
+     * @param  \Illuminate\Http\Request $request Incoming Request.
+     * @return \Illuminate\Http\Response
      */
-    public function editAuthenticated(Request $request): \Illuminate\Http\RedirectResponse
+    public function editAuthenticated(Request $request)
     {
         $manager = $request->user()->manager;
         return redirect(route('manager.profile.edit', $manager));
@@ -85,16 +85,17 @@ class ManagerProfileController extends Controller {
     /**
      * Show the form for editing the logged-in user's manager profile
      *
-     * @param  Request  $request
-     * @param  \App\Models\Manager  $manager
+     * @param  \Illuminate\Http\Request $request Incoming Request.
+     * @param  \App\Models\Manager      $manager Incoming Manager.
      * @return \Illuminate\Http\Response
      */
-    public function edit(Request $request, Manager $manager) {
+    public function edit(Request $request, Manager $manager)
+    {
 
-        //TODO: Improve workplace photos, and reference them in template direction from WorkEnvironment model
+        // TODO: Improve workplace photos, and reference them in template direction from WorkEnvironment model.
         $workplacePhotos = [];
         if ($manager->work_environment != null) {
-            foreach($manager->work_environment->workplace_photo_captions as $photoCaption) {
+            foreach ($manager->work_environment->workplace_photo_captions as $photoCaption) {
                 $workplacePhotos[] = [
                     'id' => $photoCaption->id,
                     'alt' => $photoCaption->description,
@@ -107,14 +108,13 @@ class ManagerProfileController extends Controller {
         $frequencies = Frequency::all();
 
         return view('manager/profile', [
-            /* Localization */
+            // Localization.
             'profile_l10n' => Lang::get('manager/profile'),
-
-            /* Data */
+            // Data.
             'urls' => Lang::get('common/urls'),
             'user' => $manager->user,
             'manager' => $manager,
-            'manager_profile_photo_url' => '/images/user.png', //TODO get real photo
+            'manager_profile_photo_url' => '/images/user.png', // TODO get real photo.
             'team_culture' => $manager->team_culture,
             'work_environment' => $manager->work_environment,
             'workplace_photos' => $workplacePhotos,
@@ -128,14 +128,15 @@ class ManagerProfileController extends Controller {
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\Manager  $manager
+     * @param  \Illuminate\Http\Request $request Incoming Request.
+     * @param  \App\Models\Manager      $manager Incoming Manager.
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, Manager $manager) {
+    public function update(Request $request, Manager $manager)
+    {
         $input = $request->input();
 
-        //TODO: remove control of name in production
+        // TODO: remove control of name in production.
         $manager->user->name = $input['name'];
         $manager->user->save();
 
@@ -143,15 +144,9 @@ class ManagerProfileController extends Controller {
             'department_id' => $input['department'],
             'twitter_username' => $input['twitter_username'],
             'linkedin_url' => $input['linkedin_url'],
-            //'work_review_frequency_id' => [],
-            //'stay_late_frequency_id' => [],
-            //'engage_team_frequency_id' => [],
-            //'development_opportunity_frequency_id',
-            //'refuse_low_value_work_frequency_id',
             'years_experience' => $input['years_experience'],
             'en' => [
                 'about_me' => $input['about_me']['en'],
-                //'greatest_accomplishment',
                 'branch' =>  $input['branch']['en'],
                 'division' => $input['division']['en'],
                 'position' => $input['position']['en'],
@@ -164,7 +159,6 @@ class ManagerProfileController extends Controller {
             ],
             'fr' => [
                 'about_me' => $input['about_me']['fr'],
-                //'greatest_accomplishment',
                 'branch' =>  $input['branch']['fr'],
                 'division' => $input['division']['fr'],
                 'position' => $input['position']['fr'],
@@ -188,7 +182,7 @@ class ManagerProfileController extends Controller {
                 'things_to_know' => $input['things_to_know']['fr']
             ]
         ]);
-        //Slider select inputs can be missing from input if nothing was selected
+        // Slider select inputs can be missing from input if nothing was selected.
         if (isset($input['telework'])) {
             $work_environment->telework_allowed_frequency_id = $input['telework'];
         }
@@ -214,9 +208,8 @@ class ManagerProfileController extends Controller {
         ]);
         $team_culture->save();
 
-        //TODO: save workplace Photos
-
-        //Use the button that was clicked to decide which element to redirect to
+        // TODO: save workplace Photos.
+        // Use the button that was clicked to decide which element to redirect to.
         switch ($input['submit']) {
             case 'about_me':
                 $hash = '#managerProfileSectionAbout';
@@ -231,11 +224,10 @@ class ManagerProfileController extends Controller {
                 $hash = '#managerProfileSectionLeadership';
                 break;
             default:
-                $hash = "";
+                $hash = '';
                 break;
         }
 
-        return redirect( route('manager.profile.edit', $manager).$hash );
+        return redirect(route('manager.profile.edit', $manager).$hash);
     }
-
 }

--- a/app/Http/Controllers/RatingGuideAnswerController.php
+++ b/app/Http/Controllers/RatingGuideAnswerController.php
@@ -3,11 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Models\RatingGuideAnswer;
-use App\Models\RatingGuideQuestion;
-use App\Models\Criteria;
-
-use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use App\Http\Requests\UpdateRatingGuideAnswer;
 use App\Http\Requests\StoreRatingGuideAnswer;
 
@@ -22,9 +17,8 @@ class RatingGuideAnswerController extends Controller
      */
     public function store(StoreRatingGuideAnswer $request)
     {
-        // Authorization handled by the FormRequest
-
-        // Data validation handled by this line
+        // Authorization handled by the FormRequest.
+        // Data validation handled by this line.
         $data = $request->validated();
         $ratingGuideAnswer = new RatingGuideAnswer($data);
         $ratingGuideAnswer->save();
@@ -50,16 +44,15 @@ class RatingGuideAnswerController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  \App\Requests\UpdateRatingGuideAnswer $request Incoming request.
-     * @param  \App\Models\RatingGuideAnswer $ratingGuideAnswer Incoming object.
+     * @param  \App\Requests\UpdateRatingGuideAnswer $request           Incoming request.
+     * @param  \App\Models\RatingGuideAnswer         $ratingGuideAnswer Incoming object.
      * @throws \InvalidArgumentException For empty $expected_answer.
      * @return mixed
      */
     public function update(UpdateRatingGuideAnswer $request, RatingGuideAnswer $ratingGuideAnswer)
     {
-        // Authorization handled by the FormRequest
-
-        // Data validation handled by this line
+        // Authorization handled by the FormRequest.
+        // Data validation handled by this line.
         $data = $request->validated();
 
         $ratingGuideAnswer->fill($data);

--- a/app/Http/Controllers/RatingGuideQuestionController.php
+++ b/app/Http/Controllers/RatingGuideQuestionController.php
@@ -7,7 +7,6 @@ use App\Models\JobPoster;
 use App\Models\Lookup\AssessmentType;
 
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 
 class RatingGuideQuestionController extends Controller
 {
@@ -34,7 +33,7 @@ class RatingGuideQuestionController extends Controller
                 'assessment_type_id' => $assessment_type_id,
                 'question' => $question,
             ]);
-            // Check that this user is allowed to create an Assessment for this criterion
+            // Check that this user is allowed to create an Assessment for this criterion.
             $this->authorize('update', $ratingGuideQuestion);
 
             $ratingGuideQuestion->save();

--- a/app/Http/Controllers/ReferencesController.php
+++ b/app/Http/Controllers/ReferencesController.php
@@ -28,8 +28,8 @@ class ReferencesController extends Controller
     /**
      * Show the form for editing the applicant's references
      *
-     * @param \Illuminate\Http\Request $request   Incoming request object.
-     * @param \App\Models\Applicant    $applicant Incoming applicant object.
+     * @param  \Illuminate\Http\Request $request   Incoming request object.
+     * @param  \App\Models\Applicant    $applicant Incoming applicant object.
      * @return \Illuminate\Http\Response
      */
     public function edit(Request $request, Applicant $applicant)
@@ -48,8 +48,8 @@ class ReferencesController extends Controller
     /**
      * Update or create a reference with the supplied data.
      *
-     * @param \Illuminate\Http\Request   $request   The incoming request object.
-     * @param \App\Models\Reference|null $reference The reference to update. If null, a new one should be created.
+     * @param  \Illuminate\Http\Request   $request   The incoming request object.
+     * @param  \App\Models\Reference|null $reference The reference to update. If null, a new one should be created.
      * @return \Illuminate\Http\Response
      */
     public function update(Request $request, ?Reference $reference = null)
@@ -95,7 +95,7 @@ class ReferencesController extends Controller
         $skillIds = $this->getRelativeIds($request->input(), 'skills');
         $reference->skill_declarations()->sync($skillIds);
 
-        // if an ajax request, return the new object.
+        // If an ajax request, return the new object.
         if ($request->ajax()) {
             $reference->load('relationship');
             $reference->load('projects');

--- a/app/Http/Controllers/ReferencesController.php
+++ b/app/Http/Controllers/ReferencesController.php
@@ -3,14 +3,11 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Lang;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
-use App\Models\Skill;
 use App\Models\Applicant;
 use App\Models\Reference;
 use App\Models\Project;
-use App\Models\Lookup\Relationship;
 use App\Services\Validation\Requests\UpdateReferenceValidator;
 
 class ReferencesController extends Controller
@@ -19,10 +16,10 @@ class ReferencesController extends Controller
     /**
      * Show the form for editing the logged-in applicant's references
      *
-     * @param  Request $request
-     * @return \Illuminate\Http\RedirectResponse
+     * @param  \Illuminate\Http\Request $request Incoming request object.
+     * @return \Illuminate\Http\Response
      */
-    public function editAuthenticated(Request $request): \Illuminate\Http\RedirectResponse
+    public function editAuthenticated(Request $request)
     {
         $applicant = $request->user()->applicant;
         return redirect(route('profile.references.edit', $applicant));
@@ -31,10 +28,9 @@ class ReferencesController extends Controller
     /**
      * Show the form for editing the applicant's references
      *
-     * @param Request   $request   Incoming request object.
-     * @param Applicant $applicant Incoming applicant object.
-     *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @param \Illuminate\Http\Request $request   Incoming request object.
+     * @param \App\Models\Applicant    $applicant Incoming applicant object.
+     * @return \Illuminate\Http\Response
      */
     public function edit(Request $request, Applicant $applicant)
     {
@@ -54,8 +50,7 @@ class ReferencesController extends Controller
      *
      * @param \Illuminate\Http\Request   $request   The incoming request object.
      * @param \App\Models\Reference|null $reference The reference to update. If null, a new one should be created.
-     *
-     * @return
+     * @return \Illuminate\Http\Response
      */
     public function update(Request $request, ?Reference $reference = null)
     {
@@ -76,8 +71,8 @@ class ReferencesController extends Controller
 
         $reference->load('projects');
 
-        //TODO: As soon as you can interact with projects outside of references,
-        //  this will become a dangerous operation
+        // TODO: As soon as you can interact with projects outside of references,
+        // this will become a dangerous operation.
         $reference->projects()->delete();
 
         $newProjects = [];
@@ -92,16 +87,15 @@ class ReferencesController extends Controller
                 ]);
                 $project->save();
                 $newProjects[] = $project->id;
-                // $reference->projects()->attach($project);
             }
         }
         $reference->projects()->sync($newProjects);
 
-        //Attach relatives
+        // Attach relatives.
         $skillIds = $this->getRelativeIds($request->input(), 'skills');
         $reference->skill_declarations()->sync($skillIds);
 
-        // if an ajax request, return the new object
+        // if an ajax request, return the new object.
         if ($request->ajax()) {
             $reference->load('relationship');
             $reference->load('projects');
@@ -114,22 +108,22 @@ class ReferencesController extends Controller
     /**
      * Delete the particular reference from storage.
      *
-     * @param  \Illuminate\Http\Request $request
-     * @param  \App\Models\Reference    $reference
+     * @param  \Illuminate\Http\Request $request   Incoming Request.
+     * @param  \App\Models\Reference    $reference Incoming Reference.
      * @return \Illuminate\Http\Response
      */
     public function destroy(Request $request, Reference $reference)
     {
         $this->authorize('delete', $reference);
 
-        //TODO: when projects exist independently on profile, delete seperatley
+        // TODO: when projects exist independently on profile, delete separately.
         $reference->projects()->delete();
 
         $reference->delete();
 
         if ($request->ajax()) {
             return [
-                "message" => 'Reference deleted'
+                'message' => 'Reference deleted'
             ];
         }
 

--- a/app/Http/Controllers/SkillController.php
+++ b/app/Http/Controllers/SkillController.php
@@ -15,7 +15,7 @@ class SkillController extends Controller
     {
         $skills = Skill::all();
         $skillsArray = [];
-        //TODO: improve effiency of getting translations
+        // TODO: improve effiency of getting translations.
         foreach ($skills as $skill) {
             $translations = [
                 'en' => [

--- a/app/Http/Controllers/SkillDeclarationController.php
+++ b/app/Http/Controllers/SkillDeclarationController.php
@@ -16,8 +16,8 @@ class SkillDeclarationController extends Controller
     /**
      * Show the form for editing the logged-in applicant's skills
      *
-     * @param  Request $request Incoming request.
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     * @param  \Illuminate\Http\Request $request Incoming request.
+     * @return \Illuminate\Http\Response
      */
     public function editAuthenticated(Request $request)
     {
@@ -28,10 +28,9 @@ class SkillDeclarationController extends Controller
     /**
      * Show the form for editing the applicant's skills
      *
-     * @param Request   $request   Incoming request object.
-     * @param Applicant $applicant Applicant object.
-     *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @param  \Illuminate\Http\Request $request   Incoming request object.
+     * @param  \App\Models\Applicant    $applicant Applicant object.
+     * @return \Illuminate\Http\Response
      */
     public function edit(Request $request, Applicant $applicant)
     {
@@ -51,7 +50,7 @@ class SkillDeclarationController extends Controller
      * Create the particular skill declaration in storage.
      *
      * @param  \Illuminate\Http\Request $request Incoming request.
-     * @return \Illuminate\Http\RedirectResponse|string
+     * @return \Illuminate\Http\Response|string
      */
     public function create(Request $request)
     {
@@ -60,17 +59,17 @@ class SkillDeclarationController extends Controller
         $user = $request->user();
         $applicant = $user->applicant;
 
-        //Get the default claim status id
+        // Get the default claim status id.
         $claimedStatusId = SkillStatus::where('name', 'claimed')->firstOrFail()->id;
 
         // Create a new Skill Declaration
-        // But don't save, as it hasn't been validated yet
+        // But don't save, as it hasn't been validated yet.
         $skillDeclaration = new SkillDeclaration();
         $skillDeclaration->applicant_id = $applicant->id;
         $skillDeclaration->skill_id = $request->input('skill_id');
         $skillDeclaration->skill_status_id = $claimedStatusId;
 
-        //Update variable fields in skill declaration
+        // Update variable fields in skill declaration.
         return $this->updateSkillDeclaration($request, $skillDeclaration);
     }
 
@@ -79,7 +78,7 @@ class SkillDeclarationController extends Controller
      *
      * @param  \Illuminate\Http\Request     $request          Incoming request.
      * @param  \App\Models\SkillDeclaration $skillDeclaration Incoming Skill Declaration.
-     * @return \Illuminate\Http\RedirectResponse|string
+     * @return \Illuminate\Http\Response|string
      */
     public function update(Request $request, SkillDeclaration $skillDeclaration)
     {
@@ -93,33 +92,31 @@ class SkillDeclarationController extends Controller
      *
      * @param  \Illuminate\Http\Request     $request          Incoming request.
      * @param  \App\Models\SkillDeclaration $skillDeclaration Incoming Skill Declaration.
-     * @return \Illuminate\Http\RedirectResponse|string
+     * @return \Illuminate\Http\Response|string
      */
     protected function updateSkillDeclaration(Request $request, SkillDeclaration $skillDeclaration)
     {
-        //Fill variable values
+        // Fill variable values.
         $skillDeclaration->fill([
             'description' => $request->input('description'),
             'skill_level_id' => $request->input('skill_level_id'),
         ]);
 
-        //Validate before saving
+        // Validate before saving.
         $validator = new SkillDeclarationValidator($request->user()->applicant);
         $validator->validate($skillDeclaration);
 
-        //Save this skill declaration
+        // Save this skill declaration.
         $skillDeclaration->save();
 
-        //Attach relatives
+        // Attach relatives.
         $referenceIds = $this->getRelativeIds($request->input(), 'references');
         $skillDeclaration->references()->sync($referenceIds);
 
         $sampleIds = $this->getRelativeIds($request->input(), 'samples');
         $skillDeclaration->work_samples()->sync($sampleIds);
 
-        // $skillDeclaration->save();
-
-        // If an ajax request, return the new object
+        // If an ajax request, return the new object.
         if ($request->ajax()) {
             $skillDeclaration->load('references');
             $skillDeclaration->load('work_samples');
@@ -136,7 +133,7 @@ class SkillDeclarationController extends Controller
      *
      * @param  \Illuminate\Http\Request     $request          Incoming request.
      * @param  \App\Models\SkillDeclaration $skillDeclaration Incoming Skill Declaration.
-     * @return \Illuminate\Http\RedirectResponse|string[]
+     * @return \Illuminate\Http\Response|string[]
      */
     public function destroy(Request $request, SkillDeclaration $skillDeclaration)
     {

--- a/app/Http/Controllers/WorkExperienceController.php
+++ b/app/Http/Controllers/WorkExperienceController.php
@@ -10,8 +10,8 @@ class WorkExperienceController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Models\WorkExperience  $workExperience
+     * @param  \Illuminate\Http\Request   $request        Incoming Request.
+     * @param  \App\Models\WorkExperience $workExperience Incoming Work Experience.
      * @return \Illuminate\Http\Response
      */
     public function destroy(Request $request, WorkExperience $workExperience)
@@ -21,7 +21,7 @@ class WorkExperienceController extends Controller
 
         if ($request->ajax()) {
             return [
-                'message' => "Work Experience delete",
+                'message' => 'Work Experience delete',
             ];
         }
 

--- a/app/Http/Controllers/WorkSamplesController.php
+++ b/app/Http/Controllers/WorkSamplesController.php
@@ -3,37 +3,32 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Lang;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
-use App\Models\Skill;
 use App\Models\Applicant;
 use App\Models\WorkSample;
 use App\Services\Validation\Requests\UpdateWorkSampleValidator;
 
 class WorkSamplesController extends Controller
 {
-
     /**
      * Show the form for editing the logged-in applicant's Work Samples
      *
-     * @param  Request $request
+     * @param  \Illuminate\Http\Request $request Incoming Request.
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function editAuthenticated(Request $request): \Illuminate\Http\RedirectResponse
+    public function editAuthenticated(Request $request)
     {
         $applicant = $request->user()->applicant;
         return redirect(route('profile.work_samples.edit', $applicant));
     }
 
-
     /**
      * Show the form for editing the applicant's work samples
      *
-     * @param Request   $request   Incoming request object.
-     * @param Applicant $applicant Incoming Applicant object.
-     *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @param  \Illuminate\Http\Request $request   Incoming request object.
+     * @param  \App\Models\Applicant    $applicant Incoming Applicant object.
+     * @return \Illuminate\Http\Response
      */
     public function edit(Request $request, Applicant $applicant)
     {
@@ -51,8 +46,8 @@ class WorkSamplesController extends Controller
     /**
      * Update the workSample in storage, or create new one.
      *
-     * @param  \Illuminate\Http\Request    $request
-     * @param  \App\Models\WorkSample|null $workSample
+     * @param  \Illuminate\Http\Request    $request    Incoming Request.
+     * @param  \App\Models\WorkSample|null $workSample Incoming optional Work Sample.
      * @return \Illuminate\Http\Response
      */
     public function update(Request $request, ?WorkSample $workSample = null)
@@ -72,11 +67,11 @@ class WorkSamplesController extends Controller
         ]);
         $workSample->save();
 
-        //Attach relatives
+        // Attach relatives.
         $skillIds = $this->getRelativeIds($request->input(), 'skills');
         $workSample->skill_declarations()->sync($skillIds);
 
-        // if an ajax request, return the new object
+        // if an ajax request, return the new object.
         if ($request->ajax()) {
             $workSample->load('file_type');
             return $workSample->toJson();
@@ -88,8 +83,8 @@ class WorkSamplesController extends Controller
     /**
      * Delete the particular work sample from storage.
      *
-     * @param  \Illuminate\Http\Request $request
-     * @param  \App\Models\WorkSample   $workSample
+     * @param  \Illuminate\Http\Request $request    Incoming Request.
+     * @param  \App\Models\WorkSample   $workSample Incoming Work Sample.
      * @return \Illuminate\Http\Response
      */
     public function destroy(Request $request, WorkSample $workSample)
@@ -100,7 +95,7 @@ class WorkSamplesController extends Controller
 
         if ($request->ajax()) {
             return [
-                "message" => 'Work sample deleted'
+                'message' => 'Work sample deleted'
             ];
         }
 

--- a/app/Http/Controllers/WorkSamplesController.php
+++ b/app/Http/Controllers/WorkSamplesController.php
@@ -71,7 +71,7 @@ class WorkSamplesController extends Controller
         $skillIds = $this->getRelativeIds($request->input(), 'skills');
         $workSample->skill_declarations()->sync($skillIds);
 
-        // if an ajax request, return the new object.
+        // If an ajax request, return the new object.
         if ($request->ajax()) {
             $workSample->load('file_type');
             return $workSample->toJson();

--- a/app/Models/JobPoster.php
+++ b/app/Models/JobPoster.php
@@ -70,7 +70,7 @@ use \Backpack\CRUD\CrudTrait;
  * Methods
  * @method boolean isOpen()
  * @method string timeRemaining()
- * @method string toApiArray()
+ * @method mixed[] toApiArray()
  */
 class JobPoster extends BaseModel
 {
@@ -400,7 +400,7 @@ class JobPoster extends BaseModel
      *
      * @return mixed[]
      */
-    public function toApiArray()
+    public function toApiArray(): array
     {
         $jobWithTranslations = array_merge($this->toArray(), $this->getTranslationsArray());
         $jobCollection = collect($jobWithTranslations)->only([

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,16 +54,16 @@ Route::group(
                     ->name('applications.show');
 
                 /* Step 01 */
-                Route::get('jobs/{jobPoster}/application/step-01', 'ApplicationByJobController@edit_basics')->name('job.application.edit.1');
+                Route::get('jobs/{jobPoster}/application/step-01', 'ApplicationByJobController@editBasics')->name('job.application.edit.1');
 
                 /* Step 02 */
-                Route::get('jobs/{jobPoster}/application/step-02', 'ApplicationByJobController@edit_experience')->name('job.application.edit.2');
+                Route::get('jobs/{jobPoster}/application/step-02', 'ApplicationByJobController@editExperience')->name('job.application.edit.2');
 
                 /* Step 03 */
-                Route::get('jobs/{jobPoster}/application/step-03', 'ApplicationByJobController@edit_essential_skills')->name('job.application.edit.3');
+                Route::get('jobs/{jobPoster}/application/step-03', 'ApplicationByJobController@editEssentialSkills')->name('job.application.edit.3');
 
                 /* Step 04 */
-                Route::get('jobs/{jobPoster}/application/step-04', 'ApplicationByJobController@edit_asset_skills')->name('job.application.edit.4');
+                Route::get('jobs/{jobPoster}/application/step-04', 'ApplicationByJobController@editAssetSkills')->name('job.application.edit.4');
 
                 /* Step 05 */
                 Route::get('jobs/{jobPoster}/application/step-05', 'ApplicationByJobController@preview')->name('job.application.edit.5');
@@ -77,16 +77,16 @@ Route::group(
                 /* Application Update routes */
 
                 /* Step 01 */
-                Route::post('jobs/{jobPoster}/application/step-01/update', 'ApplicationByJobController@update_basics')->name('job.application.update.1');
+                Route::post('jobs/{jobPoster}/application/step-01/update', 'ApplicationByJobController@updateBasics')->name('job.application.update.1');
 
                 /* Step 02 */
-                Route::post('jobs/{jobPoster}/application/step-02/update', 'ApplicationByJobController@update_experience')->name('job.application.update.2');
+                Route::post('jobs/{jobPoster}/application/step-02/update', 'ApplicationByJobController@updateExperience')->name('job.application.update.2');
 
                 /* Step 03 */
-                Route::post('jobs/{jobPoster}/application/step-03/update', 'ApplicationByJobController@update_essential_skills')->name('job.application.update.3');
+                Route::post('jobs/{jobPoster}/application/step-03/update', 'ApplicationByJobController@updateEssentialSkills')->name('job.application.update.3');
 
                 /* Step 04 */
-                Route::post('jobs/{jobPoster}/application/step-04/update', 'ApplicationByJobController@update_asset_skills')->name('job.application.update.4');
+                Route::post('jobs/{jobPoster}/application/step-04/update', 'ApplicationByJobController@updateAssetSkills')->name('job.application.update.4');
 
                 /* Step 05 */
                 Route::post('jobs/{jobPoster}/application/submit', 'ApplicationByJobController@submit')->name('job.application.submit');

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -16,9 +16,23 @@
     <rule ref="PSR2"/>
     <!-- Use Slevomat's coding standards to sniff docblocks -->
     <config name="installed_paths" value="../../slevomat/coding-standard"/>
-    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration" phpcs-only="true">
+        <exclude-pattern>*/app/Http/Controllers/*</exclude-pattern>
+        <type>warning</type>
+    </rule>
     <!-- More docblock sniffs -->
-    <rule ref="Squiz.Commenting.FunctionComment" />
-    <rule ref="Squiz.Commenting.FunctionCommentThrowTag" />
-    <rule ref="Squiz.Commenting.VariableComment" />
+    <rule ref="Squiz.Commenting.FunctionComment" phpcs-only="true">
+        <type>warning</type>
+    </rule>
+    <rule ref="Squiz.Commenting.FunctionCommentThrowTag">
+        <type>warning</type>
+    </rule>
+    <rule ref="Squiz.Commenting.InlineComment">
+        <type>warning</type>
+    </rule>
+    <rule ref="Squiz.Commenting.VariableComment">
+        <type>warning</type>
+    </rule>
+    <!-- Quote style -->
+    <rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired" />
 </ruleset>


### PR DESCRIPTION
### Notes:
- Reviewed all controllers for explicit return typehints that can cause problems, and removed them
- Updated `ruleset.xml` with the following changes
  - Made sniffs relating to typehints warnings instead of errors
  - Excluded the `Controllers` directory from the typehint warnings
  - Added sniff for quote style and inline comment formatting
  - Changed all sniffs relating to "style", like commenting/docblock/etc warnings instead of errors
- Ran through a general formatting cleanup in all controllers

It should be safe to run PHP formatting on save now, but please pay attention to warnings in the IDE (green squigglies).

Sorry for the noise, but should be a good place to move forward from.
