### PR TITLE
Generate new SRI hash for html2canvas

### DIFF
--- a/resources/views/common/head.html.twig
+++ b/resources/views/common/head.html.twig
@@ -98,7 +98,7 @@
 
     <script
         src="https://html2canvas.hertzen.com/dist/html2canvas.js"
-        integrity="sha384-vhfRL/EJVW2tOaB2/hQqMb8N29l78w84mJMs8WjKQ5ciRS9XsNeELFxLhVKoNKlQ"
+        integrity="sha384-uwipw2NS04BmJK/U41XUWEf22GNeKMPASXCzEL0/J9RIS8ENurrbpw/86uhXtBRG"
         crossorigin="anonymous">
     </script>
 


### PR DESCRIPTION
Resolves error: ```Failed to find a valid digest in the 'integrity' attribute for resource 'https://html2canvas.hertzen.com/dist/html2canvas.js' ... The resource has been blocked.```