### PR TITLE
removes deprecated module from jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,6 @@ module.exports = {
   testEnvironment: "jsdom",
   roots: ["<rootDir>/resources/assets/js"],
   setupFilesAfterEnv: [
-    "@testing-library/react/cleanup-after-each",
     "./jest.setup.js",
     "./resources/assets/js/helpers/setupTests.ts",
   ],


### PR DESCRIPTION
 console.warn node_modules/@testing-library/react/cleanup-after-each.js:1
      The module `@testing-library/react/cleanup-after-each` has been deprecated and no longer does anything (it is not needed). You no longer need to import this module and can safely remove any import or configuration which imports this module
