### PR TITLE
Fix Modal rendering/scrolling issues

### DIFF
--- a/resources/assets/js/components/JobBuilderImpact/JobBuilderImpact.tsx
+++ b/resources/assets/js/components/JobBuilderImpact/JobBuilderImpact.tsx
@@ -330,64 +330,62 @@ const JobBuilderImpact: React.FunctionComponent<
                   </button>
                 </div>
               </Form>
-              {isModalVisible && (
-                <Modal
-                  id={modalId}
-                  parentElement={modalParentRef.current}
-                  visible={isModalVisible}
-                  onModalConfirm={(): void => {
-                    handleModalConfirm();
-                    setIsModalVisible(false);
-                  }}
-                  onModalCancel={(): void => {
-                    handleModalCancel();
-                    setIsModalVisible(false);
-                  }}
-                >
-                  <Modal.Header>
-                    <div
-                      data-c-background="c1(100)"
-                      data-c-border="bottom(thin, solid, black)"
-                      data-c-padding="normal"
+              <Modal
+                id={modalId}
+                parentElement={modalParentRef.current}
+                visible={isModalVisible}
+                onModalConfirm={(): void => {
+                  handleModalConfirm();
+                  setIsModalVisible(false);
+                }}
+                onModalCancel={(): void => {
+                  handleModalCancel();
+                  setIsModalVisible(false);
+                }}
+              >
+                <Modal.Header>
+                  <div
+                    data-c-background="c1(100)"
+                    data-c-border="bottom(thin, solid, black)"
+                    data-c-padding="normal"
+                  >
+                    <h5
+                      data-c-colour="white"
+                      data-c-font-size="h4"
+                      id={`${modalId}-title`}
                     >
-                      <h5
-                        data-c-colour="white"
-                        data-c-font-size="h4"
-                        id={`${modalId}-title`}
-                      >
-                        {/* TODO: Localize Title, Description, and Button Text */}
-                        Awesome work!
-                      </h5>
-                    </div>
-                  </Modal.Header>
-                  <Modal.Body>
-                    <div
-                      data-c-border="bottom(thin, solid, black)"
-                      data-c-padding="normal"
-                      id={`${modalId}-description`}
-                    >
-                      Here&apos;s a preview of the Impact Statement you just
-                      entered. Feel free to go back and edit things or move to
-                      the next step if you&apos;re happy with it.
-                    </div>
-                    <div
-                      data-c-background="grey(20)"
-                      data-c-border="bottom(thin, solid, black)"
-                      data-c-padding="normal"
-                    >
-                      <JobImpactPreview
-                        deptImpact={deptImpacts[locale]}
-                        teamImpact={values.teamImpact}
-                        hireImpact={values.hireImpact}
-                      />
-                    </div>
-                  </Modal.Body>
-                  <Modal.Footer>
-                    <Modal.FooterCancelBtn>Go Back</Modal.FooterCancelBtn>
-                    <Modal.FooterConfirmBtn>Next Step</Modal.FooterConfirmBtn>
-                  </Modal.Footer>
-                </Modal>
-              )}
+                      {/* TODO: Localize Title, Description, and Button Text */}
+                      Awesome work!
+                    </h5>
+                  </div>
+                </Modal.Header>
+                <Modal.Body>
+                  <div
+                    data-c-border="bottom(thin, solid, black)"
+                    data-c-padding="normal"
+                    id={`${modalId}-description`}
+                  >
+                    Here&apos;s a preview of the Impact Statement you just
+                    entered. Feel free to go back and edit things or move to the
+                    next step if you&apos;re happy with it.
+                  </div>
+                  <div
+                    data-c-background="grey(20)"
+                    data-c-border="bottom(thin, solid, black)"
+                    data-c-padding="normal"
+                  >
+                    <JobImpactPreview
+                      deptImpact={deptImpacts[locale]}
+                      teamImpact={values.teamImpact}
+                      hireImpact={values.hireImpact}
+                    />
+                  </div>
+                </Modal.Body>
+                <Modal.Footer>
+                  <Modal.FooterCancelBtn>Go Back</Modal.FooterCancelBtn>
+                  <Modal.FooterConfirmBtn>Next Step</Modal.FooterConfirmBtn>
+                </Modal.Footer>
+              </Modal>
             </>
           )}
         />

