### PR TITLE
When application submission fails, log the causes.

### DIFF
--- a/app/Http/Controllers/ApplicationByJobController.php
+++ b/app/Http/Controllers/ApplicationByJobController.php
@@ -790,6 +790,15 @@ class ApplicationByJobController extends Controller
 
             // Error out of this process now if application is not complete.
             $validator = new ApplicationValidator();
+            $validatorInstance = $validator->validator($application);
+            if (!$validatorInstance->passes()) {
+                // $msg = implode(', ', $validator->errors()->all());
+                // $msg = implode('; ', $validator->getMessageBag()->getMessages());
+                $userId = $application->applicant->user_id;
+                $msg = "Application $application->id for user $userId is invalid for submission: " .
+                    implode('; ', $validator->detailedValidatorErrors($application));
+                Log::info($msg);
+            }
             $validator->validate($application);
 
             // Change status to 'submitted'.

--- a/app/Http/Controllers/ApplicationByJobController.php
+++ b/app/Http/Controllers/ApplicationByJobController.php
@@ -792,8 +792,6 @@ class ApplicationByJobController extends Controller
             $validator = new ApplicationValidator();
             $validatorInstance = $validator->validator($application);
             if (!$validatorInstance->passes()) {
-                // $msg = implode(', ', $validator->errors()->all());
-                // $msg = implode('; ', $validator->getMessageBag()->getMessages());
                 $userId = $application->applicant->user_id;
                 $msg = "Application $application->id for user $userId is invalid for submission: " .
                     implode('; ', $validator->detailedValidatorErrors($application));

--- a/app/Services/Validation/ApplicationValidator.php
+++ b/app/Services/Validation/ApplicationValidator.php
@@ -7,21 +7,22 @@ use Illuminate\Support\Facades\Validator;
 use App\Models\Lookup\CriteriaType;
 use App\Services\Validation\Rules\ContainsObjectWithAttributeRule;
 use App\Services\Validation\JobApplicationAnswerValidator;
+use Illuminate\Support\Facades\Log;
 
 class ApplicationValidator
 {
 
-    public function validator(JobApplication $application)
-    {
-        $backendRules = [
+    public $backendRules =  [
             'job_poster_id' => 'required',
             'application_status_id' => 'required',
             'applicant_id' => 'required',
         ];
+    public function validator(JobApplication $application)
+    {
         $data = $application->toArray();
 
         $rules = array_merge(
-            $backendRules,
+            $this->backendRules,
             $this->experienceRules,
             $this->affirmationRules
         );
@@ -47,9 +48,20 @@ class ApplicationValidator
         $this->validator($application)->validate();
     }
 
-    public function validateComplete(JobApplication $application): bool
+    public function validateComplete(JobApplication $application)
     {
         return $this->validator($application)->passes();
+    }
+
+    public function detailedValidatorErrors(JobApplication $application)
+    {
+        return array_merge(
+            Validator::make($application->toArray(), $this->backendRules)->errors()->all(),
+            $this->basicsValidator($application)->errors()->all(),
+            $this->experienceValidator($application)->errors()->all(),
+            $this->essentialSkillsValidator($application)->errors()->all(),
+            $this->affirmationValidator($application)->errors()->all()
+        );
     }
 
     /**


### PR DESCRIPTION
Doesn't resolve, but intended to help investigate #2914.

### Notes:
- When submitting an application fails, we tell the user which steps need to be completed. But it would useful for debugging purposes to know exactly why the step was considered incomplete. This will add those details to the log.
