### PR TITLE
Let Admins trigger FinishHrRegistration middleware.

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -248,8 +248,7 @@ class User extends BaseModel implements
      */
     public function isHrAdvisor(): bool
     {
-        // Currently, every user can use the Manager portal as a demoManager.
-        return $this->user_role->name === 'hr_advisor';
+        return $this->user_role->name === 'hr_advisor' || $this->isAdmin();
     }
 
     /**


### PR DESCRIPTION
Resolves #2729.

### Notes:
- I just let Admins be considered to have the role of HrAdvisor. Anything that triggers for Hr Advisors should now trigger for Admins. This is how we deal with Admins using the Manager portal.
