### PR TITLE
Remove "Team Culture" section from job poster modal

### DIFF
--- a/resources/assets/sass/components/applicant/job/post/_apply.scss
+++ b/resources/assets/sass/components/applicant/job/post/_apply.scss
@@ -25,7 +25,7 @@
     color: $palette--font-white;
     font-family: $font--sans;
     font-size: $font-scale--h3;
-    margin: 0 0 2rem 0;
+    margin: 0 0 3rem 0;
 }
 
 .job-post__apply-content,
@@ -35,10 +35,23 @@
     font-family: $font--sans;
     font-size: $font-scale--regular;
     line-height: 1.5;
+
+}
+
+.job-post__apply-content-preference {
+    margin: 1rem 0 0 0;
+
+    @media #{$p-tablet} {
+        margin: 0;
+    }
 }
 
 .job-post__apply-content {
-    margin: 0 0 3rem 0;
+    margin: 1rem 0 3rem 0;
+
+    @media #{$p-tablet} {
+        margin: 0 0 3rem 0;
+    }
 }
 
 .job-post__apply-content-preference:not(:last-child) {

--- a/resources/assets/sass/components/applicant/job/post/_header.scss
+++ b/resources/assets/sass/components/applicant/job/post/_header.scss
@@ -103,9 +103,4 @@
     font-weight: 400;
     line-height: 1.2;
     margin: 2rem 0 0 0;
-
-    @media #{$p-tablet} {
-        margin: 0 !important;
-    }
-
 }

