### PR TITLE
Bugfix - JPB - Total number of tasks

### DIFF
--- a/resources/assets/js/components/JobBuilder/Details/JobDetailsPage.tsx
+++ b/resources/assets/js/components/JobBuilder/Details/JobDetailsPage.tsx
@@ -19,10 +19,7 @@ import {
   jobBuilderReview,
 } from "../../../helpers/routes";
 import JobBuilderStepContainer from "../JobBuilderStep";
-import {
-  isJobBuilderComplete,
-  VALID_COUNT,
-} from "../jobBuilderHelpers";
+import { isJobBuilderComplete } from "../jobBuilderHelpers";
 import { navigate } from "../../../helpers/router";
 
 interface JobDetailsPageProps {
@@ -35,9 +32,8 @@ interface JobDetailsPageProps {
   handleUpdateJob: (newJob: Job) => Promise<boolean>;
 }
 
-const JobDetailsPage: React.FunctionComponent<
-  JobDetailsPageProps & WrappedComponentProps
-> = ({
+const JobDetailsPage: React.FunctionComponent<JobDetailsPageProps &
+  WrappedComponentProps> = ({
   jobId,
   job,
   handleUpdateJob,
@@ -66,8 +62,7 @@ const JobDetailsPage: React.FunctionComponent<
   };
 
   const jobIsComplete =
-    job !== null &&
-    isJobBuilderComplete(job, keyTasks, VALID_COUNT, criteria, locale);
+    job !== null && isJobBuilderComplete(job, keyTasks, criteria, locale);
   return (
     <JobBuilderStepContainer jobId={jobId} currentPage="details">
       {job !== null && (

--- a/resources/assets/js/components/JobBuilder/Impact/JobBuilderImpactPage.tsx
+++ b/resources/assets/js/components/JobBuilder/Impact/JobBuilderImpactPage.tsx
@@ -25,7 +25,7 @@ import {
   getCriteriaByJob,
 } from "../../../store/Job/jobSelector";
 import JobBuilderStepContainer from "../JobBuilderStep";
-import { isJobBuilderComplete, VALID_COUNT } from "../jobBuilderHelpers";
+import { isJobBuilderComplete } from "../jobBuilderHelpers";
 import { navigate } from "../../../helpers/router";
 
 interface JobBuilderImpactPageProps {
@@ -39,9 +39,8 @@ interface JobBuilderImpactPageProps {
   handleUpdateJob: (newJob: Job) => Promise<boolean>;
 }
 
-const JobBuilderImpactPage: React.FunctionComponent<
-  JobBuilderImpactPageProps & WrappedComponentProps
-> = ({
+const JobBuilderImpactPage: React.FunctionComponent<JobBuilderImpactPageProps &
+  WrappedComponentProps> = ({
   jobId,
   job,
   departments,
@@ -72,8 +71,7 @@ const JobBuilderImpactPage: React.FunctionComponent<
     }
   };
   const jobIsComplete =
-    job !== null &&
-    isJobBuilderComplete(job, keyTasks, VALID_COUNT, criteria, locale);
+    job !== null && isJobBuilderComplete(job, keyTasks, criteria, locale);
   return (
     <JobBuilderStepContainer jobId={jobId} currentPage="impact">
       {job !== null && departments.length > 0 && (

--- a/resources/assets/js/components/JobBuilder/JobBuilderProgressTracker.tsx
+++ b/resources/assets/js/components/JobBuilder/JobBuilderProgressTracker.tsx
@@ -33,7 +33,6 @@ interface JobBuilderProgressTrackerProps {
   job: Job | null;
   jobId: number | null;
   tasks: JobPosterKeyTask[];
-  maxTasksCount: number;
   criteria: Criteria[];
   dataIsLoading: boolean;
   currentPage: JobBuilderPage | null;
@@ -59,13 +58,11 @@ const stepComesBefore = (
   return comesBefore;
 };
 
-export const JobBuilderProgressTracker: React.FunctionComponent<
-  JobBuilderProgressTrackerProps & WrappedComponentProps
-> = ({
+export const JobBuilderProgressTracker: React.FunctionComponent<JobBuilderProgressTrackerProps &
+  WrappedComponentProps> = ({
   job,
   jobId,
   tasks,
-  maxTasksCount,
   dataIsLoading,
   criteria,
   currentPage,
@@ -107,7 +104,6 @@ export const JobBuilderProgressTracker: React.FunctionComponent<
       ? "null"
       : jobTasksProgressState(
           tasks,
-          maxTasksCount,
           locale,
           stepComesBefore(currentPage, "tasks"),
         ),

--- a/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
+++ b/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
@@ -9,7 +9,7 @@ import {
   Skill,
   Department,
 } from "../../models/types";
-import { VALID_COUNT, JobBuilderPage } from "./jobBuilderHelpers";
+import { NUM_OF_TASKS, JobBuilderPage } from "./jobBuilderHelpers";
 import {
   getJob,
   getTasksByJob,
@@ -137,7 +137,6 @@ const JobBuilderStep: React.FunctionComponent<JobBuilderStepProps> = ({
         job={job}
         jobId={jobId}
         tasks={keyTasks}
-        maxTasksCount={VALID_COUNT}
         criteria={criteria}
         dataIsLoading={dataIsLoading}
         currentPage={currentPage}

--- a/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
+++ b/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
@@ -9,7 +9,7 @@ import {
   Skill,
   Department,
 } from "../../models/types";
-import { NUM_OF_TASKS, JobBuilderPage } from "./jobBuilderHelpers";
+import { JobBuilderPage } from "./jobBuilderHelpers";
 import {
   getJob,
   getTasksByJob,

--- a/resources/assets/js/components/JobBuilder/RedirectToLastIncompleteStep.tsx
+++ b/resources/assets/js/components/JobBuilder/RedirectToLastIncompleteStep.tsx
@@ -10,7 +10,6 @@ import {
   jobBuilderIntroProgressState,
   jobBuilderDetailsProgressState,
   JobBuilderPage,
-  VALID_COUNT,
   pageToUrlBuilder,
 } from "./jobBuilderHelpers";
 import { ProgressTrackerState } from "../ProgressTracker/types";
@@ -31,7 +30,6 @@ interface RedirectToLastIncompleteStepProps {
   job: Job | null;
   jobIsLoading: boolean;
   tasks: JobPosterKeyTask[];
-  maxTasksCount: number;
   tasksIsLoading: boolean;
   criteria: Criteria[];
   criteriaIsLoading: boolean;
@@ -66,14 +64,11 @@ export const firstIncompletePage = (
   return firstIncompletePage(pageStates, pageOrder.slice(1));
 };
 
-export const RedirectToLastIncompleteStep: React.FunctionComponent<
-  RedirectToLastIncompleteStepProps
-> = ({
+export const RedirectToLastIncompleteStep: React.FunctionComponent<RedirectToLastIncompleteStepProps> = ({
   jobId,
   job,
   jobIsLoading,
   tasks,
-  maxTasksCount,
   tasksIsLoading,
   criteria,
   criteriaIsLoading,
@@ -98,9 +93,7 @@ export const RedirectToLastIncompleteStep: React.FunctionComponent<
     impact: () =>
       jobIsLoading ? "null" : jobImpactProgressState(job, locale, false),
     tasks: () =>
-      tasksIsLoading
-        ? "null"
-        : jobTasksProgressState(tasks, maxTasksCount, locale, false),
+      tasksIsLoading ? "null" : jobTasksProgressState(tasks, locale, false),
     skills: () =>
       criteriaIsLoading
         ? "null"
@@ -162,7 +155,6 @@ export const RedirectPage: React.FC<{ jobId: number }> = ({ jobId }) => {
     <JobBuilderStepContainer jobId={jobId} currentPage={null} forceIsLoading>
       <RedirectToLastIncompleteStepConnected
         jobId={jobId}
-        maxTasksCount={VALID_COUNT}
         handleRedirect={redirect}
       />
     </JobBuilderStepContainer>

--- a/resources/assets/js/components/JobBuilder/Review/JobReviewPage.tsx
+++ b/resources/assets/js/components/JobBuilder/Review/JobReviewPage.tsx
@@ -23,10 +23,7 @@ import { getSkills } from "../../../store/Skill/skillSelector";
 import { DispatchType } from "../../../configureStore";
 import { submitJobForReview } from "../../../store/Job/jobActions";
 import JobBuilderStepContainer from "../JobBuilderStep";
-import {
-  isJobBuilderComplete,
-  VALID_COUNT,
-} from "../jobBuilderHelpers";
+import { isJobBuilderComplete } from "../jobBuilderHelpers";
 import JobReview from "./JobReview";
 import { getDepartments } from "../../../store/Department/deptSelector";
 import { getSelectedManager } from "../../../store/Manager/managerSelector";
@@ -48,9 +45,8 @@ interface JobBuilderReviewPageProps {
   loadManager: (managerId: number) => Promise<void>;
 }
 
-const JobBuilderReviewPage: React.FunctionComponent<
-  JobBuilderReviewPageProps & WrappedComponentProps
-> = ({
+const JobBuilderReviewPage: React.FunctionComponent<JobBuilderReviewPageProps &
+  WrappedComponentProps> = ({
   jobId,
   job,
   skills,
@@ -84,8 +80,7 @@ const JobBuilderReviewPage: React.FunctionComponent<
     nprogress.start();
   };
   const jobIsComplete =
-    job !== null &&
-    isJobBuilderComplete(job, keyTasks, VALID_COUNT, criteria, locale);
+    job !== null && isJobBuilderComplete(job, keyTasks, criteria, locale);
 
   return (
     <JobBuilderStepContainer jobId={jobId} currentPage="review">

--- a/resources/assets/js/components/JobBuilder/Tasks/JobTasks.tsx
+++ b/resources/assets/js/components/JobBuilder/Tasks/JobTasks.tsx
@@ -82,9 +82,8 @@ const formMessages = defineMessages({
   },
 });
 
-const JobTasks: React.FunctionComponent<
-  JobTasksProps & WrappedComponentProps
-> = ({
+const JobTasks: React.FunctionComponent<JobTasksProps &
+  WrappedComponentProps> = ({
   jobId,
   keyTasks,
   validCount,
@@ -175,14 +174,14 @@ const JobTasks: React.FunctionComponent<
   const updateValuesAndReturn = (values: { tasks: TaskFormValues[] }): void => {
     // The following only triggers after validations pass
     nprogress.start();
-    handleSubmit(
-      updateTasksWithValues(values.tasks, keyTasks || emptyTasks()),
-    ).then((): void => {
-      nprogress.done();
-      handleReturn();
-    }).catch((error): void => {
-      nprogress.done();
-    });
+    handleSubmit(updateTasksWithValues(values.tasks, keyTasks || emptyTasks()))
+      .then((): void => {
+        nprogress.done();
+        handleReturn();
+      })
+      .catch((error): void => {
+        nprogress.done();
+      });
   };
 
   return (
@@ -220,7 +219,7 @@ const JobTasks: React.FunctionComponent<
         <li>
           <FormattedMessage
             id="jobBuilder.tasks.intro.third"
-            defaultMessage="Aim to provide between four and six key tasks. (You can add as many key tasks as you want as you brainstorm here, but you can include no more than eight in the final job poster.)"
+            defaultMessage="Aim to provide between four and six key tasks. (You can add as many key tasks as you want as you brainstorm here, but you can include no more than six in the final job poster.)"
             description="Job Tasks page third intro section"
           />
         </li>

--- a/resources/assets/js/components/JobBuilder/Tasks/JobTasksPage.tsx
+++ b/resources/assets/js/components/JobBuilder/Tasks/JobTasksPage.tsx
@@ -3,10 +3,7 @@ import { WrappedComponentProps, injectIntl } from "react-intl";
 import { connect } from "react-redux";
 import ReactDOM from "react-dom";
 import { JobPosterKeyTask, Job, Criteria } from "../../../models/types";
-import {
-  VALID_COUNT,
-  isJobBuilderComplete,
-} from "../jobBuilderHelpers";
+import { NUM_OF_TASKS, isJobBuilderComplete } from "../jobBuilderHelpers";
 import JobTasks from "./JobTasks";
 import {
   jobBuilderSkills,
@@ -37,9 +34,8 @@ interface JobTasksPageProps {
   ) => Promise<JobPosterKeyTask[]>;
 }
 
-const JobTasksPage: React.FunctionComponent<
-  JobTasksPageProps & WrappedComponentProps
-> = ({
+const JobTasksPage: React.FunctionComponent<JobTasksPageProps &
+  WrappedComponentProps> = ({
   jobId,
   job,
   keyTasks,
@@ -67,15 +63,14 @@ const JobTasksPage: React.FunctionComponent<
     navigate(jobBuilderReview(locale, jobId));
   };
   const jobIsComplete =
-    job !== null &&
-    isJobBuilderComplete(job, keyTasks, VALID_COUNT, criteria, locale);
+    job !== null && isJobBuilderComplete(job, keyTasks, criteria, locale);
   return (
     <JobBuilderStepContainer jobId={jobId} currentPage="tasks">
       {job !== null && (
         <JobTasks
           jobId={jobId}
           keyTasks={keyTasks}
-          validCount={VALID_COUNT}
+          validCount={NUM_OF_TASKS}
           handleSubmit={handleSubmit}
           handleReturn={handleReturn}
           handleModalCancel={handleModalCancel}

--- a/resources/assets/js/components/JobBuilder/WorkEnv/JobBuilderWorkEnv.tsx
+++ b/resources/assets/js/components/JobBuilder/WorkEnv/JobBuilderWorkEnv.tsx
@@ -19,10 +19,7 @@ import {
   jobBuilderReview,
 } from "../../../helpers/routes";
 import JobBuilderStepContainer from "../JobBuilderStep";
-import {
-  isJobBuilderComplete,
-  VALID_COUNT,
-} from "../jobBuilderHelpers";
+import { isJobBuilderComplete } from "../jobBuilderHelpers";
 import { navigate } from "../../../helpers/router";
 
 interface JobBuilderWorkEnvProps {
@@ -39,9 +36,8 @@ interface JobBuilderWorkEnvProps {
   handleUpdateJob: (newJob: Job) => Promise<Job>;
 }
 
-const JobBuilderWorkEnv: React.FunctionComponent<
-  JobBuilderWorkEnvProps & WrappedComponentProps
-> = ({
+const JobBuilderWorkEnv: React.FunctionComponent<JobBuilderWorkEnvProps &
+  WrappedComponentProps> = ({
   jobId,
   job,
   handleUpdateJob,
@@ -67,8 +63,7 @@ const JobBuilderWorkEnv: React.FunctionComponent<
     }
   };
   const jobIsComplete =
-    job !== null &&
-    isJobBuilderComplete(job, keyTasks, VALID_COUNT, criteria, locale);
+    job !== null && isJobBuilderComplete(job, keyTasks, criteria, locale);
   return (
     <JobBuilderStepContainer jobId={jobId} currentPage="env">
       {job !== null && (

--- a/resources/assets/js/components/JobBuilder/jobBuilderHelpers.ts
+++ b/resources/assets/js/components/JobBuilder/jobBuilderHelpers.ts
@@ -11,7 +11,7 @@ import {
 } from "../../helpers/routes";
 
 /** Job Builder Constants */
-export const VALID_COUNT = 8;
+export const NUM_OF_TASKS = 6;
 
 const isFilled = (value: any | null | undefined): boolean => {
   return value !== null && value !== undefined && value !== "";
@@ -174,12 +174,11 @@ const isKeyTaskComplete = (
 ): boolean => isFilled(task[locale].description);
 const isJobTasksComplete = (
   tasks: JobPosterKeyTask[],
-  maxCount: number,
   locale: "en" | "fr",
 ): boolean => {
   return (
     tasks.length > 0 &&
-    tasks.length <= maxCount &&
+    tasks.length <= NUM_OF_TASKS &&
     tasks.every((task): boolean => isKeyTaskComplete(task, locale))
   );
 };
@@ -188,14 +187,13 @@ const isJobTasksUntouched = (tasks: JobPosterKeyTask[]): boolean =>
   tasks.length === 0;
 export const jobTasksProgressState = (
   tasks: JobPosterKeyTask[],
-  maxCount: number,
   locale: "en" | "fr",
   allowUntouched = false,
 ): ProgressTrackerState => {
   if (allowUntouched && isJobTasksUntouched(tasks)) {
     return "null";
   }
-  return isJobTasksComplete(tasks, maxCount, locale) ? "complete" : "error";
+  return isJobTasksComplete(tasks, locale) ? "complete" : "error";
 };
 
 const isCriterionComplete = (
@@ -233,7 +231,6 @@ export const criteriaProgressState = (
 export const isJobBuilderComplete = (
   job: Job,
   tasks: JobPosterKeyTask[],
-  maxTasksCount: number,
   criteria: Criteria[],
   locale: "en" | "fr",
 ): boolean => {
@@ -242,7 +239,7 @@ export const isJobBuilderComplete = (
     isJobBuilderDetailsComplete(job, locale) &&
     isJobBuilderEnvComplete(job, locale) &&
     isJobImpactComplete(job, locale) &&
-    isJobTasksComplete(tasks, maxTasksCount, locale) &&
+    isJobTasksComplete(tasks, locale) &&
     isCriteriaComplete(criteria, locale)
   );
 };

--- a/resources/assets/js/stories/JobPosterBuilder/RedirectToLastIncompleteStep.stories.tsx
+++ b/resources/assets/js/stories/JobPosterBuilder/RedirectToLastIncompleteStep.stories.tsx
@@ -6,7 +6,6 @@ import { boolean } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import fakeJob, { fakeCriterion, fakeJobTasks } from "../../fakeData/fakeJob";
 import { RedirectToLastIncompleteStep } from "../../components/JobBuilder/RedirectToLastIncompleteStep";
-import { VALID_COUNT } from "../../components/JobBuilder/jobBuilderHelpers";
 
 const stories = storiesOf(
   "Job Poster Builder|Redirect To Last Incomplete Step",
@@ -21,7 +20,6 @@ stories.add(
       job={boolean("Job is complete", false) ? fakeJob(1) : null}
       jobIsLoading={boolean("Job is loading", true)}
       tasks={boolean("Tasks are complete", false) ? fakeJobTasks(1) : []}
-      maxTasksCount={VALID_COUNT}
       tasksIsLoading={boolean("Tasks are loading", true)}
       criteria={
         boolean("Criteria are complete", false) ? [fakeCriterion(2, 1)] : []

--- a/resources/assets/js/translations/extractedMessages/resources/assets/js/components/JobTasks/JobTasks.json
+++ b/resources/assets/js/translations/extractedMessages/resources/assets/js/components/JobTasks/JobTasks.json
@@ -37,7 +37,7 @@
   {
     "id": "jobBuilder.tasks.intro.third",
     "description": "Job Tasks page third intro section",
-    "defaultMessage": "Aim to provide between four and six key tasks. (You can add as many key tasks as you want as you brainstorm here, but you can include no more than eight in the final job poster.)"
+    "defaultMessage": "Aim to provide between four and six key tasks. (You can add as many key tasks as you want as you brainstorm here, but you can include no more than six in the final job poster.)"
   },
   {
     "id": "jobBuilder.tasks.intro.fourth",

--- a/resources/assets/js/translations/locales/defaultMessages.json
+++ b/resources/assets/js/translations/locales/defaultMessages.json
@@ -2890,7 +2890,7 @@
         "id": "jobBuilder.tasks.intro.second"
       },
       {
-        "defaultMessage": "Aim to provide between four and six key tasks. (You can add as many key tasks as you want as you brainstorm here, but you can include no more than eight in the final job poster.)",
+        "defaultMessage": "Aim to provide between four and six key tasks. (You can add as many key tasks as you want as you brainstorm here, but you can include no more than six in the final job poster.)",
         "description": "Job Tasks page third intro section",
         "id": "jobBuilder.tasks.intro.third"
       },

--- a/resources/assets/js/translations/locales/fr.json
+++ b/resources/assets/js/translations/locales/fr.json
@@ -441,7 +441,7 @@
   "jobBuilder.tasks.intro.first": "À quoi le nouveau membre de votre équipe consacrera-t-il son temps? Quelles sont les tâches à exécuter?",
   "jobBuilder.tasks.intro.fourth": "Une fois que vous aurez terminé d’entrer les tâches principales, vous passerez à la détermination des compétences individuelles nécessaires à l’exécution de ces tâches.",
   "jobBuilder.tasks.intro.second": "Mettez l’accent sur les tâches à exécuter. Vous n’avez pas à donner tous les détails de l’emploi, mais les candidats souhaitent savoir comment ils vont passer la plus grande partie de leur temps.",
-  "jobBuilder.tasks.intro.third": "Visez à indiquer de quatre à six tâches principales. (Tout au long du remue-méninges, vous pouvez ajouter autant de tâches principales que vous le souhaitez ici, mais vous ne pouvez pas en inclure plus de huit dans l’offre d’emploi finale.)",
+  "jobBuilder.tasks.intro.third": "Visez à indiquer de quatre à six tâches principales. (Tout au long du remue-méninges, vous pouvez ajouter autant de tâches principales que vous le souhaitez ici, mais vous ne pouvez pas en inclure plus de six dans l’offre d’emploi finale.)",
   "jobBuilder.tasks.modal.body": "Voici un aperçu des tâches que vous venez de saisir. N’hésitez pas à retourner à la page précédente pour corriger ce que vous avez saisi ou à passer à l’étape suivante si vous en êtes satisfait.",
   "jobBuilder.tasks.modal.body.heading": "Tâches",
   "jobBuilder.tasks.modal.cancelButtonLabel": "Retour en arrière",


### PR DESCRIPTION
Resolves #2096 

### Notes:
- Changed the name of the constant to make more explicit. 
    - `VALID_COUNT` -> `NUM_OF_TASKS`
- Instead of importing the constant into each file using `isJobTasksUntouched`. I removed the argument and called the global value instead. 
- Updated the copy. 
