### PR TITLE
Update React root templates to include proper headings

### DIFF
--- a/resources/views/common/redux.html.twig
+++ b/resources/views/common/redux.html.twig
@@ -15,7 +15,7 @@
 
     {% include "common/goc" %}
 
-    {% include "common/header" %}
+    {% include "common/header" with { 'header': { 'title': title } } %}
 
     <a id="skipLink"></a>
 

--- a/resources/views/manager/job-builder-root.html.twig
+++ b/resources/views/manager/job-builder-root.html.twig
@@ -8,7 +8,7 @@
 
     {% include "common/goc" %}
 
-    {% include "common/header" %}
+    {% include "common/header" with { 'header': { 'title': title } } %}
 
     <a id="skipLink"></a>
 


### PR DESCRIPTION
Job Poster Builder and Assessment Plan were missing hero section headings
