### PR TITLE
Updates partner departments in FAQ

### DIFF
--- a/resources/lang/en/applicant/faq.php
+++ b/resources/lang/en/applicant/faq.php
@@ -627,6 +627,8 @@ return [
                             '6' => 'Shared Services Canada',
                             '7' => 'Health Canada',
                             '8' => 'National Research Council',
+                            '9' => 'Employment and Social Development Canada',
+                            '10' => 'The Royal Canadian Mounted Police'
                         ]
                     ]
                 ]

--- a/resources/lang/fr/applicant/faq.php
+++ b/resources/lang/fr/applicant/faq.php
@@ -627,6 +627,8 @@ return [
                             "6" => "Services partagés Canada",
                             "7" => "Santé Canada",
                             "8" => "Conseil national de recherches Canada",
+                            "9" => "Emploi et Développement social Canada",
+                            "10" => "Gendarmerie royale du Canada"
                         ]
                     ]
                 ]


### PR DESCRIPTION
Adds two new partner departments to the FAQ content.

NOTE: This hasn't touched the database in anyway, just the static content on the one page.