--- a/resources/assets/js/components/JobBuilderWorkEnv/WorkEnvForm.tsx
+++ b/resources/assets/js/components/JobBuilderWorkEnv/WorkEnvForm.tsx
@@ -1144,27 +1144,25 @@ const WorkEnvForm = ({
                 </button>
               </div>
             </Form>
-            {isModalVisible && (
-              <WorkEnvModal
-                modalConfirm={(): void => {
-                  setIsModalVisible(false);
-                  handleModalConfirm();
-                }}
-                modalCancel={(): void => {
-                  setIsModalVisible(false);
-                  handleModalCancel();
-                }}
-                isVisible={isModalVisible}
-                parentElement={modalParentRef.current}
-                values={values}
-                cultureSummary={
-                  values.cultureSummary || buildCultureSummary(values)
-                }
-                physEnvData={phyEnvData}
-                techData={techData}
-                amenitiesData={amenitiesData}
-              />
-            )}
+            <WorkEnvModal
+              modalConfirm={(): void => {
+                setIsModalVisible(false);
+                handleModalConfirm();
+              }}
+              modalCancel={(): void => {
+                setIsModalVisible(false);
+                handleModalCancel();
+              }}
+              isVisible={isModalVisible}
+              parentElement={modalParentRef.current}
+              values={values}
+              cultureSummary={
+                values.cultureSummary || buildCultureSummary(values)
+              }
+              physEnvData={phyEnvData}
+              techData={techData}
+              amenitiesData={amenitiesData}
+            />
           </>
         )}
       />

--- a/resources/assets/js/components/JobDetails/JobDetails.tsx
+++ b/resources/assets/js/components/JobDetails/JobDetails.tsx
@@ -888,95 +888,93 @@ const JobDetails: React.FunctionComponent<
                   </button>
                 </div>
               </Form>
