### PR TITLE
Bugfix - LinkedIn regex

### DIFF
--- a/app/Http/Controllers/ApplicantProfileController.php
+++ b/app/Http/Controllers/ApplicantProfileController.php
@@ -10,6 +10,8 @@ use App\Models\Applicant;
 use App\Models\ApplicantProfileAnswer;
 use App\Http\Controllers\Controller;
 use App\Services\Validation\Requests\UpdateApplicationProfileValidator;
+use App\Services\Validation\Rules\LinkedInUrlRule;
+use App\Services\Validation\Rules\TwitterHandleRule;
 
 class ApplicantProfileController extends Controller
 {
@@ -94,6 +96,9 @@ class ApplicantProfileController extends Controller
             array_push($profileQuestionForms, $formValues);
         }
 
+        $linkedInUrlPattern = LinkedInUrlRule::PATTERN;
+        $twitterHandlePattern = TwitterHandleRule::PATTERN;
+
         return view(
             'applicant/profile_01_about',
             [
@@ -105,7 +110,9 @@ class ApplicantProfileController extends Controller
                 'user' => $applicant->user,
                 'applicant' => $applicant,
                 'profile_photo_url' => '/images/user.png', // TODO: get real photos.
-                'form_submit_action' => route('profile.about.update', $applicant)
+                'form_submit_action' => route('profile.about.update', $applicant),
+                'linkedInUrlPattern' => $linkedInUrlPattern,
+                'twitterHandlePattern' => $twitterHandlePattern,
             ]
         );
     }

--- a/app/Services/Validation/Rules/LinkedInUrlRule.php
+++ b/app/Services/Validation/Rules/LinkedInUrlRule.php
@@ -12,7 +12,7 @@ class LinkedInUrlRule implements Rule
      *
      * @var string
      */
-    const PATTERN = '^https:\/\/[a-z]{2,3}\.linkedin\.com\/.*$';
+    const PATTERN = '^https?:\/\/[a-z]{2,3}\.linkedin\.com\/.*$';
 
     /**
      * Determine if the validation rule passes.

--- a/resources/views/applicant/profile/about/about.html.twig
+++ b/resources/views/applicant/profile/about/about.html.twig
@@ -187,6 +187,7 @@
                                     id="editProfileTwitter"
                                     type="text"
                                     name="twitter_username"
+                                    pattern="{{ twitterHandlePattern }}"
                                     value="{{ applicant.twitter_username }}" />
                             </div>
 
@@ -204,6 +205,7 @@
                                     id="editProfileLinkedin"
                                     type="text"
                                     name="linkedin_url"
+                                    pattern="{{ linkedInUrlPattern }}"
                                     value="{{ applicant.linkedin_url }}" />
                             </div>
 


### PR DESCRIPTION
Resolves #1952 

### Notes:
- I found the regex from here: https://stackoverflow.com/a/33760587
- I modified to allow `http` as well. I believe all linkedIn profiles use `.com`, and there is a country code  or `www` for prefix.
- I added the regex pattern to Applicant profile. 
