### PR TITLE
Bugfix - Set Modal to always overflow 

### DIFF
--- a/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
+++ b/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
@@ -70,7 +70,7 @@ const JobBuilderStep: React.FunctionComponent<JobBuilderStepProps> = ({
   children,
 }): React.ReactElement => {
   // Trigger fetching of job details
-  const [isLoadingJob, setIsLoadingJob] = useState(false);
+  const [isLoadingJob, setIsLoadingJob] = useState(true);
   useEffect((): (() => void) => {
     let isSubscribed = true;
     if (jobId) {
@@ -85,7 +85,7 @@ const JobBuilderStep: React.FunctionComponent<JobBuilderStepProps> = ({
       isSubscribed = false;
     };
   }, [jobId, loadJob]);
-  const [isLoadingTasks, setIsLoadingTasks] = useState(false);
+  const [isLoadingTasks, setIsLoadingTasks] = useState(true);
   useEffect((): (() => void) => {
     let isSubscribed = true;
     if (jobId) {
@@ -100,7 +100,7 @@ const JobBuilderStep: React.FunctionComponent<JobBuilderStepProps> = ({
       isSubscribed = false;
     };
   }, [jobId, loadTasks]);
-  const [isLoadingCriteria, setIsLoadingCriteria] = useState(false);
+  const [isLoadingCriteria, setIsLoadingCriteria] = useState(true);
   useEffect((): (() => void) => {
     let isSubscribed = true;
     if (jobId) {

--- a/resources/assets/js/components/Modal.tsx
+++ b/resources/assets/js/components/Modal.tsx
@@ -35,9 +35,6 @@ export default function Modal({
   // Set up div ref to measure modal height
   const modalRef = useRef<HTMLDivElement>(null);
 
-  // Internal state to keep track of the overflow setting
-  const [overflow, setOverflow] = useState("");
-
   const handleTabKey = (e: KeyboardEvent): void => {
     if (modalRef && modalRef.current) {
       const focusableModalElements = modalRef.current.querySelectorAll(
@@ -85,13 +82,6 @@ export default function Modal({
     };
   }, [visible]);
 
-  // Runs when the children of the modal change to ensure proper height calculation
-  useEffect((): void => {
-    if (visible && modalRef && modalRef.current) {
-      setOverflow("active--overflowing");
-    }
-  }, [visible]);
-
   // Adds various key commands to the modal
   useEffect((): (() => void) => {
     let keyListener;
@@ -116,7 +106,7 @@ export default function Modal({
         aria-describedby={`${id}-description`}
         aria-hidden={!visible}
         aria-labelledby={`${id}-title`}
-        data-c-dialog={visible ? overflow : ""}
+        data-c-dialog={visible ? "active--overflowing" : ""}
         data-c-padding="top(double) bottom(double)"
         role="dialog"
         ref={modalRef}

--- a/resources/assets/js/components/Modal.tsx
+++ b/resources/assets/js/components/Modal.tsx
@@ -88,13 +88,9 @@ export default function Modal({
   // Runs when the children of the modal change to ensure proper height calculation
   useEffect((): void => {
     if (visible && modalRef && modalRef.current) {
-      const height = modalRef.current.scrollHeight;
-      const viewportHeight = window.innerHeight;
-      setOverflow(
-        height > viewportHeight ? "active--overflowing" : "active--contained",
-      );
+      setOverflow("active--overflowing");
     }
-  }, [children, visible]);
+  }, [visible]);
 
   // Adds various key commands to the modal
   useEffect((): (() => void) => {


### PR DESCRIPTION
Resolves #1582 

### Notes:
- Set the modal to always overflow if the height exceeds the view-port height. 
- Also, removed error icon flash from the JPB progress tracker.
