### PR TITLE
Cold fix Job Duration not visible on job card

### DIFF
--- a/app/Http/Controllers/Api/JobApiController.php
+++ b/app/Http/Controllers/Api/JobApiController.php
@@ -9,6 +9,7 @@ use App\Mail\JobPosterReviewRequested;
 use App\Http\Controllers\Controller;
 use App\Models\JobPoster;
 use App\Models\Criteria;
+use App\Models\Lookup\JobTerm;
 use Jenssegers\Date\Date;
 use App\Http\Requests\UpdateJobPoster;
 use App\Http\Requests\StoreJobPoster;
@@ -65,6 +66,8 @@ class JobApiController extends Controller
         $data = $request->validated();
         $job = new JobPoster();
         $job->manager_id = $request->user()->manager->id;
+        // Defaulting JPB created Jobs to monthly terms for now.
+        $job->job_term_id = JobTerm::where('name', 'month')->value('id');
         $job->fill($data);
         $job->save();
         return response()->json($this->jobToArray($job));
@@ -94,6 +97,8 @@ class JobApiController extends Controller
         // Only values both in the JobPoster->fillable array,
         // and returned by UpdateJobPoster->validatedData(), will be set.
         $job->fill($data);
+        // Defaulting JPB updated jobs to monthly for now.
+        $job->job_term_id = JobTerm::where('name', 'month')->value('id');
         $job->save();
         return response()->json($this->jobToArray($job->fresh()));
     }


### PR DESCRIPTION
### Notes:
- Jobs created through the JPB don't set a required property (`job_term_id`) so I set it in the controller rather than integrating it into the React side of the application