--- a/resources/lang/en/applicant/job_post.php
+++ b/resources/lang/en/applicant/job_post.php
@@ -102,9 +102,9 @@ return [
     ],
     'work_environment' => [
         'view_more_button' => 'View the team’s work environment and culture',
-        'modal_title' => 'Work Environement and Culture',
+        'modal_title' => 'Work Environment and Culture',
         'modal_more_on_env' => 'More About Your Environment',
-        'modal_button' => 'Okay',
+        'modal_button' => 'Close',
         'remote_work_label' => 'Remote Work',
         'remote_work_desc' => 'Work from anywhere, all the time.',
         'remote_work_allowed' => [

--- a/resources/lang/fr/applicant/job_post.php
+++ b/resources/lang/fr/applicant/job_post.php
@@ -102,9 +102,9 @@ return [
     ],
     'work_environment' => [
         'view_more_button' => 'Voir l’environnement de travail et la culture de l’équipe',
-        'modal_title' => 'Work Environement and Culture FR', // TODO: needs translation
+        'modal_title' => 'Work Environment and Culture FR', // TODO: needs translation
         'modal_more_on_env' => 'More About Your Environment FR', // TODO: needs translation
-        'modal_button' => 'Okay FR', // TODO: needs translation
+        'modal_button' => 'Fermer',
         'remote_work_label' => 'Travail à distance :',
         'remote_work_desc' => 'Travaillez n’importe où, en tout temps.',
         'remote_work_allowed' => [

--- a/resources/views/applicant/jpb_job_post/culture.html.twig
+++ b/resources/views/applicant/jpb_job_post/culture.html.twig
@@ -195,6 +195,9 @@
                             <div id="applicant-work-culture-description">
                                 <div data-c-background="grey(20)" data-c-padding="normal">
                                     <div class="manager-job-card" data-c-background="white(100)" data-c-padding="normal" data-c-radius="rounded">
+                                        <h4 data-c-border="bottom(thin, solid, black)" data-c-font-size="h4" data-c-font-weight="600" data-c-margin="bottom(normal)" data-c-padding="bottom(normal)">{{ job_post.culture.work_culture_label }}</h4>
+                                        <p data-c-margin={{ job.culture_special ? "bottom(normal)" : "bottom(double)" }}>{{ job.culture_summary }}</p>
+                                        <p data-c-margin="bottom(double)">{{ job.culture_special }}</p>
                                         <h4 data-c-border="bottom(thin, solid, black)" data-c-font-size="h4" data-c-font-weight="600" data-c-margin="bottom(normal)" data-c-padding="bottom(normal)">{{ job_post.culture.work_environment_label }}</h4>
                                             {# Below is a React container for the work environment features. This is being done to not duplicate JobWorkEnv component, and its translations, on the react side.  #}
                                             <div
@@ -204,84 +207,10 @@
                                             >
                                             </div>
                                             {# End of Component #}
-                                            <div data-c-grid-item="base(1of1)" data-c-margin="top(normal)">
+                                            <div data-c-grid-item="base(1of1)" data-c-margin="top(double)">
                                                 <span data-c-colour="c1" data-c-margin="top(half) bottom(half)" data-c-font-weight="bold">{{ job_post.work_environment.modal_more_on_env }}</span>
                                                 <p>{{ job.work_env_description }}</p>
                                             </div>
-                                        <h4 data-c-border="bottom(thin, solid, black)" data-c-font-size="h4" data-c-font-weight="600" data-c-margin="top(double) bottom(normal)" data-c-padding="bottom(normal)">{{ job_post.culture.team_culture_label }}</h4>
-                                        <div data-c-margin="top(normal)">
-                                            <div data-c-grid="gutter">
-                                                <div class="job-post__culture-wrapper" data-c-grid-item="base(1of3)">
-                                                    <div>
-                                                        <p data-c-colour="c1" data-c-font-weight="bold">
-                                                            {{ job_post.work_environment.remote_work_label }}
-                                                        </p>
-                                                        <p class="job-post__culture-desc">
-                                                            {{ job_post.work_environment.remote_work_desc }}
-                                                        </p>
-                                                    </div>
-                                                    <p class="job-post__culture-copy">
-                                                        {{ job_post.work_environment.remote_work_allowed[job.remote_work_allowed] ?: noInfo }}
-                                                    </p>
-                                                </div>
-
-                                                <div class="job-post__culture-wrapper" data-c-grid-item="base(1of3)">
-                                                    <div>
-                                                        <p data-c-colour="c1" data-c-font-weight="bold">
-                                                            {{ job_post.work_environment.telework_label }}
-                                                        </p>
-                                                        <p class="job-post__culture-desc">
-                                                            {{ job_post.work_environment.telework_desc }}
-                                                        </p>
-                                                    </div>
-                                                    <p class="job-post__culture-copy">
-                                                        {{ job_post.work_environment.telework_allowed[job.telework_allowed_frequency.name] ?: noInfo }}
-                                                    </p>
-                                                </div>
-
-                                                <div class="job-post__culture-wrapper" data-c-grid-item="base(1of3)">
-                                                    <div>
-                                                        <p data-c-colour="c1" data-c-font-weight="bold">
-                                                            {{ job_post.work_environment.time_flexibility_label }}
-                                                        </p>
-                                                        <p class="job-post__culture-desc">
-                                                            {{ job_post.work_environment.time_flexibility_desc }}
-                                                        </p>
-                                                    </div>
-                                                    <p class="job-post__culture-copy">
-                                                        {{ job_post.work_environment.time_flexibility_allowed[job.flexible_hours_frequency.name] ?: noInfo }}
-                                                    </p>
-                                                </div>
-
-                                                <div class="job-post__culture-wrapper" data-c-grid-item="base(1of3)">
-                                                    <div>
-                                                        <p data-c-colour="c1" data-c-font-weight="bold">
-                                                            {{ job_post.work_environment.travel_label }}
-                                                        </p>
-                                                        <p class="job-post__culture-desc">
-                                                            {{ job_post.work_environment.travel_desc }}
-                                                        </p>
-                                                    </div>
-                                                    <p class="job-post__culture-copy">
-                                                        {{ job_post.work_environment.travel[job.travel_requirement.name] ?: noInfo }}
-                                                    </p>
-                                                </div>
-
-                                                <div class="job-post__culture-wrapper" data-c-grid-item="base(1of3)">
-                                                    <div>
-                                                        <p data-c-colour="c1" data-c-font-weight="bold">
-                                                            {{ job_post.work_environment.overtime_label }}
-                                                        </p>
-                                                        <p class="job-post__culture-desc">
-                                                            {{ job_post.work_environment.overtime_desc }}
-                                                        </p>
-                                                    </div>
-                                                    <p class="job-post__culture-copy">
-                                                        {{ job_post.work_environment.overtime[job.overtime_requirement.name] ?: noInfo }}
-                                                    </p>
-                                                </div>
-                                            </div>
-                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/resources/views/applicant/jpb_job_post/culture.html.twig
+++ b/resources/views/applicant/jpb_job_post/culture.html.twig
@@ -195,10 +195,7 @@
                             <div id="applicant-work-culture-description">
                                 <div data-c-background="grey(20)" data-c-padding="normal">
                                     <div class="manager-job-card" data-c-background="white(100)" data-c-padding="normal" data-c-radius="rounded">
-                                        <h4 data-c-border="bottom(thin, solid, black)" data-c-font-size="h4" data-c-font-weight="600" data-c-margin="bottom(normal)" data-c-padding="bottom(normal)">{{ job_post.culture.work_culture_label }}</h4>
-                                        <p>{{ job.culture_summary }}</p>
-                                        <p data-c-margin="top(normal)">{{ job.culture_special }}</p>
-                                        <h4 data-c-border="bottom(thin, solid, black)" data-c-font-size="h4" data-c-font-weight="600" data-c-margin="top(double) bottom(normal)" data-c-padding="bottom(normal)">{{ job_post.culture.work_environment_label }}</h4>
+                                        <h4 data-c-border="bottom(thin, solid, black)" data-c-font-size="h4" data-c-font-weight="600" data-c-margin="bottom(normal)" data-c-padding="bottom(normal)">{{ job_post.culture.work_environment_label }}</h4>
                                             {# Below is a React container for the work environment features. This is being done to not duplicate JobWorkEnv component, and its translations, on the react side.  #}
                                             <div
                                                 id="work-env-features-section"


### PR DESCRIPTION
Resolves #1390  

- Removed the duplicate "Team culture" section from modal.
- Changed close button from "Okay" to "Close",
- Responsive style changes to job poster. 