### PR TITLE
Copy / Null State Fixes

### DIFF
--- a/resources/assets/js/components/JobBuilderImpact/JobBuilderImpact.tsx
+++ b/resources/assets/js/components/JobBuilderImpact/JobBuilderImpact.tsx
@@ -424,9 +424,11 @@ const JobBuilderImpact: React.FunctionComponent<
                     data-c-padding="normal"
                     id={`${modalId}-description`}
                   >
+                    <p>
                     Here&apos;s a preview of the Impact Statement you just
                     entered. Feel free to go back and edit things or move to the
                     next step if you&apos;re happy with it.
+                    </p>
                   </div>
                   <div
                     data-c-background="grey(20)"

--- a/resources/assets/js/components/JobBuilderSkills/JobBuilderSkills.tsx
+++ b/resources/assets/js/components/JobBuilderSkills/JobBuilderSkills.tsx
@@ -1680,6 +1680,7 @@ export const JobBuilderSkills: React.FunctionComponent<
               data-c-padding="normal"
               id={`${previewModalId}-description`}
             >
+              <p>
               <FormattedMessage
                 id="jobBuilder.skills.description.keepItUp"
                 defaultMessage="Here's a preview of the Skills you just entered. Feel free to
@@ -1687,6 +1688,7 @@ export const JobBuilderSkills: React.FunctionComponent<
                 happy with it."
                 description="Body text of Keep it up! Modal"
               />
+              </p>
             </div>
 
             <div data-c-background="grey(20)" data-c-padding="normal">
@@ -1709,20 +1711,30 @@ export const JobBuilderSkills: React.FunctionComponent<
                     description="Section Header in Modal"
                   />
                 </h4>
