### PR TITLE
Get react-intl 3 working in IE

### DIFF
--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -1,21 +1,4 @@
-import "core-js"; // adds almost all polyfills
-
-// Polyfills for missing browser API's (IE11 and Safari)
-// https://github.com/formatjs/react-intl/blob/master/docs/Upgrade-Guide.md#migrate-to-using-native-intl-apis
-if (!Intl.PluralRules) {
-  require("@formatjs/intl-pluralrules/polyfill");
-  require("@formatjs/intl-pluralrules/dist/locale-data/en");
-  require("@formatjs/intl-pluralrules/dist/locale-data/fr");
-}
-
-if (!Intl.RelativeTimeFormat) {
-  require("@formatjs/intl-relativetimeformat/polyfill");
-  require("@formatjs/intl-relativetimeformat/dist/locale-data/en");
-  require("@formatjs/intl-relativetimeformat/dist/locale-data/fr");
-}
-
-// Add a global fetch implementation
-require("isomorphic-fetch");
+import "./polyfills";
 
 /**
  * We'll load the axios HTTP library which allows us to easily issue requests

--- a/resources/assets/js/polyfills.js
+++ b/resources/assets/js/polyfills.js
@@ -1,0 +1,18 @@
+import "core-js"; // adds almost all polyfills
+
+// Polyfills for missing browser API's (IE11 and Safari)
+// https://github.com/formatjs/react-intl/blob/master/docs/Upgrade-Guide.md#migrate-to-using-native-intl-apis
+if (!Intl.PluralRules) {
+  require("@formatjs/intl-pluralrules/polyfill");
+  require("@formatjs/intl-pluralrules/dist/locale-data/en");
+  require("@formatjs/intl-pluralrules/dist/locale-data/fr");
+}
+
+if (!Intl.RelativeTimeFormat) {
+  require("@formatjs/intl-relativetimeformat/polyfill");
+  require("@formatjs/intl-relativetimeformat/dist/locale-data/en");
+  require("@formatjs/intl-relativetimeformat/dist/locale-data/fr");
+}
+
+// Add a global fetch implementation
+require("isomorphic-fetch");

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -71,6 +71,7 @@ mix.webpackConfig({
     alias: {
       "@": path.resolve(__dirname, "resources/assets/js"),
     },
+    mainFields: ["browser", "main", "module"],
   },
 });
 


### PR DESCRIPTION
Resolves #1797.

### Notes:
- Uses the solution mentioned [here](https://github.com/formatjs/react-intl/issues/1433#issuecomment-541788065).
- Setting the resolve.mainFields property of webpack config to `mainFields: ['browser', 'module', 'main']` fixes the issue. From what I understand, it works because this gets the browser to use already-transpiled versions of dependency modules.
