### PR TITLE
Bugfix - Prevent multiple applicant submits

### DIFF
--- a/app/Http/Controllers/ApplicationByJobController.php
+++ b/app/Http/Controllers/ApplicationByJobController.php
@@ -761,14 +761,12 @@ class ApplicationByJobController extends Controller
      */
     public function submit(Request $request, JobPoster $jobPoster)
     {
-        $applicant = Auth::user()->applicant;
         $application = $this->getApplicationFromJob($jobPoster);
 
-        // Ensure user has permissions to update this application.
-        $this->authorize('update', $application);
-
         // Only complete submission if submit button was pressed.
-        if ($request->input('submit') == 'submit') {
+        if ($request->input('submit') == 'submit' && $application->application_status->name == 'draft') {
+            // Ensure user has permissions to update this application.
+            $this->authorize('update', $application);
             $request->validate([
                 'submission_signature' => [
                     'required',

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1327,4 +1327,15 @@
       }
     });
   });
+
+  // Disable application form submit buttons
+  function formPreventMultipleSubmit() {
+      $(".form-prevent-multiple-submit").submit(function (e) {
+          //disable the submit button
+          $(".button-prevent-multiple-submit").addClass("disabled");
+          return true;
+      });
+  }
+
+  formPreventMultipleSubmit();
 })(jQuery);

--- a/resources/assets/sass/components/common/_forms.scss
+++ b/resources/assets/sass/components/common/_forms.scss
@@ -360,7 +360,8 @@
                 color: red;
                 content: "\f06a";
                 display: block;
-                font: "Font Awesome 5 Free";
+                font-family: "Font Awesome 5 Free";
+                font-weight: 900;
                 font-size: $font-scale--regular;
                 position: absolute;
                 top: 50%;

--- a/resources/views/applicant/application_post_06.html.twig
+++ b/resources/views/applicant/application_post_06.html.twig
@@ -19,7 +19,7 @@
 	{% include "applicant/application_post/common/tracker-ajax" %}
 	{# Body #}
 	<form
-		action="{{ form_submit_action }}" method="post">
+		class="form-prevent-multiple-submit" action="{{ form_submit_action }}" method="post">
 		{# Builds an input field for CSRF token validation #}
 		{{ csrf_field() }}
 		{# Sections #}
@@ -54,12 +54,12 @@
 				{# <p>{{ application_template.integrity.review }}</p> #}
 				<div class="flex-grid middle application-post__action-wrapper">
 					<div class="box med-1of2">
-						<button class="button--blue light-bg" type="submit" name="submit" value="save_and_quit">
+						<button id="save_and_quit" class="button--blue light-bg button-prevent-multiple-submit" type="submit" name="submit" value="save_and_quit">
 							{{ application_template.integrity.save_label }}
 						</button>
 					</div>
 					<div class="box med-1of2">
-						<button class="button--blue light-bg" type="submit" name="submit" value="submit">
+						<button class="button--blue light-bg button-prevent-multiple-submit" type="submit" name="submit" value="submit">
 							{{ application_template.integrity.submit_label }}
 						</button>
 					</div>

--- a/resources/views/applicant/application_post_complete.html.twig
+++ b/resources/views/applicant/application_post_complete.html.twig
@@ -9,11 +9,10 @@
 	{{ application_template.complete.step_06_title }}
 {% endblock %}
 {% block body %}
-	# Government of Canada Block #}
+	{# Government of Canada Block #}
 	{% include "common/goc" %}
 	{# Alert #}
 	{% include "common/alert" %}
-	{
 	{# Page Header #}
 	{% include "common/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job.title})}} %}
 	<a id="skipLink"></a>


### PR DESCRIPTION
Resolves #2316 

### Notes:
- I prevented the multiple submits on the front-end and back-end:
  - Front-end: disabled the button after submission.
  - Back-end: Check if the applications status is equal to `draft` before updating in DB.
  