-              {isModalVisible && (
-                <Modal
-                  id="job-details-preview"
-                  parentElement={modalParentRef.current}
-                  visible={isModalVisible}
-                  onModalConfirm={(): void => {
-                    handleModalConfirm();
-                    setIsModalVisible(false);
-                  }}
-                  onModalCancel={(): void => {
-                    handleModalCancel();
-                    setIsModalVisible(false);
-                  }}
-                >
-                  <Modal.Header>
-                    <div
-                      data-c-background="c1(100)"
-                      data-c-border="bottom(thin, solid, black)"
-                      data-c-padding="normal"
-                    >
-                      <h5
-                        data-c-colour="white"
-                        data-c-font-size="h4"
-                        id="job-details-preview-title"
-                      >
-                        <FormattedMessage
-                          id="jobDetails.modalHeader"
-                          defaultMessage="You're off to a great start!"
-                          description="The text displayed in the header of the Job Details modal."
-                        />
-                      </h5>
-                    </div>
-                  </Modal.Header>
-                  <Modal.Body>
-                    <div
-                      data-c-border="bottom(thin, solid, black)"
-                      data-c-padding="normal"
-                      id="job-details-preview-description"
+              <Modal
+                id="job-details-preview"
+                parentElement={modalParentRef.current}
+                visible={isModalVisible}
+                onModalConfirm={(): void => {
+                  handleModalConfirm();
+                  setIsModalVisible(false);
+                }}
+                onModalCancel={(): void => {
+                  handleModalCancel();
+                  setIsModalVisible(false);
+                }}
+              >
+                <Modal.Header>
+                  <div
+                    data-c-background="c1(100)"
+                    data-c-border="bottom(thin, solid, black)"
+                    data-c-padding="normal"
+                  >
+                    <h5
+                      data-c-colour="white"
+                      data-c-font-size="h4"
+                      id="job-details-preview-title"
                     >
                       <FormattedMessage
-                        id="jobDetails.modalBody"
-                        defaultMessage="Here's a preview of the Job Information you just entered. Feel free to go back and edit things or move to the next step if you're happy with it."
-                        description="The text displayed in the body of the Job Details modal."
+                        id="jobDetails.modalHeader"
+                        defaultMessage="You're off to a great start!"
+                        description="The text displayed in the header of the Job Details modal."
                       />
-                    </div>
-                    <div
-                      data-c-background="grey(20)"
-                      data-c-border="bottom(thin, solid, black)"
-                      data-c-padding="normal"
-                    >
-                      {/* TODO: Pull in the signed-in Manager's department */}
-                      <JobPreview
-                        title={values.title}
-                        department="Department"
-                        remoteWork={values.remoteWork !== "remoteWorkNone"}
-                        language={intl.formatMessage(
-                          languageRequirement(Number(values.language)),
-                        )}
-                        city={values.city}
-                        province={intl.formatMessage(
-                          provinceName(Number(values.province)),
-                        )}
-                        termLength={Number(values.termLength)}
-                        securityLevel={intl.formatMessage(
-                          securityClearance(Number(values.securityLevel)),
-                        )}
-                        classification={String(values.classification)}
-                        level={String(values.level)}
-                      />
-                    </div>
-                  </Modal.Body>
-                  <Modal.Footer>
-                    <Modal.FooterCancelBtn>
-                      <FormattedMessage
-                        id="jobDetails.modalCancelLabel"
-                        defaultMessage="Go Back"
-                        description="The text displayed on the cancel button of the Job Details modal."
-                      />
-                    </Modal.FooterCancelBtn>
-                    <Modal.FooterConfirmBtn>
-                      <FormattedMessage
-                        id="jobDetails.modalConfirmLabel"
-                        defaultMessage="Next Step"
-                        description="The text displayed on the confirm button of the Job Details modal."
-                      />
-                    </Modal.FooterConfirmBtn>
-                  </Modal.Footer>
-                </Modal>
-              )}
+                    </h5>
+                  </div>
+                </Modal.Header>
+                <Modal.Body>
+                  <div
+                    data-c-border="bottom(thin, solid, black)"
+                    data-c-padding="normal"
+                    id="job-details-preview-description"
+                  >
+                    <FormattedMessage
+                      id="jobDetails.modalBody"
+                      defaultMessage="Here's a preview of the Job Information you just entered. Feel free to go back and edit things or move to the next step if you're happy with it."
+                      description="The text displayed in the body of the Job Details modal."
+                    />
+                  </div>
+                  <div
+                    data-c-background="grey(20)"
+                    data-c-border="bottom(thin, solid, black)"
+                    data-c-padding="normal"
+                  >
+                    {/* TODO: Pull in the signed-in Manager's department */}
+                    <JobPreview
+                      title={values.title}
+                      department="Department"
+                      remoteWork={values.remoteWork !== "remoteWorkNone"}
+                      language={intl.formatMessage(
+                        languageRequirement(Number(values.language)),
+                      )}
+                      city={values.city}
+                      province={intl.formatMessage(
+                        provinceName(Number(values.province)),
+                      )}
+                      termLength={Number(values.termLength)}
+                      securityLevel={intl.formatMessage(
+                        securityClearance(Number(values.securityLevel)),
+                      )}
+                      classification={String(values.classification)}
+                      level={String(values.level)}
+                    />
+                  </div>
+                </Modal.Body>
+                <Modal.Footer>
+                  <Modal.FooterCancelBtn>
+                    <FormattedMessage
+                      id="jobDetails.modalCancelLabel"
+                      defaultMessage="Go Back"
+                      description="The text displayed on the cancel button of the Job Details modal."
+                    />
+                  </Modal.FooterCancelBtn>
+                  <Modal.FooterConfirmBtn>
+                    <FormattedMessage
+                      id="jobDetails.modalConfirmLabel"
+                      defaultMessage="Next Step"
+                      description="The text displayed on the confirm button of the Job Details modal."
+                    />
+                  </Modal.FooterConfirmBtn>
+                </Modal.Footer>
+              </Modal>
             </>
           )}
         />

