### PR TITLE
Add View Application button to completed and expired draft applications

### DIFF
--- a/resources/views/applicant/application_index/application.html.twig
+++ b/resources/views/applicant/application_index/application.html.twig
@@ -71,21 +71,17 @@
             </a>
         </div>
 
-        {# If the job poster has expired then do not show link to user #}
-        {% if item.job_poster.close_date_time.isPast() %}
-
-            {# Do nothing #}
-
-        {# If the job poster has not expired, but is in draft status #}
-        {% elseif item.application_status.name == "draft" %}
+        {# If the job poster application is in draft status #}
+        {% if item.application_status.name == "draft" %}
+        {% set expired = item.job_poster.close_date_time.isPast() %}
 
             <div class="box lg-2of9">
 
                 <a
                     class="button--blue light-bg"
-                    href={{ route('job.application.edit.1', item.job_poster) }}
-                    title="{{ application_index.draft_link_title }}">
-                    {{ application_index.draft_link_label }}
+                    href={{ expired ? route('applications.show', item) : route('job.application.edit.1', item.job_poster) }}
+                    title="{{ expired ? application_index.view_link_title : application_index.draft_link_title }}">
+                    {{ expired ? application_index.view_link_label : application_index.draft_link_label }}
                 </a>
 
             </div>
@@ -108,10 +104,10 @@
 
         {% if item.application_status.name == "draft"  %}
 
-            <div class="box lg-1of9 {% if item.job_poster.close_date_time.isPast() %}expired{% endif %}">
+            <div class="box lg-1of9">
 
                 <button
-                    class="modal-trigger {% if item.job_poster.close_date_time.isPast() %}expired{% endif %}"
+                    class="modal-trigger{% if item.job_poster.close_date_time.isPast() %} expired{% endif %}"
                     data-modal-id="deleteTrash"
                     title="{{ application_index.delete_title }}"
                     type="button">

--- a/resources/views/common/application/view/view_sidebar.html.twig
+++ b/resources/views/common/application/view/view_sidebar.html.twig
@@ -43,19 +43,6 @@
             {{ application_template.preview.sidebar.item_04 }}
         </a>
 
-        {% if job_application.application_status_id == "2" %}
-
-        {% else %}
-
-            <a
-                class="sidebar-link"
-                href="#applicationView05"
-                title="">
-                {{ application_template.preview.sidebar.item_05 }}
-            </a>
-
-        {% endif %}
-
     </nav>
 
 </div>


### PR DESCRIPTION
Resolves #872

### Notes:
- Adds `View Application` button back to all sections, regardless of the status of the application
- Removes the `Submit` option from the application preview sidebar, as there was no corresponding template to render anyway
