### PR TITLE
Don't reference Applicant in two-factor routes

### DIFF
--- a/resources/views/applicant/profile/about/about.html.twig
+++ b/resources/views/applicant/profile/about/about.html.twig
@@ -160,12 +160,12 @@
                                 {% if applicant.user.google2fa_secret %}
 
                                 <p data-c-padding="bottom(normal)">You're currently receiving verification codes via an authenticator app on your smartphone.</p>
-                                <a href="{{ route('two_factor.deactivate', applicant.id) }}" title="">Deactivate Two Factor</a>
+                                <a href="{{ route('two_factor.deactivate') }}" title="">Deactivate Two Factor</a>
 
                                 {% else %}
 
                                 <p data-c-padding="bottom(normal)">Two-factor auth blurb. <a href="" title="">Here's a useful link.</a></p>
-                                <a class="button--blue light-bg" href="{{ route('two_factor.activate', applicant.id) }}">{{ profile.about_section.two_factor_button_text }}</a>
+                                <a class="button--blue light-bg" href="{{ route('two_factor.activate') }}">{{ profile.about_section.two_factor_button_text }}</a>
 
                                 {% endif %}
 

--- a/resources/views/auth/two_factor.html.twig
+++ b/resources/views/auth/two_factor.html.twig
@@ -22,7 +22,7 @@
                     <div class="tc-auth-header gradient-left-right" data-c-padding="all(double)" data-c-align="base(center)">
                         <h1 data-c-font-size="h2" data-c-color="white">{{ two_factor.header }}</h1>
                     </div>
-                    <form action="{{ route('two_factor.confirm', applicant.id) }}" method="POST">
+                    <form action="{{ route('two_factor.confirm') }}" method="POST">
                         {{ csrf_field() }}
                         <div data-c-background="white(100)" data-c-padding="tb(normal) rl(double)">
                             <div data-c-grid="middle">

--- a/routes/web.php
+++ b/routes/web.php
@@ -149,27 +149,21 @@ Route::group(
                     ->name('profile.work_samples.edit');
 
                 Route::get(
-                    'profile/{applicant}/two-factor/activate',
+                    'profile/two-factor/activate',
                     'Auth\TwoFactorController@activate'
                 )
-                    ->middleware('can:view,applicant')
-                    ->middleware('can:update,applicant')
                     ->name('two_factor.activate');
 
                 Route::get(
-                    'profile/{applicant}/two-factor/deactivate',
+                    'profile/two-factor/deactivate',
                     'Auth\TwoFactorController@deactivate'
                 )
-                    ->middleware('can:view,applicant')
-                    ->middleware('can:update,applicant')
                     ->name('two_factor.deactivate');
 
                 Route::post(
-                    'profile/{applicant}/two-factor/confirm',
+                    'profile/two-factor/confirm',
                     'Auth\TwoFactorController@confirm'
                 )
-                ->middleware('can:view,applicant')
-                ->middleware('can:update,applicant')
                 ->name('two_factor.confirm');
             });
 


### PR DESCRIPTION
Resolves #1757.

### Notes:
- This will make it easier to use the same Two Factor controller methods in the Manager and Admin portals.
