### PR TITLE
Fix intermittent failing Job Poster status test

### DIFF
--- a/database/factories/JobPosterFactory.php
+++ b/database/factories/JobPosterFactory.php
@@ -112,7 +112,7 @@ $factory->state(
         return [
             'published' => true,
             'published_at' => $faker->dateTimeBetween('-1 months', '-3 weeks'),
-            'close_date_time' => ptDayEndToUtcTime($faker->dateTimeBetween('-2 days', '-1 days')->format('Y-m-d')),
+            'close_date_time' => ptDayEndToUtcTime($faker->dateTimeBetween('-5 days', '-3 days')->format('Y-m-d')),
         ];
     }
 );


### PR DESCRIPTION
### Notes:
Our PT day end to UTC function returns 6:59:59 UTC for the close time for the Job Poster. If the test suite runs around 6:58:00 UTC the close time is in the future, which sets a 'published' status instead of a 'closed' status. I just moved the factory day to be a couple days in the past instead of one.