### PR TITLE
Bugfix - 2FA - Returning user to expected url

### DIFF
--- a/app/Http/Controllers/Auth/RecoveryCodeController.php
+++ b/app/Http/Controllers/Auth/RecoveryCodeController.php
@@ -55,8 +55,7 @@ class RecoveryCodeController extends AuthController
     {
         return view('auth.use_recovery_code', [
             'recover' => Lang::get('common/auth/use_recovery_code'),
-            'return_url' => redirect()->back()->getTargetUrl(),
-            'otp_url' => redirect()->intended(WhichPortal::home())->getTargetUrl(),
+            'return_url' => session()->get('url.expected'),
         ]);
     }
 
@@ -76,7 +75,10 @@ class RecoveryCodeController extends AuthController
             });
             $user->recovery_codes = $still_valid_codes->toArray();
             $user->save();
-            return redirect()->intended(WhichPortal::home());
+            // If authentication passes, remove the expected url from the session.
+            $expectedUrl = session()->get('url.expected');
+            session()->remove('url.expected');
+            return redirect($expectedUrl);
         }
         return redirect(route('recovery_codes.use'))
             ->withErrors(['incorrect' => Lang::get('common/auth/use_recovery_code.incorrect_code')]);

--- a/app/Http/Middleware/Google2FA.php
+++ b/app/Http/Middleware/Google2FA.php
@@ -19,8 +19,11 @@ class Google2FA
         if ($authenticator->isAuthenticated()) {
             return $next($request);
         }
-        // Unlike \PragmaRX\Google2FALaravel\Middleware, set the intended url
-        Session::put('url.intended', URL::full());
+        // Unlike \PragmaRX\Google2FALaravel\Middleware, set the intended url.
+        // Check if the intended url already exists, if not then store in global session.
+        if (!session()->has('url.expected')) {
+            Session::put('url.expected', URL::full());
+        }
         return $authenticator->makeRequestOneTimePasswordResponse();
     }
 }

--- a/resources/views/auth/use_recovery_code.html.twig
+++ b/resources/views/auth/use_recovery_code.html.twig
@@ -41,13 +41,6 @@
                         </div>
                         <div data-c-background="white(100)" data-c-padding="tb(normal) rl(double)" data-c-border="top(thin, solid, grey)">
                             <div data-c-grid="middle">
-                                {# TODO: Set up a route for one-time-password
-                                <div data-c-grid-item="base(1of2)">
-                                    <a href="{{ otp_url }}" title="{{ recover.otp_link_title }}">
-                                        {{ recover.otp_link }}
-                                    </a>
-                                </div>
-                                #}
                                 <div data-c-grid-item="base(1of1)" data-c-align="base(right)">
                                     <button data-c-button="solid(c1)" data-c-radius="rounded" type="submit">
                                         {{ recover.submit }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,7 +31,10 @@ Route::group(
              */
             Route::middleware(['2fa'])->group(function (): void {
                 Route::post('/2fa', function () {
-                    return redirect()->intended();
+                    // If 2fa passes redirect to the expected url and remove it from session.
+                    $expectedUrl = session()->get('url.expected');
+                    session()->remove('url.expected');
+                    return redirect($expectedUrl);
                 })->name('2fa');
 
                 /* Home */


### PR DESCRIPTION
Resolves #1667 

### Notes:
- First off, thank you Tristan.
- Should return the user to the expected/intended URL, before being asked for 2FA.
- Currently, applicants can only reach GET requests. The site doesn't have any place to create a POST request to cause a 405 (that I could find). 