### PR TITLE
Use SPA routing when linking from JPB review page to eariler steps.

### DIFF
--- a/resources/assets/js/components/JobBuilder/Review/JobReview.tsx
+++ b/resources/assets/js/components/JobBuilder/Review/JobReview.tsx
@@ -202,11 +202,9 @@ const JobReviewSection: React.FunctionComponent<JobReviewSectionProps> = ({
             data-c-grid-item="tp(1of2)"
             data-c-alignment="base(centre) tp(right)"
           >
-            <Link url={link} title={linkLabel}>
-              <>
-                <i data-c-colour="c2" className="fas fa-edit" />
-                {linkLabel}
-              </>
+            <Link href={link} title={linkLabel}>
+              <i data-c-colour="c2" className="fas fa-edit" />
+              {linkLabel}
             </Link>
           </div>
         </div>

--- a/resources/assets/js/components/JobBuilder/Review/JobReview.tsx
+++ b/resources/assets/js/components/JobBuilder/Review/JobReview.tsx
@@ -44,7 +44,7 @@ import JobWorkEnv from "../JobWorkEnv";
 import JobWorkCulture from "../JobWorkCulture";
 import Modal from "../../Modal";
 import { textToParagraphs } from "../../../helpers/textToParagraphs";
-import { useUrlHash } from "../../../helpers/router";
+import { useUrlHash, Link } from "../../../helpers/router";
 
 interface JobReviewSectionProps {
   title: string;
@@ -202,10 +202,12 @@ const JobReviewSection: React.FunctionComponent<JobReviewSectionProps> = ({
             data-c-grid-item="tp(1of2)"
             data-c-alignment="base(centre) tp(right)"
           >
-            <a href={link}>
-              <i data-c-colour="c2" className="fas fa-edit" />
-              {linkLabel}
-            </a>
+            <Link url={link} title={linkLabel}>
+              <>
+                <i data-c-colour="c2" className="fas fa-edit" />
+                {linkLabel}
+              </>
+            </Link>
           </div>
         </div>
       </div>
@@ -339,9 +341,8 @@ interface JobReviewProps {
   handleReturn: () => void;
 }
 
-export const JobReview: React.FunctionComponent<
-  JobReviewProps & WrappedComponentProps
-> = ({
+export const JobReview: React.FunctionComponent<JobReviewProps &
+  WrappedComponentProps> = ({
   job,
   manager,
   tasks,

--- a/resources/assets/js/helpers/router.tsx
+++ b/resources/assets/js/helpers/router.tsx
@@ -70,3 +70,22 @@ export const navigate = (url: string): void => {
 export const redirect = (url: string): void => {
   HISTORY.replace(url);
 };
+
+export const Link: React.FC<{ url: string, title: string }> = ({
+  url,
+  title,
+  children,
+}): React.ReactElement => {
+  return (
+    <a
+      href={url}
+      title={title}
+      onClick={(event): void => {
+        event.preventDefault();
+        navigate(url);
+      }}
+    >
+      {children}
+    </a>
+  );
+};

--- a/resources/assets/js/helpers/router.tsx
+++ b/resources/assets/js/helpers/router.tsx
@@ -71,21 +71,19 @@ export const redirect = (url: string): void => {
   HISTORY.replace(url);
 };
 
-export const Link: React.FC<{ url: string, title: string }> = ({
-  url,
+export const Link: React.FC<{ href: string; title: string }> = ({
+  href,
   title,
   children,
-}): React.ReactElement => {
-  return (
-    <a
-      href={url}
-      title={title}
-      onClick={(event): void => {
-        event.preventDefault();
-        navigate(url);
-      }}
-    >
-      {children}
-    </a>
-  );
-};
+}): React.ReactElement => (
+  <a
+    href={href}
+    title={title}
+    onClick={(event): void => {
+      event.preventDefault();
+      navigate(href);
+    }}
+  >
+    {children}
+  </a>
+);


### PR DESCRIPTION
Resolves #1353.