### PR TITLE
Add data-c-dialog-focus attribute to clone modal

### DIFF
--- a/resources/views/applicant/jpb_job_post/culture.html.twig
+++ b/resources/views/applicant/jpb_job_post/culture.html.twig
@@ -222,6 +222,7 @@
                                     data-c-grid-item="base(1of2)"
                                     data-c-alignment="base(right)">
                                     <button
+                                        data-c-dialog-focus
                                         data-c-button="solid(go)"
                                         data-c-radius="rounded"
                                         data-c-dialog-action="close"

--- a/resources/views/common/modals/skills_need_help.html.twig
+++ b/resources/views/common/modals/skills_need_help.html.twig
@@ -92,6 +92,7 @@
                         data-c-grid-item="base(1of2)"
                         data-c-alignment="base(right)">
                         <button
+                            data-c-dialog-focus
                             data-c-button="solid(c5)"
                             data-c-radius="rounded"
                             data-c-dialog-action="close"


### PR DESCRIPTION
Clone's latest js is throwing an error when the modal is opened if no elements contain the `data-c-dialog-focus` attribute, adding to alleviate for now.
