### PR TITLE
Task - open Job Action cards 

### DIFF
--- a/resources/assets/js/components/JobCard.tsx
+++ b/resources/assets/js/components/JobCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useIntl, defineMessages, FormattedMessage } from "react-intl";
-import { JobStatus } from "../models/types";
+import { JobStatus } from "../models/lookupConstants";
 
 interface Link {
   url: string | null;

--- a/resources/assets/js/components/JobCard.tsx
+++ b/resources/assets/js/components/JobCard.tsx
@@ -1,14 +1,6 @@
 import React from "react";
 import { useIntl, defineMessages, FormattedMessage } from "react-intl";
-
-export enum JobStatus {
-  Approved = "Approved",
-  Closed = "Closed",
-  Complete = "Complete",
-  Draft = "Draft",
-  Published = "Published",
-  Review = "Review",
-}
+import { JobStatus } from "../models/types";
 
 interface Link {
   url: string | null;

--- a/resources/assets/js/components/OpenJobAction.tsx
+++ b/resources/assets/js/components/OpenJobAction.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { FormattedMessage } from "react-intl";
-import { JobStatus } from "../models/types";
+import { JobStatus } from "../models/lookupConstants";
 
 interface OpenJobActionProps {
   title: string;

--- a/resources/assets/js/components/OpenJobAction.tsx
+++ b/resources/assets/js/components/OpenJobAction.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { FormattedMessage } from "react-intl";
+import { JobStatus } from "../models/types";
+
+interface OpenJobActionProps {
+  title: string;
+  createdAt: string;
+  status: JobStatus;
+  hiringManagers: string[];
+  hrAdvisors: string[];
+}
+
+const OpenJobAction: React.FunctionComponent<OpenJobActionProps> = ({
+  title,
+  createdAt,
+  status,
+  hiringManagers,
+  hrAdvisors,
+}) => {
+  return (
+    <div
+      data-c-grid-item="tp(1of2) tl(1of3) equal-col"
+      className="tc-hr-job-card"
+    >
+      <div data-c-card data-c-radius="rounded" data-c-background="white(100)">
+        <a href="" title="" style={{ textDecoration: "none" }}>
+          <div data-c-background="black(100)" data-c-padding="all(normal)">
+            <div data-c-grid="gutter middle">
+              <div data-c-grid-item="base(1of1)">
+                <p
+                  data-c-font-size="h4"
+                  data-c-colour="white"
+                  data-c-font-style="underline"
+                >
+                  {title}
+                </p>
+              </div>
+              <div data-c-grid-item="base(1of2)">
+                <p data-c-colour="white" data-c-font-size="small">
+                  <FormattedMessage
+                    id="openJobCard.createdAt"
+                    description="Header for when Job Poster was created."
+                    defaultMessage="Created: "
+                  />
+                  {createdAt}
+                </p>
+              </div>
+              <div data-c-grid-item="base(1of2)" data-c-align="base(right)">
+                <span
+                  data-c-color="white"
+                  data-c-border="all(thin, solid, white)"
+                  data-c-padding="tb(quarter) rl(half)"
+                  data-c-font-size="small"
+                  data-c-radius="pill"
+                >
+                  {status}
+                </span>
+              </div>
+            </div>
+          </div>
+          <div data-c-padding="all(normal)">
+            <p data-c-color="black" data-c-margin="bottom(normal)">
+              <FormattedMessage
+                id="openJobCard.hiringManager"
+                description="Header before list of hiring managers."
+                defaultMessage="Hiring Managers: "
+              />
+
+              {hiringManagers.map((manager, index): string => {
+                const comma =
+                  hiringManagers.length !== 1 &&
+                  index + 1 !== hiringManagers.length
+                    ? ","
+                    : " ";
+                return `${manager}${comma} `;
+              })}
+            </p>
+
+            {hrAdvisors.length > 0 ? (
+              <p data-c-color="black" data-c-margin="bottom(normal)">
+                <FormattedMessage
+                  id="openJobCard.hrAdvisors"
+                  description="Header before list of HR advisors."
+                  defaultMessage="HR Advisors: "
+                />
+                {hrAdvisors.map((advisor, index): string => {
+                  const comma =
+                    hrAdvisors.length !== 1 && index + 1 !== hrAdvisors.length
+                      ? ","
+                      : " ";
+                  return `${advisor}${comma} `;
+                })}
+              </p>
+            ) : (
+              <p data-c-color="stop">
+                <FormattedMessage
+                  id="openJobCard.unclaimed"
+                  description="Message displayed if not HR managers have claimed a job."
+                  defaultMessage="Unclaimed"
+                />
+              </p>
+            )}
+          </div>
+          <div
+            data-c-padding="all(normal)"
+            data-c-border="top(thin, solid, black)"
+            data-c-align="base(right)"
+          >
+            <span data-c-color="black">
+              +{" "}
+              <span data-c-font-style="underline">
+                <FormattedMessage
+                  id="openJobCard.claimJob"
+                  description="Message indicating the event of clicking on the job card."
+                  defaultMessage="Claim This Job"
+                />
+              </span>
+            </span>
+          </div>
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default OpenJobAction;

--- a/resources/assets/js/models/lookupConstants.ts
+++ b/resources/assets/js/models/lookupConstants.ts
@@ -117,6 +117,15 @@ export const ClassificationId = {
   AD: 13,
 };
 
+export enum JobStatus {
+  Approved = "Approved",
+  Closed = "Closed",
+  Complete = "Complete",
+  Draft = "Draft",
+  Published = "Published",
+  Review = "Review",
+}
+
 export function enumToIds(enumType: object): number[] {
   const enumVals = Object.values(enumType);
   // Note: this first array includes the list of ids as strings, followed by the list of names as strings

--- a/resources/assets/js/models/types.ts
+++ b/resources/assets/js/models/types.ts
@@ -1,5 +1,4 @@
 /* eslint camelcase: "off", @typescript-eslint/camelcase: "off" */
-import { LocaleValue } from "yup";
 import { ReviewStatusId, ReviewStatusName } from "./lookupConstants";
 
 export interface JobTranslation {
@@ -48,15 +47,6 @@ export interface Job {
   overtime_requirement_id: number | null;
   en: JobTranslation;
   fr: JobTranslation;
-}
-
-export enum JobStatus {
-  Approved = "Approved",
-  Closed = "Closed",
-  Complete = "Complete",
-  Draft = "Draft",
-  Published = "Published",
-  Review = "Review",
 }
 
 export interface ManagerTranslation {

--- a/resources/assets/js/models/types.ts
+++ b/resources/assets/js/models/types.ts
@@ -50,6 +50,15 @@ export interface Job {
   fr: JobTranslation;
 }
 
+export enum JobStatus {
+  Approved = "Approved",
+  Closed = "Closed",
+  Complete = "Complete",
+  Draft = "Draft",
+  Published = "Published",
+  Review = "Review",
+}
+
 export interface ManagerTranslation {
   division: string | null;
   position: string | null;

--- a/resources/assets/js/stories/JobCard.stories.tsx
+++ b/resources/assets/js/stories/JobCard.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react";
 import { text, boolean, number } from "@storybook/addon-knobs";
 import { withIntl } from "storybook-addon-intl";
 import JobCard from "../components/JobCard";
-import { JobStatus } from "../models/types";
+import { JobStatus } from "../models/lookupConstants";
 
 const stories = storiesOf("Components|Job Card", module).addDecorator(withIntl);
 

--- a/resources/assets/js/stories/JobCard.stories.tsx
+++ b/resources/assets/js/stories/JobCard.stories.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { text, boolean, number } from "@storybook/addon-knobs";
 import { withIntl } from "storybook-addon-intl";
-import JobCard, { JobStatus } from "../components/JobCard";
+import JobCard from "../components/JobCard";
+import { JobStatus } from "../models/types";
 
 const stories = storiesOf("Components|Job Card", module).addDecorator(withIntl);
 

--- a/resources/assets/js/stories/OpenJobAction.stories.tsx
+++ b/resources/assets/js/stories/OpenJobAction.stories.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { text, select, array } from "@storybook/addon-knobs";
+import { withIntl } from "storybook-addon-intl";
+import OpenJobAction from "../components/OpenJobAction";
+import { JobStatus } from "../models/types";
+
+const stories = storiesOf("Components|Open Job Action", module).addDecorator(
+  withIntl,
+);
+
+const statusOptions = {
+  Approved: JobStatus.Approved,
+  Closed: JobStatus.Closed,
+  Complete: JobStatus.Complete,
+  Draft: JobStatus.Draft,
+  Published: JobStatus.Published,
+  Review: JobStatus.Review,
+};
+
+stories
+  .add(
+    "Unclaimed",
+    (): React.ReactElement => (
+      <div data-c-container="large" data-c-padding="tb(triple)">
+        <OpenJobAction
+          title={text("Title", "CS01 - Front-end Developer", "Props")}
+          createdAt={text("Created At", "Created: 2019-MAY-02", "Props")}
+          status={select("Status", statusOptions, JobStatus.Draft, "Props")}
+          hiringManagers={array(
+            "Hiring Managers",
+            ["Rebecca Appleby"],
+            ",",
+            "Props",
+          )}
+          hrAdvisors={[]}
+        />
+      </div>
+    ),
+  )
+  .add(
+    "Claimed",
+    (): React.ReactElement => (
+      <div data-c-container="large" data-c-padding="tb(triple)">
+        <OpenJobAction
+          title={text("Title", "AS02 - Executive Assisstant", "Props")}
+          createdAt={text("Created At", "Created: 2019-MAY-02", "Props")}
+          status={select("Status", statusOptions, JobStatus.Draft, "Props")}
+          hiringManagers={array(
+            "Hiring Managers",
+            ["Rebecca Appleby"],
+            ",",
+            "Props",
+          )}
+          hrAdvisors={array(
+            "HR Managers",
+            ["Rebecca Appleby", "Jack Little"],
+            ",",
+            "Props",
+          )}
+        />
+      </div>
+    ),
+  );

--- a/resources/assets/js/stories/OpenJobAction.stories.tsx
+++ b/resources/assets/js/stories/OpenJobAction.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react";
 import { text, select, array } from "@storybook/addon-knobs";
 import { withIntl } from "storybook-addon-intl";
 import OpenJobAction from "../components/OpenJobAction";
-import { JobStatus } from "../models/types";
+import { JobStatus } from "../models/lookupConstants";
 
 const stories = storiesOf("Components|Open Job Action", module).addDecorator(
   withIntl,


### PR DESCRIPTION
Resolves #1935 

### Notes:
- Created a Job Action Card component for jobs that can be claimed by the current HR adviser. 
    - Since there was already a component with the name `JobCard`, I named this `OpenJobAction`. However, I feel it needs a better name.
- The component can be viewed in Storybook under "Open Job Action". 