-                {essentialCriteria.map(
-                  (criterion): React.ReactElement | null => {
-                    const skill = getSkillOfCriteria(criterion);
-                    if (skill === null) {
-                      return null;
-                    }
-                    return (
-                      <Criterion
-                        criterion={criterion}
-                        skill={skill}
-                        key={criterion.id}
-                      />
-                    );
-                  },
+                {essentialCriteria.length === 0 ? (
+                  <p>
+                    <FormattedMessage
+                      id="jobBuilder.skills.nullState"
+                      defaultMessage="You haven't added any skills yet."
+                      description="The text displayed in the skills modal when you haven't added any skills."
+                    />
+                  </p>
+                ) : (
+                  essentialCriteria.map(
+                    (criterion): React.ReactElement | null => {
+                      const skill = getSkillOfCriteria(criterion);
+                      if (skill === null) {
+                        return null;
+                      }
+                      return (
+                        <Criterion
+                          criterion={criterion}
+                          skill={skill}
+                          key={criterion.id}
+                        />
+                      );
+                    },
+                  )
                 )}
                 <h4
                   data-c-border="bottom(thin, solid, black)"
@@ -1737,19 +1749,31 @@ export const JobBuilderSkills: React.FunctionComponent<
                     description="Section Header in Modal"
                   />
                 </h4>
-                {assetCriteria.map((criterion): React.ReactElement | null => {
-                  const skill = getSkillOfCriteria(criterion);
-                  if (skill === null) {
-                    return null;
-                  }
-                  return (
-                    <Criterion
-                      criterion={criterion}
-                      skill={skill}
-                      key={criterion.id}
+                {assetCriteria.length === 0 ? (
+                  <p>
+                    <FormattedMessage
+                      id="jobBuilder.skills.nullState"
+                      defaultMessage="You haven't added any skills yet."
+                      description="The text displayed in the skills modal when you haven't added any skills."
                     />
-                  );
-                })}
+                  </p>
+                ) : (
+                  assetCriteria.map(
+                    (criterion): React.ReactElement | null => {
+                      const skill = getSkillOfCriteria(criterion);
+                      if (skill === null) {
+                        return null;
+                      }
+                      return (
+                        <Criterion
+                          criterion={criterion}
+                          skill={skill}
+                          key={criterion.id}
+                        />
+                      );
+                    },
+                  )
+                )}
               </div>
             </div>
           </div>

--- a/resources/assets/js/components/JobBuilderWorkEnv/WorkEnvModal.tsx
+++ b/resources/assets/js/components/JobBuilderWorkEnv/WorkEnvModal.tsx
@@ -60,6 +60,7 @@ const WorkEnvModal: React.FunctionComponent<WorkEnvModalProps> = ({
             data-c-padding="normal"
             id="work-environment-preview-body"
           >
+            <p>
             <FormattedMessage
               id="jobBuilder.workEnv.openingSentence"
               defaultMessage="Here's a preview of the Job Information you just entered. Feel
@@ -67,6 +68,7 @@ const WorkEnvModal: React.FunctionComponent<WorkEnvModalProps> = ({
                 you're happy with it."
               description="Opening sentence for modal."
             />
+            </p>
           </div>
           <div data-c-background="grey(20)" data-c-padding="normal">
             <div

--- a/resources/assets/js/components/JobDetails/JobDetails.tsx
+++ b/resources/assets/js/components/JobDetails/JobDetails.tsx
@@ -1003,11 +1003,13 @@ const JobDetails: React.FunctionComponent<
                     data-c-padding="normal"
                     id="job-details-preview-description"
                   >
+                    <p>
                     <FormattedMessage
                       id="jobDetails.modalBody"
                       defaultMessage="Here's a preview of the Job Information you just entered. Feel free to go back and edit things or move to the next step if you're happy with it."
                       description="The text displayed in the body of the Job Details modal."
                     />
+                    </p>
                   </div>
                   <div
                     data-c-background="grey(20)"

--- a/resources/assets/js/components/JobReview/JobReview.tsx
+++ b/resources/assets/js/components/JobReview/JobReview.tsx
@@ -553,19 +553,31 @@ export const JobReview: React.FunctionComponent<
           linkLabel={intl.formatMessage(messages.skillsEditLink)}
           link={jobBuilderSkills(locale, job.id)}
         >
-          {essentialCriteria.map((criterion): React.ReactElement | null => {
-            const skill = getSkillOfCriteria(criterion);
-            if (skill === null) {
-              return null;
-            }
-            return (
-              <Criterion
-                criterion={criterion}
-                skill={skill}
-                key={criterion.id}
+          {essentialCriteria.length === 0 ? (
+            <p>
+              <FormattedMessage
+                id="jobBuilder.review.skills.nullState"
+                defaultMessage="You haven't added any Nice to Have skills to this poster."
+                description="The text displayed for skills when you haven't added any skills."
               />
-            );
-          })}
+            </p>
+          ) : (
+            essentialCriteria.map(
+              (criterion): React.ReactElement | null => {
+                const skill = getSkillOfCriteria(criterion);
+                if (skill === null) {
+                  return null;
+                }
+                return (
+                  <Criterion
+                    criterion={criterion}
+                    skill={skill}
+                    key={criterion.id}
+                  />
+                );
+              },
+            )
+          )}
         </JobReviewSection>
         <JobReviewSection
           title={intl.formatMessage(messages.assetHeading)}

--- a/resources/assets/js/components/JobReview/JobReview.tsx
+++ b/resources/assets/js/components/JobReview/JobReview.tsx
@@ -573,19 +573,31 @@ export const JobReview: React.FunctionComponent<
           linkLabel={intl.formatMessage(messages.skillsEditLink)}
           link={jobBuilderSkills(locale, job.id)}
         >
-          {assetCriteria.map((criterion): React.ReactElement | null => {
-            const skill = getSkillOfCriteria(criterion);
-            if (skill === null) {
-              return null;
-            }
-            return (
-              <Criterion
-                criterion={criterion}
-                skill={skill}
-                key={criterion.id}
+          {assetCriteria.length === 0 ? (
+            <p>
+              <FormattedMessage
+                id="jobBuilder.review.skills.nullState"
+                defaultMessage="You haven't added any Nice to Have skills to this poster."
+                description="The text displayed for skills when you haven't added any skills."
               />
-            );
-          })}
+            </p>
+          ) : (
+            assetCriteria.map(
+              (criterion): React.ReactElement | null => {
+                const skill = getSkillOfCriteria(criterion);
+                if (skill === null) {
+                  return null;
+                }
+                return (
+                  <Criterion
+                    criterion={criterion}
+                    skill={skill}
+                    key={criterion.id}
+                  />
+                );
+              },
+            )
+          )}
         </JobReviewSection>
         <JobReviewSection
           title={intl.formatMessage(messages.languageHeading)}

--- a/resources/assets/js/components/JobTasks/JobTasks.tsx
+++ b/resources/assets/js/components/JobTasks/JobTasks.tsx
@@ -244,7 +244,7 @@ const JobTasks: React.FunctionComponent<JobTasksProps & InjectedIntlProps> = ({
         }): React.ReactElement => (
           <>
             {values.tasks.length > 0 && (
-              <p data-c-alignment="tl(right)">
+              <p data-c-alignment="tl(right)" data-c-margin="bottom(double)">
                 <FormattedMessage
                   id="jobTasks.taskCount.some"
                   defaultMessage="You have {taskCount, plural,
@@ -267,11 +267,13 @@ const JobTasks: React.FunctionComponent<JobTasksProps & InjectedIntlProps> = ({
                 data-c-border="all(thin, solid, grey)"
                 data-c-alignment="centre"
               >
+                <p>
                 <FormattedMessage
                   id="jobTasks.taskCount.none"
                   defaultMessage="You don't have any tasks added yet!"
                   description="Message displayed when there are no tasks present on the page."
                 />
+                </p>
               </div>
             )}
             <Form id="job-tasks">
@@ -558,11 +560,13 @@ const JobTasks: React.FunctionComponent<JobTasksProps & InjectedIntlProps> = ({
                     data-c-padding="normal"
                     id={`${modalId}-description`}
                   >
+                    <p>
                     <FormattedMessage
                       id="jobTasks.modal.body"
                       description="Text displayed above the body of the Job Task page Modal."
                       defaultMessage="Here's a preview of the Tasks you just entered. Feel free to go back and edit things or move to the next step if you're happy with it."
                     />
+                    </p>
                   </div>
                   <div data-c-background="grey(20)" data-c-padding="normal">
                     <div


### PR DESCRIPTION
Fixes a few strings that were being spit out without `<p>` tags, as well as adds null states for skills on both the modal and review steps.
