### PR TITLE
Avoid null exceptions when trying to publish poster.

### DIFF
--- a/app/Http/Controllers/Admin/JobPosterCrudController.php
+++ b/app/Http/Controllers/Admin/JobPosterCrudController.php
@@ -80,6 +80,14 @@ class JobPosterCrudController extends CrudController
             ]
         ]);
         $this->crud->addField([
+            'name' => 'open_date_time',
+            'label' => 'Open Date',
+            'type' => 'datetime_picker',
+            'datetime_picker_options' => [
+                'format' => 'YYYY-MM-DD HH:mm:ss',
+            ],
+        ]);
+        $this->crud->addField([
             'name' => 'close_date_time',
             'label' => 'Close Date',
             'type' => 'datetime_picker',
@@ -87,7 +95,10 @@ class JobPosterCrudController extends CrudController
                 'format' => 'YYYY-MM-DD HH:mm:ss',
             ],
         ]);
-        if ($this->crud->getCurrentEntry() && !$this->crud->getCurrentEntry()->published) {
+        if ($this->crud->getCurrentEntry() &&
+            !$this->crud->getCurrentEntry()->published &&
+            $this->crud->getCurrentEntry()->open_date_time !== null
+        ) {
             $this->crud->addField([
                 'name' => 'published',
                 'label' => 'Publish',

--- a/app/Http/Controllers/Admin/JobPosterCrudController.php
+++ b/app/Http/Controllers/Admin/JobPosterCrudController.php
@@ -96,8 +96,7 @@ class JobPosterCrudController extends CrudController
             ],
         ]);
         if ($this->crud->getCurrentEntry() &&
-            !$this->crud->getCurrentEntry()->published &&
-            $this->crud->getCurrentEntry()->open_date_time !== null
+            !$this->crud->getCurrentEntry()->published
         ) {
             $this->crud->addField([
                 'name' => 'published',

--- a/app/Models/JobPoster.php
+++ b/app/Models/JobPoster.php
@@ -432,6 +432,11 @@ class JobPoster extends BaseModel
         } elseif ($value && $this->open_date_time->isFuture()) {
             $this->attributes['published_at'] = $this->open_date_time;
         }
+        // if ($value) {
+        // $this->attributes['published_at'] = new Date();
+        // } else {
+        // $this->attributes['published_at'] = null;
+        // }
         $this->attributes['published'] = $value;
     }
 

--- a/app/Models/JobPoster.php
+++ b/app/Models/JobPoster.php
@@ -427,16 +427,11 @@ class JobPoster extends BaseModel
      */
     public function setPublishedAttribute($value) : void
     {
-        if ($value && $this->open_date_time->isPast()) {
+        if ($value) {
             $this->attributes['published_at'] = new Date();
-        } elseif ($value && $this->open_date_time->isFuture()) {
-            $this->attributes['published_at'] = $this->open_date_time;
+        } else {
+            $this->attributes['published_at'] = null;
         }
-        // if ($value) {
-        // $this->attributes['published_at'] = new Date();
-        // } else {
-        // $this->attributes['published_at'] = null;
-        // }
         $this->attributes['published'] = $value;
     }
 
@@ -486,6 +481,8 @@ class JobPoster extends BaseModel
     public function isOpen() : bool
     {
         return $this->published
+            && $this->open_date_time !== null
+            && $this->close_date_time !== null
             && $this->open_date_time->isPast()
             && $this->close_date_time->isFuture();
     }
@@ -498,6 +495,8 @@ class JobPoster extends BaseModel
     public function isClosed() : bool
     {
         return $this->published
+            && $this->open_date_time !== null
+            && $this->close_date_time !== null
             && $this->open_date_time->isPast()
             && $this->close_date_time->isPast();
     }

--- a/tests/Unit/JobPosterTest.php
+++ b/tests/Unit/JobPosterTest.php
@@ -125,18 +125,6 @@ class JobPosterTest extends TestCase
         $jobPoster->refresh();
 
         $this->assertInstanceOf(Date::class, $jobPoster->published_at);
-        $this->assertNotEquals($jobPoster->open_date_time, $jobPoster->published_at);
-
-        // Not yet open and not yet published.
-        $jobPoster = factory(JobPoster::class)->states('review_requested')->make();
-        $this->assertEquals(null, $jobPoster->published_at);
-
-        $jobPoster->published = true;
-        $jobPoster->save();
-        $jobPoster->refresh();
-
-        $this->assertInstanceOf(Date::class, $jobPoster->published_at);
-        $this->assertEquals($jobPoster->open_date_time, $jobPoster->published_at);
     }
 
     /**

--- a/tests/Unit/JobPosterTest.php
+++ b/tests/Unit/JobPosterTest.php
@@ -125,6 +125,18 @@ class JobPosterTest extends TestCase
         $jobPoster->refresh();
 
         $this->assertInstanceOf(Date::class, $jobPoster->published_at);
+
+        $this->assertNotEquals($jobPoster->open_date_time, $jobPoster->published_at);
+
+        // Not yet open and not yet published.
+        $jobPoster = factory(JobPoster::class)->states('review_requested')->make();
+        $this->assertEquals(null, $jobPoster->published_at);
+
+        $jobPoster->published = true;
+        $jobPoster->save();
+        $jobPoster->refresh();
+
+        $this->assertInstanceOf(Date::class, $jobPoster->published_at);
     }
 
     /**


### PR DESCRIPTION
Resolves #1355.

### Notes:
- This is a very minimal PR. It doesn't stop an admin from publishing a Job in an incomplete state (missing open dates, close dates, etc). That can be added in a separate PR. 
