### PR TITLE
Set the intl text component to React.Fragment in storybook stories

### DIFF
--- a/.storybook/config.ts
+++ b/.storybook/config.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { addParameters, configure, addDecorator } from "@storybook/react";
 import { themes } from "@storybook/theming";
 import { addLocaleData } from "react-intl";
@@ -54,6 +55,7 @@ setIntlConfig({
     locales: ["en", "fr"],
     defaultLocale: "en",
     getMessages,
+    textComponent: React.Fragment,
 });
 
 


### PR DESCRIPTION
The default tag to render out translated text is `<span>`, causing extra markup to be added to translated components in storybook
