### PR TITLE
Some minor changes to claim/unclaim job

### DIFF
--- a/app/Http/Controllers/Api/ClaimJobApiController.php
+++ b/app/Http/Controllers/Api/ClaimJobApiController.php
@@ -76,7 +76,6 @@ class ClaimJobApiController extends Controller
      */
     public function claimJob(HrAdvisor $hrAdvisor, JobPoster $job)
     {
-        $job = JobPoster::find($job->id);
         $hrAdvisor->claimed_jobs()->attach($job);
     }
 
@@ -89,7 +88,6 @@ class ClaimJobApiController extends Controller
      */
     public function unclaimJob(HrAdvisor $hrAdvisor, JobPoster $job)
     {
-        $job = JobPoster::find($job->id);
         $hrAdvisor->claimed_jobs()->detach($job);
     }
 }

--- a/app/Http/Controllers/Api/ClaimJobApiController.php
+++ b/app/Http/Controllers/Api/ClaimJobApiController.php
@@ -27,9 +27,8 @@ class ClaimJobApiController extends Controller
      */
     public function store(Request $request, JobPoster $job)
     {
-        if ($request->user()->hr_advisor->id) {
-            $this->claimJob($request->user()->hr_advisor, $job);
-        }
+        $this->claimJob($request->user()->hr_advisor, $job);
+
         return response()->json(['status' => 'ok']);
     }
 
@@ -63,9 +62,8 @@ class ClaimJobApiController extends Controller
      */
     public function destroy(Request $request, JobPoster $job)
     {
-        if ($request->user()->hr_advisor->id) {
-            $this->unclaimJob($request->user()->hr_advisor, $job);
-        }
+        $this->unclaimJob($request->user()->hr_advisor, $job);
+
         return response()->json(['status' => 'ok']);
     }
 

--- a/app/Policies/JobPolicy.php
+++ b/app/Policies/JobPolicy.php
@@ -83,7 +83,7 @@ class JobPolicy extends BasePolicy
     public function submitForReview(User $user, JobPoster $jobPoster)
     {
         // Only upgradedManagers can submit jobs for review, only their own jobs, and only if they're still drafts.
-        // NOTE: this is one of the only permissions to require an upgradedManager, as opposed to a demoManager.var
+        // NOTE: this is one of the only permissions to require an upgradedManager, as opposed to a demoManager.
         return $user->isUpgradedManager() &&
             $jobPoster->manager->user->id == $user->id &&
             $jobPoster->status() === 'draft';
@@ -101,5 +101,29 @@ class JobPolicy extends BasePolicy
         return $user->isManager() &&
             $jobPoster->manager->user->id == $user->id &&
             $jobPoster->isClosed();
+    }
+
+    /**
+     * Determine whether the user can 'claim' this job.
+     *
+     * @param User $user
+     * @param JobPoster $jobPoster
+     * @return boolean
+     */
+    public function claim(User $user, JobPoster $jobPoster) : bool
+    {
+        return $user->isHrAdvisor();
+    }
+
+    /**
+     * Determine whether the user can 'unclaim' this job.
+     *
+     * @param User $user
+     * @param JobPoster $jobPoster
+     * @return boolean
+     */
+    public function unClaim(User $user, JobPoster $jobPoster) : bool
+    {
+        return $this->claim($user, $jobPoster);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -546,10 +546,10 @@ Route::group(['prefix' => 'api'], function (): void {
         ->middleware('auth');
 
     // Claim / unclaim job routes, HR portal
-    Route::post('jobs/{job}/claim', 'Api\ClaimJobApiController@store')
+    Route::put('jobs/{job}/claim', 'Api\ClaimJobApiController@store')
         ->middleware('can:claim,job')
         ->where('job', '[0-9]+');
-    Route::post('jobs/{job}/unclaim', 'Api\ClaimJobApiController@destroy')
+    Route::delete('jobs/{job}/claim', 'Api\ClaimJobApiController@destroy')
         ->middleware('can:unClaim,job')
         ->where('job', '[0-9]+');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -547,9 +547,9 @@ Route::group(['prefix' => 'api'], function (): void {
 
     // Claim / unclaim job routes, HR portal
     Route::post('jobs/{job}/claim', 'Api\ClaimJobApiController@store')
-        ->middleware('auth')
+        ->middleware('can:claim,job')
         ->where('job', '[0-9]+');
     Route::post('jobs/{job}/unclaim', 'Api\ClaimJobApiController@destroy')
-        ->middleware('auth')
+        ->middleware('can:unClaim,job')
         ->where('job', '[0-9]+');
 });

--- a/tests/Feature/ClaimJobApiControllerTest.php
+++ b/tests/Feature/ClaimJobApiControllerTest.php
@@ -33,7 +33,7 @@ class ClaimJobApiControllerTest extends TestCase
         // Claim job poster
         $response = $this->followingRedirects()
             ->actingAs($hrAdvisor->user)
-            ->json('post', "api/jobs/$job->id/claim");
+            ->json('put', "api/jobs/$job->id/claim");
         $response->assertOk();
         $expectedIds = array_merge(
             ['job_poster_id' => $job->id],
@@ -44,7 +44,7 @@ class ClaimJobApiControllerTest extends TestCase
         // Unclaim job poster
         $response = $this->followingRedirects()
             ->actingAs($hrAdvisor->user)
-            ->json('post', "api/jobs/$job->id/unclaim");
+            ->json('delete', "api/jobs/$job->id/claim");
         $response->assertOk();
         $this->assertDatabaseMissing('claimed_jobs', $expectedIds);
     }


### PR DESCRIPTION
Related to #1894 .

I didn't review PR #2047 before it got merged in, but there are a few minor changes I would have wanted to make, so here they are.

### Notes:
- Add specific JobPolicy permissions for claiming and unclaiming job.
- Changed api from post:claim/post:unclaim to put:claim/delete:claim
