### PR TITLE
JPB - Stop nullifying criteria specificity of other language

### DIFF
--- a/resources/assets/js/components/JobBuilderSkills/CriteriaForm.tsx
+++ b/resources/assets/js/components/JobBuilderSkills/CriteriaForm.tsx
@@ -121,11 +121,13 @@ const updateCriteriaWithValues = (
     skill_level_id: essentialKeyToId(values.level),
     en: {
       description: skill.en.description,
-      specificity: locale === "en" ? values.specificity : null,
+      specificity:
+        locale === "en" ? values.specificity : criteria.en.specificity,
     },
     fr: {
       description: skill.fr.description,
-      specificity: locale === "fr" ? values.specificity : null,
+      specificity:
+        locale === "fr" ? values.specificity : criteria.fr.specificity,
     },
   };
 };


### PR DESCRIPTION
When changing a skill criteria in the Job Poster Builder, specificity in the non-current language would be set to null. This fixes that.
