### PR TITLE
Fix required asterisks on radio elements

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -322,9 +322,9 @@
 
       $(".form__radio-group").each(function(e) {
         $(this).addClass("required");
-        //Find labels that haven't had the asterisk added yet
+        // Find labels that haven't had the asterisk added yet
         $(this)
-          // .children()
+          .children(":not(:has(.fa-asterisk))")
           .find(".form__label")
           .append(
             "<span class='form__required'><i class='fa fa-asterisk' aria-label='Asterisk'></i></span>"


### PR DESCRIPTION
Resolves ?

Can't find the issue for this, it's been happening for a long time.

Each new skill click was adding an extra 'required' asterisk on the radio element, on profiles and job applications.

![Screen Shot 2019-12-09 at 12 38 06 PM](https://user-images.githubusercontent.com/31678168/70458794-daf75600-1a80-11ea-85ce-246635cf869f.png)