### PR TITLE
Remove Firefox from the testcafe-ci script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
   - npm run testcafe-ci
   # unit tests
   - make phpunit
-  - make jest
+  - npm run test
 
 after_script:
   # send report to codecov.io

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "storybook": "start-storybook -s ./public -p 1234",
     "snapshot-update": "jest --updateSnapshot",
     "testcafe": "testcafe all tests/Browser/*.js -S -s tests/Browser/screenshots -u -e",
-    "testcafe-ci": "testcafe chrome:headless,firefox:headless tests/Browser/*.js -u -e",
+    "testcafe-ci": "testcafe chrome:headless tests/Browser/*.js -u -e",
     "translations:extract": "cross-env NODE_ENV=development node_modules/.bin/babel ./resources/assets/js --extensions '.js,.jsx,.ts,.tsx'",
     "translations:check": "node ./translationRunner.js",
     "translations": "npm run translations:extract && npm run translations:check"

--- a/tests/Unit/Helpers/HelperTest.php
+++ b/tests/Unit/Helpers/HelperTest.php
@@ -34,18 +34,18 @@ class HelperTest extends TestCase
         $diff = humanizeDateDiff($dateToTest);
         $this->assertEquals('5 Days', $diff);
 
-        $dateToTest = Date::parse('-32 minutes');
+        $dateToTest = Date::parse('-33 minutes 15 seconds');
         $diff = humanizeDateDiff($dateToTest);
         $this->assertEquals('32 Minutes', $diff);
 
-        $dateToTest = Date::parse('10 hours');
-        $reference = Date::parse('23 hours');
+        $dateToTest = Date::parse('10 hours 10 minutes 15 seconds');
+        $reference = Date::parse('23 hours 10 minutes 15 seconds');
         $diff = humanizeDateDiff($dateToTest, $reference);
         $this->assertEquals('13 Hours', $diff);
 
-        /**  Test to show now negative time difference is rounded down, 12:59:59 is being rounded to 12 Hours */
-        $dateToTest = Date::parse('10 hours');
-        $reference = Date::parse('-3 hours');
+        // Test to show now negative time difference is rounded down, 12:59:59 is being rounded to 12 Hours.
+        $dateToTest = Date::parse('9 hours 49 minutes 49 seconds');
+        $reference = Date::parse('-3 hours 1 minute 1 second');
         $diff = humanizeDateDiff($dateToTest, $reference);
         $this->assertEquals('12 Hours', $diff);
     }


### PR DESCRIPTION
Firefox seems to have intermittent issues with selectors on the page that Chrome does not. Removing for now.