### PR TITLE
Use newly added vscode setting for format on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,5 +38,8 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "workbench.settings.useSplitJSON": true,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }


### PR DESCRIPTION
Updated as part of VS Code's new version
