### PR TITLE
Bugfix - Authorization viewing published job poster

### DIFF
--- a/app/Policies/JobPolicy.php
+++ b/app/Policies/JobPolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Models\User;
 use App\Models\JobPoster;
 use App\Policies\BasePolicy;
+use Illuminate\Support\Facades\Log;
 
 class JobPolicy extends BasePolicy
 {
@@ -20,7 +21,7 @@ class JobPolicy extends BasePolicy
     {
         // Anyone can view a published job
         // Only the manager that created it can view an unpublished job
-        return $jobPoster->status() == 'published' ||
+        return $jobPoster->status() == 'published' || $jobPoster->status() == 'closed' ||
         (
             $user &&
             $user->isManager() &&

--- a/app/Policies/JobPolicy.php
+++ b/app/Policies/JobPolicy.php
@@ -20,7 +20,7 @@ class JobPolicy extends BasePolicy
     {
         // Anyone can view a published job
         // Only the manager that created it can view an unpublished job
-        return $jobPoster->published ||
+        return $jobPoster->status() == 'published' ||
         (
             $user &&
             $user->isManager() &&


### PR DESCRIPTION
Resolves #711 

### Notes:
- Job poster can be viewed now only if:
    - The job poster `status` is published published.
    - If the user is the manager that created the job poster.
    - User is an Admin.
