### PR TITLE
Use client-side routing to navigate from JPB Details page

### DIFF
--- a/resources/assets/js/components/JobBuilderIntro/JobBuilderIntro.tsx
+++ b/resources/assets/js/components/JobBuilderIntro/JobBuilderIntro.tsx
@@ -68,7 +68,6 @@ const JobBuilderIntro: React.FunctionComponent<
   const handleSubmit = job ? handleUpdateJob : handleCreateJob;
 
   const handleContinueEn = (newJob: Job): void => {
-    // window.location.href = jobBuilderDetails("en", newJob.id);
     navigate(jobBuilderDetails("en", newJob.id));
   };
   const handleContinueFr = (newJob: Job): void => {

--- a/resources/assets/js/components/JobDetails/JobDetailsPage.tsx
+++ b/resources/assets/js/components/JobDetails/JobDetailsPage.tsx
@@ -52,7 +52,7 @@ const JobDetailsPage: React.FunctionComponent<
   const handleModalCancel = (): void => {};
   const handleModalConfirm = (): void => {
     if (job) {
-      window.location.href = jobBuilderEnv(intl.locale, jobId);
+      navigate(jobBuilderEnv(intl.locale, jobId));
     }
   };
   const handleSubmit = handleUpdateJob;
@@ -61,7 +61,7 @@ const JobDetailsPage: React.FunctionComponent<
   };
   const handleSkipToReview = async (): Promise<void> => {
     if (jobId !== null) {
-      window.location.href = jobBuilderReview(locale, jobId);
+      navigate(jobBuilderReview(locale, jobId));
     }
   };
 


### PR DESCRIPTION
The details step was missing the internal navigation that the other steps already have.