### PR TITLE
Fix bugs in admin portal caused by using User id where Manager id was needed

### DIFF
--- a/app/Http/Controllers/Admin/JobPosterCrudController.php
+++ b/app/Http/Controllers/Admin/JobPosterCrudController.php
@@ -64,7 +64,7 @@ class JobPosterCrudController extends CrudController
             'label' => 'Manager',
             'orderable' => false,
             'function' => function ($entry) {
-                return '<a href="' . route('manager.profile.edit', $entry->manager->user->id) . '" target="_blank">' . $entry->manager->user->full_name . '</a>';
+                return '<a href="' . route('manager.profile.edit', $entry->manager->id) . '" target="_blank">' . $entry->manager->user->full_name . '</a>';
             }
         ]);
         $this->crud->addColumn([

--- a/resources/views/vendor/backpack/crud/buttons/create_job_poster.blade.php
+++ b/resources/views/vendor/backpack/crud/buttons/create_job_poster.blade.php
@@ -1,4 +1,4 @@
-<form action="{{ route('admin.jobs.create_as_manager', $entry->id) }}" method="POST">
+<form action="{{ route('admin.jobs.create_as_manager', $entry->manager->id) }}" method="POST">
      @csrf
     <button class="btn btn-sm btn-link" type="submit"><i class="fa fa-edit"></i>Create Job Poster</button>
 </form>


### PR DESCRIPTION
Resolves #2492.

### Notes:
- Fixes bug with "Create as Manager" button (on Managers page of Admin portal).
- Also fixes broken "Manager profile" links on the Job Posters page of Admin portal.
