### PR TITLE
Removes total from essential skills smiley UI and fixes #1950

### DIFF
--- a/resources/assets/js/components/JobBuilder/Skills/JobBuilderSkills.tsx
+++ b/resources/assets/js/components/JobBuilder/Skills/JobBuilderSkills.tsx
@@ -666,7 +666,7 @@ export const JobBuilderSkills: React.FunctionComponent<
               <p data-c-font-weight="bold" data-c-margin="bottom(normal)">
                 <FormattedMessage
                   id="jobBuilder.skills.statusSmiley.essentialTitle"
-                  defaultMessage="Total Number of Essential Skills"
+                  defaultMessage="Number of Essential Skills"
                   description="Title of skill status tracker"
                 />
               </p>
@@ -1055,7 +1055,7 @@ export const JobBuilderSkills: React.FunctionComponent<
                   <p data-c-font-size="small" data-c-font-weight="bold">
                     <FormattedMessage
                       id="jobBuilder.skills.statusSmiley.tooMany"
-                      defaultMessage="tooMany"
+                      defaultMessage="Too Many"
                       description="Description of quantity of skills"
                     />
                   </p>

--- a/resources/assets/js/translations/locales/fr.json
+++ b/resources/assets/js/translations/locales/fr.json
@@ -415,7 +415,7 @@
   "jobBuilder.skills.statusSmiley.essential.awesome": "Fantastique",
   "jobBuilder.skills.statusSmiley.essential.tooFew": "Insuffisant",
   "jobBuilder.skills.statusSmiley.essential.tooMany": "Trop",
-  "jobBuilder.skills.statusSmiley.essentialTitle": "Le nombre total des compétences fondamentales",
+  "jobBuilder.skills.statusSmiley.essentialTitle": "Le nombre des compétences fondamentales",
   "jobBuilder.skills.statusSmiley.title": "Le nombre total des compétences",
   "jobBuilder.skills.statusSmiley.tooFew": "Insuffisant",
   "jobBuilder.skills.statusSmiley.tooMany": "Trop",


### PR DESCRIPTION
Resolves #1950 and removes "total" from the essential smileys area in both EN and FR.
