### PR TITLE
Fix bug in WhichPortal, and add regression tests

### DIFF
--- a/app/Models/JobPoster.php
+++ b/app/Models/JobPoster.php
@@ -341,9 +341,9 @@ class JobPoster extends BaseModel
      *
      * @param mixed $value Incoming attribute value.
      *
-     * @return string
+     * @return string|null
      */
-    public function getClassificationAttribute($value) : string
+    public function getClassificationAttribute($value)
     {
         if (!empty($this->classification_code) && !empty($this->classification_level)) {
             return "$this->classification_code-$this->classification_level";

--- a/app/Services/WhichPortal.php
+++ b/app/Services/WhichPortal.php
@@ -16,6 +16,14 @@ class WhichPortal
     public function isManagerPortal()
     {
         $url = URL::current();
-        return str_is('*/manager/*', $url);
+        return $this->urlIsManagerPortal($url);
+    }
+
+    public function urlIsManagerPortal($url): bool
+    {
+        $baseUrl = config('app.url');
+        $managerPrefix = config('app.manager_prefix');
+        $managerPattern = "#^$baseUrl/(\w+/)?$managerPrefix(/.*)?$#";
+        return preg_match($managerPattern, $url);
     }
 }

--- a/tests/Unit/WhichPortalTest.php
+++ b/tests/Unit/WhichPortalTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Facades\App\Services\WhichPortal;
+
+class WhichPortalTest extends TestCase
+{
+    public function testApplicantUrls(): void
+    {
+        $baseUrl = config('app.url');
+        $this->assertFalse(WhichPortal::urlIsManagerPortal("$baseUrl"));
+        $this->assertFalse(WhichPortal::urlIsManagerPortal("$baseUrl/en"));
+        $this->assertFalse(WhichPortal::urlIsManagerPortal("$baseUrl/en/"));
+        $this->assertFalse(WhichPortal::urlIsManagerPortal("$baseUrl/fr/"));
+        $this->assertFalse(WhichPortal::urlIsManagerPortal("$baseUrl/jobs"));
+        $this->assertFalse(WhichPortal::urlIsManagerPortal("$baseUrl/jobs/"));
+        $this->assertFalse(WhichPortal::urlIsManagerPortal("$baseUrl/en/jobs"));
+        $this->assertFalse(WhichPortal::urlIsManagerPortal("$baseUrl/en/jobs/"));
+        $this->assertFalse(WhichPortal::urlIsManagerPortal("$baseUrl/managers"));
+        $this->assertFalse(WhichPortal::urlIsManagerPortal("$baseUrl/managers/"));
+        $this->assertFalse(WhichPortal::urlIsManagerPortal("$baseUrl/en/managers"));
+        $this->assertFalse(WhichPortal::urlIsManagerPortal("$baseUrl/en/managers/"));
+        $this->assertFalse(WhichPortal::urlIsManagerPortal("$baseUrl/en/managers/12"));
+    }
+
+    public function testManagerUrls(): void
+    {
+        $baseUrl = config('app.url');
+        $managerPrefix = config('app.manager_prefix');
+        $this->assertTrue(WhichPortal::urlIsManagerPortal("$baseUrl/$managerPrefix"));
+        $this->assertTrue(WhichPortal::urlIsManagerPortal("$baseUrl/$managerPrefix/"));
+        $this->assertTrue(WhichPortal::urlIsManagerPortal("$baseUrl/en/$managerPrefix"));
+        $this->assertTrue(WhichPortal::urlIsManagerPortal("$baseUrl/fr/$managerPrefix"));
+        $this->assertTrue(WhichPortal::urlIsManagerPortal("$baseUrl/en_CA/$managerPrefix"));
+        $this->assertTrue(WhichPortal::urlIsManagerPortal("$baseUrl/es/$managerPrefix"));
+        $this->assertTrue(WhichPortal::urlIsManagerPortal("$baseUrl/en/$managerPrefix/"));
+        $this->assertTrue(WhichPortal::urlIsManagerPortal("$baseUrl/en/$managerPrefix/jobs"));
+        $this->assertTrue(WhichPortal::urlIsManagerPortal("$baseUrl/en/$managerPrefix/jobs/"));
+    }
+}


### PR DESCRIPTION
After recent changes, WhichPortal was falsely determining that the Manager homepage was the applicant portal (because there was no trailing backslash on the url).