### PR TITLE
Changed new impact field so old jobs will be compatible with new views and job builder

### DIFF
--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -437,7 +437,7 @@ class JobController extends Controller
                 'en' => [
                     'city' => $input['city'],
                     'title' => $input['title']['en'],
-                    'impact' => $input['impact']['en'],
+                    'hire_impact' => $input['impact']['en'],
                     'branch' => $input['branch']['en'],
                     'division' => $input['division']['en'],
                     'education' => $input['education']['en'],
@@ -445,7 +445,7 @@ class JobController extends Controller
                 'fr' => [
                     'city' => $input['city'],
                     'title' => $input['title']['fr'],
-                    'impact' => $input['impact']['fr'],
+                    'hire_impact' => $input['impact']['fr'],
                     'branch' => $input['branch']['fr'],
                     'division' => $input['division']['fr'],
                     'education' => $input['education']['fr'],

--- a/app/Models/JobPoster.php
+++ b/app/Models/JobPoster.php
@@ -60,7 +60,6 @@ use \Backpack\CRUD\CrudTrait;
  * Localized Properties:
  * @property string $city
  * @property string $title
- * @property string $impact
  * @property string $team_impact
  * @property string $hire_impact
  * @property string $branch
@@ -94,7 +93,6 @@ class JobPoster extends BaseModel
     public $translatedAttributes = [
         'city',
         'title',
-        'impact',
         'team_impact',
         'hire_impact',
         'branch',
@@ -163,7 +161,6 @@ class JobPoster extends BaseModel
     ];
 
     // @codeCoverageIgnoreStart
-
     public function department() // phpcs:ignore
     {
         return $this->belongsTo(\App\Models\Lookup\Department::class);
@@ -253,9 +250,7 @@ class JobPoster extends BaseModel
     }
 
     // @codeCoverageIgnoreEnd
-
     // Accessors
-
     // Mutators
 
     /**
@@ -277,7 +272,6 @@ class JobPoster extends BaseModel
     }
 
     // Methods
-
     public function submitted_applications_count()
     {
         return $this->submitted_applications()->count();

--- a/app/Models/JobPosterTranslation.php
+++ b/app/Models/JobPosterTranslation.php
@@ -15,7 +15,6 @@ namespace App\Models;
  * @property string $locale
  * @property string $city
  * @property string $title
- * @property string $impact
  * @property string $team_impact
  * @property string $hire_impact
  * @property string $branch
@@ -26,14 +25,14 @@ namespace App\Models;
  *
  * @property \App\Models\JobPoster $job_poster
  */
-class JobPosterTranslation extends BaseModel {
+class JobPosterTranslation extends BaseModel
+{
 
     protected $casts = [
         'job_poster_id' => 'int',
         'locale' => 'string',
         'city' => 'string',
         'title' => 'string',
-        'impact' => 'string',
         'team_impact' => 'string',
         'hire_impact' => 'string',
         'branch' => 'string',
@@ -44,7 +43,6 @@ class JobPosterTranslation extends BaseModel {
         'locale',
         'city',
         'title',
-        'impact',
         'team_impact',
         'hire_impact',
         'branch',
@@ -52,8 +50,8 @@ class JobPosterTranslation extends BaseModel {
         'education'
     ];
 
-    public function job_poster() {
+    public function job_poster()
+    {
         return $this->belongsTo(\App\Models\JobPoster::class);
     }
-
 }

--- a/database/migrations/2019_06_18_145201_remove_hire_impact_from_job_posters.php
+++ b/database/migrations/2019_06_18_145201_remove_hire_impact_from_job_posters.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RemoveHireImpactFromJobPosters extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('job_poster_translations', function (Blueprint $table) {
+            $table->dropColumn('hire_impact');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('job_poster_translations', function (Blueprint $table) {
+            $table->text('hire_impact')->nullable();
+        });
+    }
+}

--- a/database/migrations/2019_06_18_145336_rename_impact_to_hire_impact_job_posters.php
+++ b/database/migrations/2019_06_18_145336_rename_impact_to_hire_impact_job_posters.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RenameImpactToHireImpactJobPosters extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('job_poster_translations', function (Blueprint $table) {
+            $table->renameColumn('impact', 'hire_impact');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('job_poster_translations', function (Blueprint $table) {
+            $table->renameColumn('hire_impact', 'impact');
+        });
+    }
+}

--- a/resources/assets/js/api/job.test.ts
+++ b/resources/assets/js/api/job.test.ts
@@ -29,7 +29,7 @@ describe("api/job", (): void => {
       submitted_applications_count: 0,
       city: "East Liashire",
       title: "I hadn't quite dull.",
-      impact:
+      hire_impact:
         "Delectus facilis nesciunt aut est distinctio sunt. Sunt minus sed minus quaerat eos.\n\nExcepturi voluptate nesciunt voluptatem et. Facilis occaecati iusto asperiores placeat vel dolores. Delectus magni inventore et eos. Ea ullam recusandae sunt accusantium.",
       branch: "eveniet",
       division: "et",
@@ -147,7 +147,7 @@ describe("api/job", (): void => {
           locale: "fr",
           city: "West Miloview",
           title: "White Rabbit noticed.",
-          impact:
+          hire_impact:
             "Fugiat temporibus provident sed accusantium est tenetur nisi. Qui nesciunt velit necessitatibus quam accusantium. Voluptatum aut sed qui soluta voluptatem.\n\nIpsam facilis aut qui et id eaque architecto. Et nihil aliquam suscipit. Dolor placeat voluptas velit velit laboriosam sed nostrum soluta.",
           branch: "omnis",
           division: "omnis",
@@ -161,7 +161,7 @@ describe("api/job", (): void => {
           locale: "en",
           city: "East Liashire",
           title: "I hadn't quite dull.",
-          impact:
+          hire_impact:
             "Delectus facilis nesciunt aut est distinctio sunt. Sunt minus sed minus quaerat eos.\n\nExcepturi voluptate nesciunt voluptatem et. Facilis occaecati iusto asperiores placeat vel dolores. Delectus magni inventore et eos. Ea ullam recusandae sunt accusantium.",
           branch: "eveniet",
           division: "et",
@@ -173,7 +173,7 @@ describe("api/job", (): void => {
       fr: {
         city: "West Miloview",
         title: "White Rabbit noticed.",
-        impact:
+        hire_impact:
           "Fugiat temporibus provident sed accusantium est tenetur nisi. Qui nesciunt velit necessitatibus quam accusantium. Voluptatum aut sed qui soluta voluptatem.\n\nIpsam facilis aut qui et id eaque architecto. Et nihil aliquam suscipit. Dolor placeat voluptas velit velit laboriosam sed nostrum soluta.",
         branch: "omnis",
         division: "omnis",
@@ -182,7 +182,7 @@ describe("api/job", (): void => {
       en: {
         city: "East Liashire",
         title: "I hadn't quite dull.",
-        impact:
+        hire_impact:
           "Delectus facilis nesciunt aut est distinctio sunt. Sunt minus sed minus quaerat eos.\n\nExcepturi voluptate nesciunt voluptatem et. Facilis occaecati iusto asperiores placeat vel dolores. Delectus magni inventore et eos. Ea ullam recusandae sunt accusantium.",
         branch: "eveniet",
         division: "et",
@@ -697,11 +697,9 @@ describe("api/job", (): void => {
       ],
     });
     it("Can parse a real example of a job response without throwing an error", (): void => {
-      expect(
-        (): void => {
-          parseJobResponse(jobResponse());
-        },
-      ).not.toThrow();
+      expect((): void => {
+        parseJobResponse(jobResponse());
+      }).not.toThrow();
     });
     it("Parses the close date correctly", (): void => {
       const expectDate = moment("2019-06-01T06:59:59+00:00").toDate();

--- a/resources/views/applicant/job_post/impact.html.twig
+++ b/resources/views/applicant/job_post/impact.html.twig
@@ -22,8 +22,8 @@
 
     <p>
         {{handleNullState(
-            job.impact,
-            job.impact|nl2br,
+            job.hire_impact,
+            job.hire_impact|nl2br,
             noInfo
         )}}
     </p>

--- a/resources/views/manager/job_create/form.html.twig
+++ b/resources/views/manager/job_create/form.html.twig
@@ -688,7 +688,7 @@
                         class="box med-1of2">
 
                         <div class="form__input-wrapper--float
-                            {% if job.translate('en').impact != null %}active{% endif %}">
+                            {% if job.translate('en').hire_impact != null %}active{% endif %}">
                             <label
                                 class="form__label"
                                 for="createJobImpactEN">
@@ -698,7 +698,7 @@
                                 {# required #}
                                 class="form__textarea"
                                 id="createJobImpactEN"
-                                name="impact[en]">{{ job.translate('en').impact }}</textarea>
+                                name="impact[en]">{{ job.translate('en').hire_impact }}</textarea>
                         </div>
 
                     </div>
@@ -707,7 +707,7 @@
                         class="box med-1of2">
 
                         <div class="form__input-wrapper--float
-                            {% if job.translate('fr').impact != null %}active{% endif %}">
+                            {% if job.translate('fr').hire_impact != null %}active{% endif %}">
                             <label class="form__label" for="createJobImpactFR">
                                  {{form_l10n.impact_french}}
                             </label>
@@ -715,7 +715,7 @@
                                 {# required #}
                                 class="form__textarea"
                                 id="createJobImpactFR"
-                                name="impact[fr]">{{ job.translate('fr').impact }}</textarea>
+                                name="impact[fr]">{{ job.translate('fr').hire_impact }}</textarea>
                         </div>
 
                     </div>

--- a/tests/Feature/JobControllerTest.php
+++ b/tests/Feature/JobControllerTest.php
@@ -80,7 +80,8 @@ class JobControllerTest extends TestCase
             'en' => $this->faker->word,
             'fr' => $this->faker_fr->word
         ],
-        'hire_impact' => [
+        // The form is named impact, but the controller saves it to the hire_impact field
+        'impact' => [
             'en' => $this->faker->paragraphs(
                 2,
                 true

--- a/tests/Feature/JobControllerTest.php
+++ b/tests/Feature/JobControllerTest.php
@@ -80,7 +80,7 @@ class JobControllerTest extends TestCase
             'en' => $this->faker->word,
             'fr' => $this->faker_fr->word
         ],
-        'impact' => [
+        'hire_impact' => [
             'en' => $this->faker->paragraphs(
                 2,
                 true
@@ -118,7 +118,7 @@ class JobControllerTest extends TestCase
      */
     private function generateCriteriaFormData(int $criteria_type_id, int $skill_id, int $skill_level_id, ?int $crtiteria_id = null)
     {
-        $age = $crtiteria_id ? "old" : "new";
+        $age = $crtiteria_id ? 'old' : 'new';
         $type = [1 => 'essential', 2 => 'asset'][$criteria_type_id];
         $id = $crtiteria_id ? $crtiteria_id : 1;
         $data['criteria'] = [
@@ -208,44 +208,38 @@ class JobControllerTest extends TestCase
         });
     }
 
-    //TODO: Managers cannot create job posters until Job Poster Builder is complete
-
+    // TODO: Managers cannot create job posters until Job Poster Builder is complete
     // /**
-    //  * Ensure a manager can view the create Job Poster form.
-    //  *
-    //  * @return void
-    //  */
+    // * Ensure a manager can view the create Job Poster form.
+    // *
+    // * @return void
+    // */
     // public function testManagerCreateView() : void
     // {
-    //     $response = $this->actingAs($this->manager->user)
-    //     ->get('manager/jobs/create');
-    //     $response->assertStatus(200);
-
-    //     $response->assertSee(e(Lang::get('manager/job_create')['title']));
-    //     $response->assertViewIs('manager.job_create');
-
-    //     $response->assertSee(e(Lang::get('manager/job_create', [], 'en')['questions']['00']));
-    //     $response->assertSee(e(Lang::get('manager/job_create', [], 'fr')['questions']['00']));
+    // $response = $this->actingAs($this->manager->user)
+    // ->get('manager/jobs/create');
+    // $response->assertStatus(200);
+    // $response->assertSee(e(Lang::get('manager/job_create')['title']));
+    // $response->assertViewIs('manager.job_create');
+    // $response->assertSee(e(Lang::get('manager/job_create', [], 'en')['questions']['00']));
+    // $response->assertSee(e(Lang::get('manager/job_create', [], 'fr')['questions']['00']));
     // }
-
     // /**
-    //  * Ensure a manager can create a Job Poster.
-    //  *
-    //  * @return void
-    //  */
+    // * Ensure a manager can create a Job Poster.
+    // *
+    // * @return void
+    // */
     // public function testManagerCreate() : void
     // {
-    //     $newJob = $this->generateEditJobFormData();
-
-    //     $dbValues = array_slice($newJob, 0, 8);
-
-    //     $response = $this->followingRedirects()
-    //     ->actingAs($this->manager->user)
-    //     ->post('manager/jobs/', $newJob);
-    //     $response->assertStatus(200);
-    //     $response->assertViewIs('applicant.job_post');
-    //     $this->assertDatabaseHas('job_posters', $dbValues);
-    //     $response->assertSee(e(Lang::get('applicant/job_post')['apply']['edit_link_title']));
+    // $newJob = $this->generateEditJobFormData();
+    // $dbValues = array_slice($newJob, 0, 8);
+    // $response = $this->followingRedirects()
+    // ->actingAs($this->manager->user)
+    // ->post('manager/jobs/', $newJob);
+    // $response->assertStatus(200);
+    // $response->assertViewIs('applicant.job_post');
+    // $this->assertDatabaseHas('job_posters', $dbValues);
+    // $response->assertSee(e(Lang::get('applicant/job_post')['apply']['edit_link_title']));
     // }
 
     /**
@@ -299,7 +293,7 @@ class JobControllerTest extends TestCase
         $response->assertSee(e($this->jobPoster->city));
         $response->assertSee(e($this->jobPoster->education));
         $response->assertSee(e($this->jobPoster->title));
-        $response->assertSee(e($this->jobPoster->impact));
+        $response->assertSee(e($this->jobPoster->hire_impact));
         $response->assertSee(e($this->jobPoster->branch));
         $response->assertSee(e($this->jobPoster->division));
         $response->assertSee(e($this->jobPoster->education));
@@ -383,12 +377,12 @@ class JobControllerTest extends TestCase
         $dateFormat = config('app.date_format')['en'];
         $timeFormat = config('app.time_format')['en'];
 
-        $expectedOpenDateTime = new Date("2019-01-01 00:00:00", new \DateTimeZone($jobTimezone));
+        $expectedOpenDateTime = new Date('2019-01-01 00:00:00', new \DateTimeZone($jobTimezone));
         $expectedOpenDateTime->setTimezone($localTimezone);
         $expectedOpenDate = $expectedOpenDateTime->format($dateFormat);
         $expectedOpenTime = $expectedOpenDateTime->format($timeFormat);
 
-        $expectedCloseDateTime = new Date("2019-01-31 23:59:59", new \DateTimeZone($jobTimezone));
+        $expectedCloseDateTime = new Date('2019-01-31 23:59:59', new \DateTimeZone($jobTimezone));
         $expectedCloseDateTime->setTimezone($localTimezone);
         $expectedCloseDate = $expectedCloseDateTime->format($dateFormat);
         $expectedCloseTime = $expectedCloseDateTime->format($timeFormat);
@@ -401,7 +395,7 @@ class JobControllerTest extends TestCase
         $jobEdit['open_date'] = '2019-01-01';
         $jobEdit['close_date'] = '2019-01-31';
 
-        //Expected db values
+        // Expected db values
         $dbValues = array_slice($jobEdit, 0, 8);
 
         $response = $this->followingRedirects()
@@ -440,7 +434,7 @@ class JobControllerTest extends TestCase
 
         // Check the criteria has been added to job
         $criteriaValues = [
-            'criteria_type_id' => 2, //asset
+            'criteria_type_id' => 2, // asset
             'job_poster_id' => $job->id,
             'skill_id' => 28,
             'skill_level_id' => 2
@@ -451,7 +445,7 @@ class JobControllerTest extends TestCase
         $notificationValues = [
             'type' => 'CREATE',
             'job_poster_id' => $job->id,
-            'criteria_type_id' => 2, //asset
+            'criteria_type_id' => 2, // asset
             'job_poster_id' => $job->id,
             'skill_id' => 28,
             'skill_id_new' => null,
@@ -565,13 +559,12 @@ class JobControllerTest extends TestCase
 
         $response = $this->actingAs($this->manager->user)
             ->post(route('manager.jobs.update', $job), $data);
-        //$response->assertStatus(200);
-
+        // $response->assertStatus(200);
         // Check the criteria has been removed
         $criteriaValues = [
             'id' => $criteria->id,
         ];
-        //print_r(Criteria::find($criteria->id) ? Criteria::find($criteria->id)->toArray() : "NULL");
+        // print_r(Criteria::find($criteria->id) ? Criteria::find($criteria->id)->toArray() : "NULL");
         $this->assertDatabaseMissing('criteria', $criteriaValues);
 
         // Check the AssessmentPlanNotification has been created


### PR DESCRIPTION
Deleted new hire_impact field, then renamed impact to hire_impact. Now hire_impact will be used in all instances instead of impact, making display of old jobs in new views easier.