### PR TITLE
Fix issue with password confirmation naming

### DIFF
--- a/resources/views/auth/passwords/reset.html.twig
+++ b/resources/views/auth/passwords/reset.html.twig
@@ -64,7 +64,7 @@
                                         <label for="password-confirm">{{ reset_password.confirm_password }}</label>
                                         <span>Required</span>
                                         <div>
-                                            <input id="password-confirm" required type="password" name="password-confirmation"
+                                            <input id="password-confirm" required type="password" name="password_confirmation"
                                             autocomplete="off" />
                                             <button type="button">
                                                 <i class="fas fa-eye"></i>


### PR DESCRIPTION
Resolves #1719

### Notes:
- During a template change the password confirmation `name` attribute was changed from `password_confirmation` to `password-confirmation`. Laravel core expects the former so it wasn't used during the `confirmed` validation check.