--- a/resources/assets/js/components/Modal.tsx
+++ b/resources/assets/js/components/Modal.tsx
@@ -29,7 +29,7 @@ export default function Modal({
   children,
   onModalConfirm,
   onModalCancel,
-}: ModalProps): React.ReactPortal {
+}: ModalProps): React.ReactPortal | null {
   // Set up div ref to measure modal height
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -92,7 +92,7 @@ export default function Modal({
         height > viewportHeight ? "active--overflowing" : "active--contained",
       );
     }
-  }, [children]);
+  }, [children, visible]);
 
   // Adds various key commands to the modal
   useEffect((): (() => void) => {
@@ -110,29 +110,38 @@ export default function Modal({
         document.removeEventListener("keydown", keyListener);
       }
     };
-  }, [visible]);
+  }, [keyListenersMap, visible]);
 
-  return createPortal(
-    <div
-      aria-describedby={`${id}-description`}
-      aria-hidden={!visible}
-      aria-labelledby={`${id}-title`}
-      data-c-dialog={visible ? overflow : ""}
-      data-c-dialog-id={id}
-      data-c-padding="top(double) bottom(double)"
-      role="dialog"
-      ref={modalRef}
-    >
-      <div data-c-background="white(100)" data-c-radius="rounded">
-        <modalContext.Provider
-          value={{ id, parentElement, visible, onModalConfirm, onModalCancel }}
-        >
-          {children}
-        </modalContext.Provider>
-      </div>
-    </div>,
-    parentElement || document.body,
-  );
+  if (parentElement !== null) {
+    return createPortal(
+      <div
+        aria-describedby={`${id}-description`}
+        aria-hidden={!visible}
+        aria-labelledby={`${id}-title`}
+        data-c-dialog={visible ? overflow : ""}
+        data-c-padding="top(double) bottom(double)"
+        role="dialog"
+        ref={modalRef}
+      >
+        <div data-c-background="white(100)" data-c-radius="rounded">
+          <modalContext.Provider
+            value={{
+              id,
+              parentElement,
+              visible,
+              onModalConfirm,
+              onModalCancel,
+            }}
+          >
+            {children}
+          </modalContext.Provider>
+        </div>
+      </div>,
+      parentElement,
+    );
+  }
+
+  return null;
 }
 
 Modal.Header = function ModalHeader(props): React.ReactElement {
@@ -155,14 +164,13 @@ Modal.Footer = function ModalFooter(props): React.ReactElement {
 };
 
 Modal.FooterConfirmBtn = function ConfirmBtn(props): React.ReactElement {
-  const { id, onModalConfirm } = useContext(modalContext);
+  const { onModalConfirm } = useContext(modalContext);
   return (
     <div data-c-alignment="base(right)" data-c-grid-item="base(1of2)">
       <button
         {...props}
         data-c-button="solid(c1)"
         data-c-dialog-action="close"
-        data-c-dialog-id={id}
         data-c-radius="rounded"
         type="button"
         onClick={onModalConfirm}
@@ -172,14 +180,13 @@ Modal.FooterConfirmBtn = function ConfirmBtn(props): React.ReactElement {
 };
 
 Modal.FooterCancelBtn = function CancelBtn(props): React.ReactElement {
-  const { id, onModalCancel } = useContext(modalContext);
+  const { onModalCancel } = useContext(modalContext);
   return (
     <div data-c-grid-item="base(1of2)">
       <button
         {...props}
         data-c-button="outline(c1)"
         data-c-dialog-action="close"
-        data-c-dialog-id={id}
         data-c-radius="rounded"
         type="button"
         onClick={onModalCancel}


### PR DESCRIPTION
### Notes:
Couple things were happening with the modals:

1. The render method had a createPortal call that was looking for `parentElement || document.body` to get around typescript issues with a possibly null `parentElement`. This caused the Modal markup to be added twice, once to the `<body>` tag and again wherever it was supposed to live once the DOM settled.
2. Conditionally rendering the Modal with `isModalVisible` would remove it from the DOM on a state change, preventing the `useEffect` call that would release the body scrolling from running.

I also removed the `data-c-dialog-id` attributes to avoid collisions with Clone's Javascript file.

Can test with storybook. Modals should no longer lock scrolling after being closed, and there shouldn't be duplicate markup underneath the actual story.
