### PR TITLE
Testcafe - Enable quarantine mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "test-watch": "jest --watchAll --updateSnapshot",
         "storybook": "start-storybook -s ./public -p 1234",
         "testcafe": "testcafe chrome,firefox tests/Browser/*.js -S -s tests/Browser/screenshots -u -e",
-        "testcafe-ci": "testcafe chrome:headless tests/Browser/*.js -u -e",
+        "testcafe-ci": "testcafe chrome:headless tests/Browser/*.js -u -e -q",
         "translations:extract": "cross-env NODE_ENV=development node_modules/.bin/babel ./resources/assets/js --extensions '.js,.jsx,.ts,.tsx'",
         "translations:check": "node ./translationRunner.js",
         "translations": "npm run translations:extract && npm run translations:check"


### PR DESCRIPTION
### Notes:
- I want to try seeing if [quarantine mode](https://devexpress.github.io/testcafe/documentation/using-testcafe/programming-interface/runner.html#quarantine-mode) will stop these randomly breaking tests. 
