### PR TITLE
Bugfix - Use client-side routing for reverse clickable links.

### DIFF
--- a/resources/assets/js/components/ProgressTracker/ProgressTrackerItem.tsx
+++ b/resources/assets/js/components/ProgressTracker/ProgressTrackerItem.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useIntl, defineMessages } from "react-intl";
+import { navigate } from "../../helpers/router";
 
 interface ProgressTrackerItemProps {
   link: string;
@@ -58,7 +59,14 @@ const ProgressTrackerItem: React.FunctionComponent<
         </div>
       )}
       {state !== "null" ? (
-        <a href={link} title={title}>
+        <a
+          href={link}
+          title={title}
+          onClick={e => {
+            e.preventDefault();
+            navigate(link);
+          }}
+        >
           <div className="tracker-title">
             <span data-c-font-size="small">{label}</span>
             <span data-c-font-weight="bold">{title}</span>


### PR DESCRIPTION
### Notes:
- Quick bug-fix. Want to utilize client-side routing for the reverse clickable links on the progress tracker.