### PR TITLE
Refactor: Always use function to extract localized values from ts objects

### DIFF
--- a/resources/assets/js/components/AssessmentPlan/AssessmentPlanAlert.tsx
+++ b/resources/assets/js/components/AssessmentPlan/AssessmentPlanAlert.tsx
@@ -16,6 +16,7 @@ import { DispatchType } from "../../configureStore";
 import { updateAssessmentPlanNotification } from "../../store/AssessmentPlanNotification/assessmentPlanNotificationActions";
 import { getSkills } from "../../store/Skill/skillSelector";
 import { mapToObject, getId, hasKey } from "../../helpers/queries";
+import { getLocale, localizeFieldNonNull } from "../../helpers/localize";
 
 interface AssessmentPlanAlertProps {
   notifications: AssessmentPlanNotification[];
@@ -34,6 +35,7 @@ export const AssessmentPlanAlert: React.FunctionComponent<AssessmentPlanAlertPro
   handleDismiss,
   intl,
 }): React.ReactElement | null => {
+  const locale = getLocale(intl.locale);
   if ((notifications.length === 0 && !isFetching) || isUpdating) {
     return null;
   }
@@ -64,7 +66,7 @@ export const AssessmentPlanAlert: React.FunctionComponent<AssessmentPlanAlertPro
   const skillsById = mapToObject(skills, getId);
   const skillName = (skillId: number): string =>
     hasKey(skillsById, skillId)
-      ? skillsById[skillId].name[intl.locale]
+      ? localizeFieldNonNull(locale, skillsById[skillId], "name")
       : "UNKNOWN SKILL";
   const createNotifications = notifications.filter(
     (notification): boolean => notification.type === "CREATE",

--- a/resources/assets/js/components/AssessmentPlan/AssessmentPlanSkill.tsx
+++ b/resources/assets/js/components/AssessmentPlan/AssessmentPlanSkill.tsx
@@ -40,6 +40,7 @@ import {
 import { getCriteriaById } from "../../store/Job/jobSelector";
 import { getSkillById } from "../../store/Skill/skillSelector";
 import { notEmpty } from "../../helpers/queries";
+import { getLocale, localizeField } from "../../helpers/localize";
 
 interface AssessmentPlanSkillProps {
   criterion: Criteria | null;
@@ -91,6 +92,7 @@ export const AssessmentPlanSkill: React.FunctionComponent<AssessmentPlanSkillPro
   intl,
 }: AssessmentPlanSkillProps &
   WrappedComponentProps): React.ReactElement | null => {
+  const locale = getLocale(intl.locale);
   useEffect((): void => {
     if (criterion === null || skill === null) {
       return;
@@ -136,9 +138,9 @@ export const AssessmentPlanSkill: React.FunctionComponent<AssessmentPlanSkillPro
   const skillLevelDescription = intl.formatMessage(
     SkillLevelDescriptionMessage(criterion.skill_level_id, skill.skill_type_id),
   );
-  const skillDescription = criterion.description[intl.locale]
-    ? criterion.description[intl.locale]
-    : skill.description[intl.locale];
+  const skillDescription = localizeField(locale, criterion, "description")
+    ? localizeField(locale, criterion, "description")
+    : localizeField(locale, skill, "description");
   const assessmentTypeOptions = enumToIds(AssessmentTypeId).map(
     (typeId): SelectOption => {
       return {
@@ -230,7 +232,7 @@ export const AssessmentPlanSkill: React.FunctionComponent<AssessmentPlanSkillPro
               defaultMessage="{skillName} - {skillLevel}"
               description="Title of a skill section in the Assessment Plan Builder."
               values={{
-                skillName: skill.name[intl.locale],
+                skillName: localizeField(locale, skill, "name"),
                 skillLevel,
               }}
             />

--- a/resources/assets/js/components/AssessmentPlan/AssessmentPlanTable.tsx
+++ b/resources/assets/js/components/AssessmentPlan/AssessmentPlanTable.tsx
@@ -14,6 +14,7 @@ import { RootState } from "../../store/store";
 import { getCriteriaByJob } from "../../store/Job/jobSelector";
 import { getSkills } from "../../store/Skill/skillSelector";
 import { getAssessmentsByJob } from "../../store/Assessment/assessmentSelectorComplex";
+import { localizeField, Locales, getLocale } from "../../helpers/localize";
 
 interface AssessmentPlanTableProps {
   /** All assessments to be displayed in this table */
@@ -29,7 +30,7 @@ const renderAssessmentTypeBlock = (
   assessmentTypeName: string,
   criteria: Criteria[],
   skills: Skill[],
-  locale: string,
+  locale: Locales,
 ): React.ReactElement => {
   const essentialSkills: Skill[] = criteria
     .filter(
@@ -96,7 +97,7 @@ const renderAssessmentTypeBlock = (
                 <li
                   key={`assessmentSummary_type${assessmentTypeId}_essential_skill${skill.id}`}
                 >
-                  {skill.name[locale]}
+                  {localizeField(locale, skill, "name")}
                 </li>
               ),
             )}
@@ -125,7 +126,7 @@ const renderAssessmentTypeBlock = (
                 <li
                   key={`assessmentSummary_type${assessmentTypeId}_asset_skill${skill.id}`}
                 >
-                  {skill.name[locale]}
+                  {localizeField(locale, skill, "name")}
                 </li>
               ),
             )}
@@ -230,7 +231,7 @@ const AssessmentPlanTable: React.FunctionComponent<AssessmentPlanTableProps &
               intl.formatMessage(assessmentType(assessmentTypeId)),
               associatedCriteria,
               skills,
-              intl.locale,
+              getLocale(intl.locale),
             );
           },
         )}

--- a/resources/assets/js/components/AssessmentPlan/RatingGuideAnswer.tsx
+++ b/resources/assets/js/components/AssessmentPlan/RatingGuideAnswer.tsx
@@ -32,6 +32,7 @@ import {
   getCriteriaToSkills,
   getCachedCriteriaUnansweredForQuestion,
 } from "../../store/Job/jobSelectorComplex";
+import { getLocale, localizeFieldNonNull } from "../../helpers/localize";
 
 interface RatingGuideAnswerProps {
   answer: RatingGuideAnswerModel | null;
@@ -102,6 +103,7 @@ const RatingGuideAnswer: React.FunctionComponent<RatingGuideAnswerProps &
   if (answer === null) {
     return null;
   }
+  const locale = getLocale(intl.locale);
   const availableCriteria = getAvailableCriteria(
     unansweredCriteria,
     answerCriterion,
@@ -116,7 +118,7 @@ const RatingGuideAnswer: React.FunctionComponent<RatingGuideAnswerProps &
         : null;
       return {
         value: criterion.id,
-        label: skill ? skill.name[intl.locale] : "",
+        label: skill ? localizeFieldNonNull(locale, skill, "name") : "",
       };
     },
   );

--- a/resources/assets/js/components/AssessmentPlan/RatingGuideClipboard.test.ts
+++ b/resources/assets/js/components/AssessmentPlan/RatingGuideClipboard.test.ts
@@ -19,7 +19,7 @@ import {
   criteriaType,
 } from "../../models/localizedConstants";
 import { clipboardData, ClipboardTableRowProps } from "./RatingGuideClipboard";
-import { localizeField } from "../../helpers/localize";
+import { localizeFieldNonNull } from "../../helpers/localize";
 
 const jediSkill: Skill = fakeSkill();
 
@@ -95,8 +95,8 @@ const expectedOutput: ClipboardTableRowProps[] = [
     criteriaTypeName: formatMessage(
       criteriaType(someCriteria[1].criteria_type_id),
     ),
-    skillName: localizeField("en", someSkills[1], "name"),
-    skillDescription: localizeField("en", someSkills[1], "description"),
+    skillName: localizeFieldNonNull("en", someSkills[1], "name"),
+    skillDescription: localizeFieldNonNull("en", someSkills[1], "description"),
     modelAnswer: someRatingGuideAnswers[1].expected_answer,
   },
   {
@@ -112,8 +112,8 @@ const expectedOutput: ClipboardTableRowProps[] = [
     criteriaTypeName: formatMessage(
       criteriaType(someCriteria[3].criteria_type_id),
     ),
-    skillName: localizeField("en", someSkills[3], "name"),
-    skillDescription: localizeField("en", someSkills[3], "description"),
+    skillName: localizeFieldNonNull("en", someSkills[3], "name"),
+    skillDescription: localizeFieldNonNull("en", someSkills[3], "description"),
     modelAnswer: someRatingGuideAnswers[3].expected_answer,
   },
   {
@@ -129,8 +129,8 @@ const expectedOutput: ClipboardTableRowProps[] = [
     criteriaTypeName: formatMessage(
       criteriaType(someCriteria[2].criteria_type_id),
     ),
-    skillName: localizeField("en", someSkills[2], "name"),
-    skillDescription: localizeField("en", someSkills[2], "description"),
+    skillName: localizeFieldNonNull("en", someSkills[2], "name"),
+    skillDescription: localizeFieldNonNull("en", someSkills[2], "description"),
     modelAnswer: someRatingGuideAnswers[2].expected_answer,
   },
   {
@@ -146,8 +146,8 @@ const expectedOutput: ClipboardTableRowProps[] = [
     criteriaTypeName: formatMessage(
       criteriaType(someCriteria[0].criteria_type_id),
     ),
-    skillName: localizeField("en", someSkills[0], "name"),
-    skillDescription: localizeField("en", someSkills[0], "description"),
+    skillName: localizeFieldNonNull("en", someSkills[0], "name"),
+    skillDescription: localizeFieldNonNull("en", someSkills[0], "description"),
     modelAnswer: someRatingGuideAnswers[0].expected_answer,
   },
 ];

--- a/resources/assets/js/components/AssessmentPlan/RatingGuideClipboard.test.ts
+++ b/resources/assets/js/components/AssessmentPlan/RatingGuideClipboard.test.ts
@@ -19,6 +19,7 @@ import {
   criteriaType,
 } from "../../models/localizedConstants";
 import { clipboardData, ClipboardTableRowProps } from "./RatingGuideClipboard";
+import { localizeField } from "../../helpers/localize";
 
 const jediSkill: Skill = fakeSkill();
 
@@ -94,8 +95,8 @@ const expectedOutput: ClipboardTableRowProps[] = [
     criteriaTypeName: formatMessage(
       criteriaType(someCriteria[1].criteria_type_id),
     ),
-    skillName: someSkills[1].name.en,
-    skillDescription: someSkills[1].description.en,
+    skillName: localizeField("en", someSkills[1], "name"),
+    skillDescription: localizeField("en", someSkills[1], "description"),
     modelAnswer: someRatingGuideAnswers[1].expected_answer,
   },
   {
@@ -111,8 +112,8 @@ const expectedOutput: ClipboardTableRowProps[] = [
     criteriaTypeName: formatMessage(
       criteriaType(someCriteria[3].criteria_type_id),
     ),
-    skillName: someSkills[3].name.en,
-    skillDescription: someSkills[3].description.en,
+    skillName: localizeField("en", someSkills[3], "name"),
+    skillDescription: localizeField("en", someSkills[3], "description"),
     modelAnswer: someRatingGuideAnswers[3].expected_answer,
   },
   {
@@ -128,8 +129,8 @@ const expectedOutput: ClipboardTableRowProps[] = [
     criteriaTypeName: formatMessage(
       criteriaType(someCriteria[2].criteria_type_id),
     ),
-    skillName: someSkills[2].name.en,
-    skillDescription: someSkills[2].description.en,
+    skillName: localizeField("en", someSkills[2], "name"),
+    skillDescription: localizeField("en", someSkills[2], "description"),
     modelAnswer: someRatingGuideAnswers[2].expected_answer,
   },
   {
@@ -145,8 +146,8 @@ const expectedOutput: ClipboardTableRowProps[] = [
     criteriaTypeName: formatMessage(
       criteriaType(someCriteria[0].criteria_type_id),
     ),
-    skillName: someSkills[0].name.en,
-    skillDescription: someSkills[0].description.en,
+    skillName: localizeField("en", someSkills[0], "name"),
+    skillDescription: localizeField("en", someSkills[0], "description"),
     modelAnswer: someRatingGuideAnswers[0].expected_answer,
   },
 ];

--- a/resources/assets/js/components/AssessmentPlan/RatingGuideClipboard.tsx
+++ b/resources/assets/js/components/AssessmentPlan/RatingGuideClipboard.tsx
@@ -26,6 +26,7 @@ import { getSkills } from "../../store/Skill/skillSelector";
 import { getRatingGuideQuestionsByJob } from "../../store/RatingGuideQuestion/ratingGuideQuestionSelectors";
 import { getRatingGuideAnswersByJob } from "../../store/RatingGuideAnswer/ratingGuideAnswerSelectors";
 import { copyElementContents } from "../../helpers/clipboard";
+import { Locales, getLocale, localizeFieldNonNull } from "../../helpers/localize";
 
 export interface ClipboardTableRowProps {
   id: string;
@@ -44,7 +45,7 @@ export const clipboardData = (
   skills: Skill[],
   ratingGuideQuestions: RatingGuideQuestion[],
   ratingGuideAnswers: RatingGuideAnswer[],
-  locale: string,
+  locale: Locales,
   formatMessage: (message: MessageDescriptor) => string,
   narrativeReview?: Assessment[],
 ): ClipboardTableRowProps[] => {
@@ -79,11 +80,11 @@ export const clipboardData = (
                   criteriaType(narrativeCriterion.criteria_type_id),
                 ),
           skillName:
-            narrativeSkill === undefined ? "" : narrativeSkill.name[locale],
+            narrativeSkill === undefined ? "" : localizeFieldNonNull(locale, narrativeSkill, "name"),
           skillDescription:
             narrativeSkill === undefined
               ? ""
-              : narrativeSkill.description[locale],
+              : localizeFieldNonNull(locale, narrativeSkill, "description"),
           modelAnswer: "",
           id:
             narrativeCriterion === undefined
@@ -149,11 +150,11 @@ export const clipboardData = (
             ? ""
             : formatMessage(criteriaType(criterionByAnswer.criteria_type_id)),
         skillName:
-          skillByCriterion === undefined ? "" : skillByCriterion.name[locale],
+          skillByCriterion === undefined ? "" : localizeFieldNonNull(locale, skillByCriterion, "name"),
         skillDescription:
           skillByCriterion === undefined
             ? ""
-            : skillByCriterion.description[locale],
+            : localizeFieldNonNull(locale, skillByCriterion, "description"),
         modelAnswer: answer.expected_answer ? answer.expected_answer : "",
         id:
           questionByAnswer === undefined || criterionByAnswer === undefined
@@ -265,7 +266,7 @@ const RatingGuideClipboard: React.FunctionComponent<TableProps &
       skills,
       ratingGuideQuestions,
       ratingGuideAnswers,
-      intl.locale,
+      getLocale(intl.locale),
       intl.formatMessage,
       narrativeReview,
     ),

--- a/resources/assets/js/components/AssessmentPlan/RatingGuideMissing.tsx
+++ b/resources/assets/js/components/AssessmentPlan/RatingGuideMissing.tsx
@@ -13,6 +13,7 @@ import {
   getCriteriaToSkills,
 } from "../../store/Job/jobSelectorComplex";
 import { notEmpty } from "../../helpers/queries";
+import { getLocale, localizeFieldNonNull } from "../../helpers/localize";
 
 interface RatingGuideMissingProps {
   missingCriteria: Criteria[];
@@ -25,6 +26,7 @@ export const RatingGuideMissing: React.FunctionComponent<RatingGuideMissingProps
   criteriaToSkills,
   intl,
 }): React.ReactElement | null => {
+  const locale = getLocale(intl.locale);
   const getSkillsForCriteria: (criteria: Criteria[]) => Skill[] = (
     criteria,
   ): Skill[] =>
@@ -52,10 +54,10 @@ export const RatingGuideMissing: React.FunctionComponent<RatingGuideMissingProps
     return null;
   }
   const essentialSkillNames = missingEssentialSkills.map(
-    (skill: Skill): string => skill.name[intl.locale],
+    (skill: Skill): string => localizeFieldNonNull(locale, skill, "name"),
   );
-  const assetSkillNames = missingAssetSkills.map(
-    (skill: Skill): string => skill.name[intl.locale],
+  const assetSkillNames = missingAssetSkills.map((skill: Skill): string =>
+    localizeFieldNonNull(locale, skill, "name"),
   );
 
   return (

--- a/resources/assets/js/components/AssessmentPlan/RatingGuideNarrativeAssessment.tsx
+++ b/resources/assets/js/components/AssessmentPlan/RatingGuideNarrativeAssessment.tsx
@@ -19,6 +19,7 @@ import {
   getCriteriaByJobAndAssessmentType,
   getCriteriaToSkills,
 } from "../../store/Job/jobSelectorComplex";
+import { getLocale, localizeFieldNonNull } from "../../helpers/localize";
 
 interface RatingGuideNarrativeAssessmentProps {
   /** The id of the job Job Poster this is part of */
@@ -38,6 +39,7 @@ export const RatingGuideNarrativeAssessment: React.FunctionComponent<RatingGuide
   criteriaToSkill,
   intl,
 }): React.ReactElement | null => {
+  const locale = getLocale(intl.locale);
   if (jobId === null) {
     return null;
   }
@@ -47,7 +49,7 @@ export const RatingGuideNarrativeAssessment: React.FunctionComponent<RatingGuide
   };
   const getCriteriaSkillName = (criterionId: number): string => {
     const skill = criteriaToSkill[criterionId];
-    return skill ? skill.name[intl.locale] : "";
+    return skill ? localizeFieldNonNull(locale, skill, "name") : "";
   };
   return (
     <div>

--- a/resources/assets/js/components/JobBuilder/Criterion.tsx
+++ b/resources/assets/js/components/JobBuilder/Criterion.tsx
@@ -7,6 +7,7 @@ import {
 import { Criteria, Skill } from "../../models/types";
 import { getSkillLevelName } from "../../models/jobUtil";
 import { CriteriaTypeId } from "../../models/lookupConstants";
+import { getLocale, localizeField } from "../../helpers/localize";
 
 interface CriterionProps {
   criterion: Criteria;
@@ -15,10 +16,8 @@ interface CriterionProps {
 
 export const Criterion: React.FunctionComponent<CriterionProps &
   WrappedComponentProps> = ({ criterion, skill, intl }): React.ReactElement => {
-  const { locale } = intl;
-  if (locale !== "en" && locale !== "fr") {
-    throw new Error("Unknown intl.locale");
-  }
+  const locale = getLocale(intl.locale);
+
   return (
     <div
       key={skill.id}
@@ -26,7 +25,7 @@ export const Criterion: React.FunctionComponent<CriterionProps &
       data-c-margin="top(normal) bottom(double)"
     >
       <p data-c-font-weight="bold" data-c-margin="bottom(half)">
-        {skill.name[locale]}
+        {localizeField(locale, skill, "name")}
       </p>
       {criterion.criteria_type_id === CriteriaTypeId.Essential && (
         <p data-c-margin="bottom(half)">
@@ -38,8 +37,12 @@ export const Criterion: React.FunctionComponent<CriterionProps &
           {intl.formatMessage(getSkillLevelName(criterion, skill))}
         </p>
       )}
-      {criterion.description[locale] && <p>{criterion.description[locale]}</p>}
-      {criterion.specificity[locale] && <p>{criterion.specificity[locale]}</p>}
+      {localizeField(locale, criterion, "description") && (
+        <p>{localizeField(locale, criterion, "description")}</p>
+      )}
+      {localizeField(locale, criterion, "specificity") && (
+        <p>{localizeField(locale, criterion, "specificity")}</p>
+      )}
     </div>
   );
 };

--- a/resources/assets/js/components/JobBuilder/Details/JobDetails.tsx
+++ b/resources/assets/js/components/JobBuilder/Details/JobDetails.tsx
@@ -49,6 +49,7 @@ import CopyToClipboardButton from "../../CopyToClipboardButton";
 import TextAreaInput from "../../Form/TextAreaInput";
 import { formMessages, educationMessages } from "./JobDetailsMessages";
 import { hasKey } from "../../../helpers/queries";
+import { localizeField } from "../../../helpers/localize";
 
 interface JobDetailsProps {
   // Optional Job to prepopulate form values from.
@@ -197,14 +198,14 @@ const jobToValues = (
 ): DetailsFormValues => {
   const values: DetailsFormValues = job
     ? {
-        title: job.title[locale] || "", // TODO: use utility method
+        title: localizeField(locale, job, "title") || "", // TODO: use utility method
         termLength: job.term_qty || "",
         classification: job.classification_id || "",
         level: job.classification_level || "",
-        educationRequirements: job.education[locale] || "",
+        educationRequirements: localizeField(locale, job, "education") || "",
         securityLevel: job.security_clearance_id || "",
         language: job.language_requirement_id || "",
-        city: job.city[locale] || "",
+        city: localizeField(locale, job, "city") || "",
         province: job.province_id || "",
         remoteWork: job.remote_work_allowed
           ? "remoteWorkCanada"

--- a/resources/assets/js/components/JobBuilder/Intro/IntroForm.tsx
+++ b/resources/assets/js/components/JobBuilder/Intro/IntroForm.tsx
@@ -14,6 +14,7 @@ import { Job, Department, Manager } from "../../../models/types";
 import { emptyJob } from "../../../models/jobUtil";
 import TextInput from "../../Form/TextInput";
 import { accountSettings } from "../../../helpers/routes";
+import { localizeFieldNonNull } from "../../../helpers/localize";
 
 const pageMessages = defineMessages({
   explanationBoldText: {
@@ -207,9 +208,12 @@ const IntroForm: React.FunctionComponent<IntroFormProps &
   const [languageSelection, setLanguageSelection] = useState(locale);
   const getDepartmentName = (): string | undefined => {
     // eslint-disable-next-line camelcase
-    return departments.find(
+    const department = departments.find(
       department => department.id === manager.department_id,
-    )?.name[locale];
+    );
+    return department
+      ? localizeFieldNonNull(locale, department, "name")
+      : undefined;
   };
 
   const introSchema = Yup.object().shape({

--- a/resources/assets/js/components/JobBuilder/JobBasicInfo.tsx
+++ b/resources/assets/js/components/JobBuilder/JobBasicInfo.tsx
@@ -11,6 +11,7 @@ import {
   languageRequirement,
   provinceName,
 } from "../../models/localizedConstants";
+import { localizeField, getLocale } from "../../helpers/localize";
 
 interface JobBasicInfoProps {
   job: Job;
@@ -27,12 +28,9 @@ const messages = defineMessages({
 
 export const JobBasicInfo: React.FunctionComponent<JobBasicInfoProps &
   WrappedComponentProps> = ({ job, intl }): React.ReactElement => {
-  const { locale } = intl;
-  if (locale !== "en" && locale !== "fr") {
-    throw new Error("Unknown intl.locale");
-  }
-  const title = job.title[locale];
-  const city = job.city[locale];
+  const locale = getLocale(intl.locale);
+  const title = localizeField(locale, job, "title");
+  const city = localizeField(locale, job, "city");
   const termLength = job.term_qty || 0;
   const securityLevel = job.security_clearance_id
     ? intl.formatMessage(securityClearance(job.security_clearance_id))

--- a/resources/assets/js/components/JobBuilder/Review/JobReview.tsx
+++ b/resources/assets/js/components/JobBuilder/Review/JobReview.tsx
@@ -50,7 +50,7 @@ import { classificationString } from "../../../models/jobUtil";
 import DemoSubmitJobModal from "./DemoSubmitJobModal";
 import ManagerSurveyModal from "./ManagerSurveyModal";
 import JobReviewActivityFeed from "./JobReviewActivityFeed";
-import { localizeField } from "../../../helpers/localize";
+import { localizeFieldNonNull, localizeField } from "../../../helpers/localize";
 
 interface JobReviewSectionProps {
   title: string;
@@ -365,7 +365,7 @@ export const JobReviewDisplay: React.FC<JobReviewDisplayProps> = ({
     const department =
       departmentId !== null ? find(departments, departmentId) : null;
     return department !== null
-      ? localizeField(locale, department, "name")
+      ? localizeFieldNonNull(locale, department, "name")
       : "MISSING DEPARTMENT";
   };
   const departmentName = getDeptName(job.department_id);

--- a/resources/assets/js/components/JobBuilder/Skills/CriteriaForm.tsx
+++ b/resources/assets/js/components/JobBuilder/Skills/CriteriaForm.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../../models/localizedConstants";
 import ContextBlockItem from "../../ContextBlock/ContextBlockItem";
 import ContextBlock from "../../ContextBlock/ContextBlock";
+import { localizeField, getLocale } from "../../../helpers/localize";
 
 interface CriteriaFormProps {
   // The Job Poster this criteria will belong to.
@@ -118,7 +119,7 @@ export const criteriaToValues = (
   criteria: Criteria,
   locale: "en" | "fr",
 ): FormValues => ({
-  specificity: criteria.specificity[locale] || "",
+  specificity: localizeField(locale, criteria, "specificity") || "",
   level:
     criteria.criteria_type_id === CriteriaTypeId.Asset
       ? "asset"
@@ -176,14 +177,12 @@ export const CriteriaForm: React.FunctionComponent<CriteriaFormProps &
   handleCancel,
   intl,
 }): React.ReactElement => {
-  const { locale } = intl;
-  if (locale !== "en" && locale !== "fr") {
-    throw new Error("Unknown intl.locale");
-  }
+  const locale = getLocale(intl.locale);
   const stringNotEmpty = (value: string | null): boolean =>
     value !== null && (value as string).length !== 0;
   const [showSpecificity, setShowSpecificity] = useState(
-    criteria !== undefined && stringNotEmpty(criteria.specificity[locale]),
+    criteria !== undefined &&
+      stringNotEmpty(localizeField(locale, criteria, "specificity")),
   );
 
   const initialValues: FormValues =
@@ -241,9 +240,11 @@ export const CriteriaForm: React.FunctionComponent<CriteriaFormProps &
                 />
               </p>
               <div>
-                <p data-c-margin="bottom(normal)">{skill.name[locale]}</p>
                 <p data-c-margin="bottom(normal)">
-                  {skill.description[locale]}
+                  {localizeField(locale, skill, "name")}
+                </p>
+                <p data-c-margin="bottom(normal)">
+                  {localizeField(locale, skill, "description")}
                 </p>
                 {showSpecificity ? (
                   <>

--- a/resources/assets/js/components/JobBuilder/Skills/JobBuilderSkills.tsx
+++ b/resources/assets/js/components/JobBuilder/Skills/JobBuilderSkills.tsx
@@ -19,6 +19,7 @@ import {
 import Select, { SelectOption } from "../../Select";
 import { getSkillLevelName } from "../../../models/jobUtil";
 import Criterion from "../Criterion";
+import { localizeField, getLocale, localizeFieldNonNull } from "../../../helpers/localize";
 
 interface JobBuilderSkillsProps {
   // The job being built
@@ -214,10 +215,7 @@ export const JobBuilderSkills: React.FunctionComponent<JobBuilderSkillsProps &
   handleSkipToReview,
   intl,
 }): React.ReactElement => {
-  const { locale } = intl;
-  if (locale !== "en" && locale !== "fr") {
-    throw new Error("Unknown intl.locale");
-  }
+  const locale = getLocale(intl.locale);
 
   // The ideal number of skills for each category
   const minOccupational = 3;
@@ -278,8 +276,8 @@ export const JobBuilderSkills: React.FunctionComponent<JobBuilderSkillsProps &
   };
 
   const sortAlphabetically = (a: Skill, b: Skill): number => {
-    const skillA: string = a.name[locale].toUpperCase();
-    const skillB: string = b.name[locale].toUpperCase();
+    const skillA: string = localizeFieldNonNull(locale, a, "name").toUpperCase();
+    const skillB: string = localizeFieldNonNull(locale, b, "name").toUpperCase();
 
     return skillA.localeCompare(skillB, locale, { sensitivity: "base" });
   };
@@ -504,7 +502,7 @@ export const JobBuilderSkills: React.FunctionComponent<JobBuilderSkillsProps &
                   <i className="fas fa-book" />
                 </span> */}
                 {/* The skill name. */}
-                <span>{skill.name[locale]}</span>
+                <span>{localizeField(locale, skill, "name")}</span>
               </div>
               <div data-c-grid-item="base(1of1) tl(1of3)">
                 <span
@@ -582,7 +580,7 @@ export const JobBuilderSkills: React.FunctionComponent<JobBuilderSkillsProps &
             <i className="fas fa-plus-circle" />
             <i className="fas fa-minus-circle" />
           </span>
-          {skill.name[locale]}
+          {localizeField(locale, skill, "name")}
         </button>
       </li>
     );
@@ -1480,7 +1478,7 @@ export const JobBuilderSkills: React.FunctionComponent<JobBuilderSkillsProps &
                 options={unselectedOtherSkills.map(
                   (skill): SelectOption => ({
                     value: skill.id,
-                    label: skill.name[locale],
+                    label: localizeFieldNonNull(locale, skill, "name"),
                   }),
                 )}
                 onChange={(event): void => {
@@ -1602,7 +1600,7 @@ export const JobBuilderSkills: React.FunctionComponent<JobBuilderSkillsProps &
               <ul>
                 {keyTasks.map(
                   (task): React.ReactElement => (
-                    <li key={task.id}>{task.description[locale]}</li>
+                    <li key={task.id}>{localizeField(locale, task, "description")}</li>
                   ),
                 )}
               </ul>

--- a/resources/assets/js/components/JobBuilder/Tasks/JobTasks.tsx
+++ b/resources/assets/js/components/JobBuilder/Tasks/JobTasks.tsx
@@ -24,6 +24,7 @@ import TextAreaInput from "../../Form/TextAreaInput";
 import { JobPosterKeyTask } from "../../../models/types";
 import { find } from "../../../helpers/queries";
 import { emptyTasks } from "../../../models/jobUtil";
+import { localizeFieldNonNull } from "../../../helpers/localize";
 
 interface JobTasksProps {
   /** Job ID to pass to tasks. */
@@ -110,7 +111,7 @@ const JobTasks: React.FunctionComponent<JobTasksProps &
       (task: JobPosterKeyTask): TaskFormValues => ({
         id: task.id,
         jobPosterId: task.job_poster_id,
-        description: task.description[locale],
+        description: localizeFieldNonNull(locale, task, "description"),
       }),
     ),
   });

--- a/resources/assets/js/components/JobBuilder/WorkEnv/WorkEnvForm.tsx
+++ b/resources/assets/js/components/JobBuilder/WorkEnv/WorkEnvForm.tsx
@@ -38,6 +38,7 @@ import {
   techDescriptions,
   amenitiesDescriptions,
 } from "./JobWorkEnv";
+import { localizeField } from "../../../helpers/localize";
 
 export const formMessages = defineMessages({
   ourWorkEnvDesc: {
@@ -602,9 +603,9 @@ const jobToValues = (
       collaborativenessList,
       collaborative_vs_independent,
     ),
-    envDescription: job.work_env_description[locale] || "",
-    cultureSummary: job.culture_summary[locale] || "",
-    moreCultureSummary: job.culture_special[locale] || "",
+    envDescription: localizeField(locale, job, "work_env_description") || "",
+    cultureSummary: localizeField(locale, job, "culture_summary") || "",
+    moreCultureSummary: localizeField(locale, job, "culture_special") || "",
   };
 };
 

--- a/resources/assets/js/components/JobBuilder/jobBuilderHelpers.ts
+++ b/resources/assets/js/components/JobBuilder/jobBuilderHelpers.ts
@@ -9,6 +9,11 @@ import {
   jobBuilderSkills,
   jobBuilderReview,
 } from "../../helpers/routes";
+import {
+  localizeField,
+  localizeFieldNonNull,
+  Locales,
+} from "../../helpers/localize";
 
 /** Job Builder Constants */
 export const NUM_OF_TASKS = 6;
@@ -21,10 +26,10 @@ const isEmpty = (value: any | null | undefined): boolean => {
   return value === null || value === undefined;
 };
 
-const jobIntroValues = (job: Job): (string | number | null)[] => [
+const jobIntroValues = (job: Job) => [
   job.department_id,
-  job.division.en,
-  job.division.fr,
+  localizeField("en", job, "division"),
+  localizeField("fr", job, "division"),
 ];
 const isJobBuilderIntroComplete = (job: Job): boolean => {
   return jobIntroValues(job).every(isFilled);
@@ -49,8 +54,8 @@ export const jobBuilderIntroProgressState = (
 
 const jobDetailsValues = (
   job: Job,
-  locale: string,
-): (string | number | null | boolean)[] => [
+  locale: Locales,
+) => [
   job.term_qty,
   job.classification_id,
   job.classification_level,
@@ -60,20 +65,20 @@ const jobDetailsValues = (
   job.remote_work_allowed,
   job.telework_allowed_frequency_id,
   job.flexible_hours_frequency_id,
-  job.title[locale],
-  job.city[locale],
+  localizeField(locale, job, "title"),
+  localizeField(locale, job, "city"),
 ];
 
 export const isJobBuilderDetailsComplete = (
   job: Job,
-  locale: string,
+  locale: Locales,
 ): boolean => {
   return jobDetailsValues(job, locale).every(isFilled);
 };
 
 export const isJobBuilderDetailsUntouched = (
   job: Job,
-  locale: string,
+  locale: Locales,
 ): boolean => {
   const nullableValues = jobDetailsValues(job, locale).filter(
     (item): boolean => typeof item !== "boolean",
@@ -89,7 +94,7 @@ export const isJobBuilderDetailsUntouched = (
  */
 export const jobBuilderDetailsProgressState = (
   job: Job | null,
-  locale: string,
+  locale: Locales,
   allowUntouched = false,
 ): ProgressTrackerState => {
   if (
@@ -101,7 +106,10 @@ export const jobBuilderDetailsProgressState = (
   return job && isJobBuilderDetailsComplete(job, locale) ? "complete" : "error";
 };
 
-const jobEnvValues = (job: Job, locale: string): (string | number | null)[] => [
+const jobEnvValues = (
+  job: Job,
+  locale: Locales,
+) => [
   job.team_size,
   job.fast_vs_steady,
   job.horizontal_vs_vertical,
@@ -109,20 +117,17 @@ const jobEnvValues = (job: Job, locale: string): (string | number | null)[] => [
   job.citizen_facing_vs_back_office,
   job.collaborative_vs_independent,
   job.work_env_features,
-  job.culture_summary[locale],
+  localizeField(locale, job, "culture_summary"),
 ];
-const jobEnvValuesOptional = (
-  job: Job,
-  locale: string,
-): (string | number | null)[] => [
-  job.work_env_description[locale],
-  job.culture_special[locale],
+const jobEnvValuesOptional = (job: Job, locale: Locales): (string | null)[] => [
+  localizeField(locale, job, "work_env_description"),
+  localizeField(locale, job, "culture_special"),
 ];
 
-const isJobBuilderEnvComplete = (job: Job, locale: string): boolean => {
+const isJobBuilderEnvComplete = (job: Job, locale: Locales): boolean => {
   return jobEnvValues(job, locale).every(isFilled);
 };
-const isJobBuilderEnvUntouched = (job: Job, locale: string): boolean => {
+const isJobBuilderEnvUntouched = (job: Job, locale: Locales): boolean => {
   const allJobValues = [
     ...jobEnvValues(job, locale),
     ...jobEnvValuesOptional(job, locale),
@@ -134,7 +139,7 @@ const isJobBuilderEnvUntouched = (job: Job, locale: string): boolean => {
 };
 export const jobBuilderEnvProgressState = (
   job: Job | null,
-  locale: string,
+  locale: Locales,
   allowUntouched = false,
 ): ProgressTrackerState => {
   if (
@@ -147,9 +152,9 @@ export const jobBuilderEnvProgressState = (
 };
 
 const jobImpactValues = (job: Job, locale: "en" | "fr"): (string | null)[] => [
-  job.dept_impact[locale],
-  job.team_impact[locale],
-  job.hire_impact[locale],
+  localizeField(locale, job, "dept_impact"),
+  localizeField(locale, job, "team_impact"),
+  localizeField(locale, job, "hire_impact"),
 ];
 const isJobImpactComplete = (job: Job, locale: "en" | "fr"): boolean => {
   return jobImpactValues(job, locale).every(isFilled);
@@ -171,7 +176,7 @@ export const jobImpactProgressState = (
 const isKeyTaskComplete = (
   task: JobPosterKeyTask,
   locale: "en" | "fr",
-): boolean => isFilled(task.description[locale]);
+): boolean => isFilled(localizeFieldNonNull(locale, task, "description"));
 const isJobTasksComplete = (
   tasks: JobPosterKeyTask[],
   locale: "en" | "fr",
@@ -199,7 +204,7 @@ export const jobTasksProgressState = (
 const isCriterionComplete = (
   criterion: Criteria,
   locale: "en" | "fr",
-): boolean => isFilled(criterion.description[locale]);
+): boolean => isFilled(localizeField(locale, criterion, "description"));
 // FIXME: There is currently no way to know the difference between an untouched list, and one where criteria have been added then removed
 const isCriteriaUntouched = (criteria: Criteria[]): boolean =>
   criteria.length === 0;

--- a/resources/assets/js/helpers/localize.ts
+++ b/resources/assets/js/helpers/localize.ts
@@ -1,15 +1,27 @@
-import { localizedField } from "../models/app";
+import { localizedField, localizedFieldNonNull } from "../models/app";
 
 export type Locales = "en" | "fr";
-type LocalizedFields<T> = {
+type TranslatableKeysNonNull<T> = {
+  [K in keyof T]: T[K] extends localizedFieldNonNull ? K : never;
+}[keyof T];
+type TranslatableKeys<T> = {
   [K in keyof T]: T[K] extends localizedField ? K : never;
 }[keyof T];
 
 export function localizeField<T>(
   locale: Locales,
   model: T,
-  field: LocalizedFields<T>,
-) {
+  field: TranslatableKeys<T>,
+): string | null {
+  const a = model[field];
+  return model[field][locale];
+}
+export function localizeFieldNonNull<T>(
+  locale: Locales,
+  model: T,
+  field: TranslatableKeysNonNull<T>,
+): string {
+  const a = model[field];
   return model[field][locale];
 }
 

--- a/resources/assets/js/helpers/localize.ts
+++ b/resources/assets/js/helpers/localize.ts
@@ -13,7 +13,6 @@ export function localizeField<T>(
   model: T,
   field: TranslatableKeys<T>,
 ): string | null {
-  const a = model[field];
   return model[field][locale];
 }
 export function localizeFieldNonNull<T>(
@@ -21,7 +20,6 @@ export function localizeFieldNonNull<T>(
   model: T,
   field: TranslatableKeysNonNull<T>,
 ): string {
-  const a = model[field];
   return model[field][locale];
 }
 

--- a/resources/assets/js/stories/JobPosterBuilder/Skills.stories.tsx
+++ b/resources/assets/js/stories/JobPosterBuilder/Skills.stories.tsx
@@ -12,14 +12,14 @@ import CriteriaForm from "../../components/JobBuilder/Skills/CriteriaForm";
 import { mapToObject } from "../../helpers/queries";
 import { SkillLevelId, CriteriaTypeId } from "../../models/lookupConstants";
 import { Criteria } from "../../models/types";
+import { localizeFieldNonNull } from "../../helpers/localize";
 
 const stories = storiesOf("Job Poster Builder|Skills", module).addDecorator(
   withIntl,
 );
 
-const skillOptions = mapToObject(
-  fakeSkills(),
-  (skill): string => skill.name.en,
+const skillOptions = mapToObject(fakeSkills(), (skill): string =>
+  localizeFieldNonNull("en", skill, "name"),
 ) as SelectTypeOptionsProp;
 
 const skillLevelOptions = {


### PR DESCRIPTION
This adds 3 helper functions:
- Two are for getting a field from a model (eg `city` from a `job`) in the right locale, depending on whether the result may be null or not.
- One function to replace the "get locale from react-intl, throw exception if not en or fr" pattern we have all over the place.

I've tried to replace every instance of getting a localized field with the use of a function (except for cases where we're constructing a new model or using both locales). 
I've only replaced getting locale from react-intl in a few places so far.

### Notes:
- Having all localization go through a couple functions will make it easy to do things like add null checking for everything.
- The type checking on these functions is actually helpful. You should get code-completion options, for only the localizable fields.
- This assumes that all the models use the same pattern for localization, but it also makes it easy to change (eg if we had to do something like the common-language-package refactor again).

