### PR TITLE
Task - Admin - Job Poster filters

### DIFF
--- a/app/Http/Controllers/Admin/JobPosterCrudController.php
+++ b/app/Http/Controllers/Admin/JobPosterCrudController.php
@@ -2,11 +2,8 @@
 
 namespace App\Http\Controllers\Admin;
 
-use App\Models\JobPoster;
 use App\Models\Lookup\Department;
-use App\Models\User;
 use Backpack\CRUD\app\Http\Controllers\CrudController;
-use Illuminate\Support\Facades\Log;
 
 class JobPosterCrudController extends CrudController
 {
@@ -67,9 +64,7 @@ class JobPosterCrudController extends CrudController
             'label' => 'Manager',
             'orderable' => false,
             'function' => function ($entry) {
-                $full_name = $entry->manager->user->full_name;
-                $manager_id = $entry->manager->user->id;
-                return '<a href="' . route('manager.profile.edit', $manager_id) . '" target="_blank">' . $full_name . '</a>';
+                return '<a href="' . route('manager.profile.edit', $entry->manager->user->id) . '" target="_blank">' . $entry->manager->user->full_name . '</a>';
             }
         ]);
         $this->crud->addColumn([
@@ -101,22 +96,6 @@ class JobPosterCrudController extends CrudController
                     }
                 }
             });
-        });
-
-        $this->crud->addFilter([
-            'name' => 'status',
-            'type' => 'dropdown',
-            'label' => 'Status',
-        ], [
-            'draft' => 'draft',
-            'published' => 'published',
-            'closed' => 'closed',
-            'submitted' => 'submitted'
-        ], function ($value) {
-            $jobPosters = JobPoster::all();
-            foreach ($jobPosters as $jobPoster) {
-                Log::debug($jobPoster->status());
-            }
         });
     }
 

--- a/resources/views/vendor/backpack/crud/buttons/job_poster_link.blade.php
+++ b/resources/views/vendor/backpack/crud/buttons/job_poster_link.blade.php
@@ -1,0 +1,3 @@
+@if ($crud->hasAccess('update') && ($entry->status() === 'draft' || $entry->status() === 'submitted'))
+<a href="{{ route('manager.jobs.show', $entry->id) }} " target="_blank" class="btn btn-sm btn-link"><i class="fa fa-edit"></i>View</a>
+@endif


### PR DESCRIPTION
Resolves #1734 

## Requirements

- [x] Remove open and close date. (but should still exist in the "edit" form).
- [x] Add column for department.
- [x] Allow filter by department.
- [ ] Allow filter by status. 
    - Currently there is no column in the `job_posters` table that holds the current status. If we want to be able to filter by status we need to add a column in that is linked and updates the value during the lifespan of the job poster. This needs to be an issue on its own. @tristan-orourke 
- [x] Add "view" link in "actions" column that takes you to job poster (uri: /manager/jobs/{jobId})
- [x] Add column for manager name (Name). Make name a link to manager profile. (uri: /manager/profile/{managerId}/edit).
- [ ] change search to ONLY search English and French job poster "Title".
    - I went over this with Chris and from what I understand.. Since the Job Poster Translations are held within a different table this makes it very difficult (maybe not possible) to query the table. A solution is to mimic the setup used in the `skills` table, storing the locale values in JSON format. Again, this should be split up into another issue on it's own. @tristan-orourke 
## If not too hard

- [x] limit the width of these categories so they do not push other columns off the page.
  - [x] Title
  - [x] Manager
  - [x] Department
  - For above the page is already responsive.

