### PR TITLE
Ensure data passed to components from controller matches Job interface

### DIFF
--- a/app/Http/Controllers/ApplicationByJobController.php
+++ b/app/Http/Controllers/ApplicationByJobController.php
@@ -46,7 +46,7 @@ class ApplicationByJobController extends Controller
             // Localization Strings.
             'jobs_l10n' => Lang::get('manager/job_index'),
             // Data.
-            'job' => $jobPoster,
+            'job' => $jobPoster->toApiArray(),
             'applications' => $applications,
             'review_statuses' => ReviewStatus::all()
         ]);


### PR DESCRIPTION
The front-end Job interface was changed, and we forgot to change how this controller passed job data to match. Fixed now.