### PR TITLE
Add new Talent Stream fields to job poster

### DIFF
--- a/app/Http/Controllers/Admin/JobPosterCrudController.php
+++ b/app/Http/Controllers/Admin/JobPosterCrudController.php
@@ -263,6 +263,29 @@ class JobPosterCrudController extends CrudController
             'allows_null' => false,
             'default' => $job->job_poster_status_id,
         ]);
+
+        // Strategic Talent Response fields
+        $this->crud->addField([
+            'label' => 'Talent Stream',
+            'type' => 'select',
+            'name' => 'talent_stream_id', // the db column for the foreign key
+            'entity' => 'talent_stream', // the method that defines the relationship in your Model
+            'attribute' => 'name', // foreign key attribute that is shown to user
+        ]);
+        $this->crud->addField([
+            'label' => 'Talent Stream Subcategory',
+            'type' => 'select',
+            'name' => 'talent_stream_category_id', // the db column for the foreign key
+            'entity' => 'talent_stream_category', // the method that defines the relationship in your Model
+            'attribute' => 'name', // foreign key attribute that is shown to user
+        ]);
+        $this->crud->addField([
+            'label' => 'Job Skill Level',
+            'type' => 'select',
+            'name' => 'job_skill_level_id', // the db column for the foreign key
+            'entity' => 'job_skill_level', // the method that defines the relationship in your Model
+            'attribute' => 'name', // foreign key attribute that is shown to user
+        ]);
     }
 
     public function update()

--- a/app/Http/Controllers/Admin/JobSkillLevelCrudController.php
+++ b/app/Http/Controllers/Admin/JobSkillLevelCrudController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Illuminate\Support\Facades\App;
+
+class JobSkillLevelCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
+    use \Backpack\Crud\app\Http\Controllers\Operations\CreateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
+
+    /**
+     * Prepare the admin interface by setting the associated
+     * model, setting the route, and adding custom columns/fields.
+     *
+     * @return void
+     */
+    public function setup(): void
+    {
+        // Eloquent model to associate with this collection of views and controller actions.
+        $this->crud->setModel('App\Models\Lookup\JobSkillLevel');
+        // Custom backpack route.
+        $this->crud->setRoute('admin/job-skill-level');
+        // Custom strings to display within the backpack UI.
+        $this->crud->setEntityNameStrings('job skill level', 'job skill levels');
+
+        $this->crud->operation(['create', 'update'], function () {
+            $this->crud->addField([
+                'name' => 'key',
+                'type' => 'text',
+                'label' => 'key',
+            ]);
+            $this->crud->addField([
+                'name' => 'name',
+                'type' => 'text',
+                'label' => 'Name',
+                'limit' => 120,
+            ]);
+        });
+    }
+
+    public function setupListOperation()
+    {
+        // Required for order logic.
+        $locale = 'en';
+        if (null !== $this->request->input('locale')) {
+            $locale = $this->request->input('locale');
+        }
+        App::setLocale($locale);
+
+        $this->crud->addColumn([
+            'name' => 'id',
+            'type' => 'text',
+            'label' => 'ID',
+            'orderable' => true,
+        ]);
+        $this->crud->addColumn([
+            'name' => 'key',
+            'type' => 'text',
+            'label' => 'Key',
+            'orderable' => true,
+        ]);
+        $this->crud->addColumn([
+            'name' => 'name',
+            'type' => 'text',
+            'label' => 'Name',
+            'orderable' => true,
+            'limit' => 70,
+            'orderLogic' => function ($query, $column, $columnDirection) use ($locale) {
+                return $query->orderBy('name->' . $locale, $columnDirection)->select('*');
+            }
+        ]);
+    }
+}

--- a/app/Http/Controllers/Admin/TalentStreamCategoryCrudController.php
+++ b/app/Http/Controllers/Admin/TalentStreamCategoryCrudController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Illuminate\Support\Facades\App;
+
+class TalentStreamCategoryCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
+    use \Backpack\Crud\app\Http\Controllers\Operations\CreateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
+
+    /**
+     * Prepare the admin interface by setting the associated
+     * model, setting the route, and adding custom columns/fields.
+     *
+     * @return void
+     */
+    public function setup(): void
+    {
+        // Eloquent model to associate with this collection of views and controller actions.
+        $this->crud->setModel('App\Models\Lookup\TalentStreamCategory');
+        // Custom backpack route.
+        $this->crud->setRoute('admin/talent-stream-category');
+        // Custom strings to display within the backpack UI.
+        $this->crud->setEntityNameStrings('talent stream category', 'talent stream categories');
+
+        $this->crud->operation(['create', 'update'], function () {
+            $this->crud->addField([
+                'name' => 'key',
+                'type' => 'text',
+                'label' => 'key',
+            ]);
+            $this->crud->addField([
+                'name' => 'name',
+                'type' => 'text',
+                'label' => 'Name',
+                'limit' => 120,
+            ]);
+        });
+    }
+
+    public function setupListOperation()
+    {
+        // Required for order logic.
+        $locale = 'en';
+        if (null !== $this->request->input('locale')) {
+            $locale = $this->request->input('locale');
+        }
+        App::setLocale($locale);
+
+        $this->crud->addColumn([
+            'name' => 'id',
+            'type' => 'text',
+            'label' => 'ID',
+            'orderable' => true,
+        ]);
+        $this->crud->addColumn([
+            'name' => 'key',
+            'type' => 'text',
+            'label' => 'Key',
+            'orderable' => true,
+        ]);
+        $this->crud->addColumn([
+            'name' => 'name',
+            'type' => 'text',
+            'label' => 'Name',
+            'orderable' => true,
+            'limit' => 70,
+            'orderLogic' => function ($query, $column, $columnDirection) use ($locale) {
+                return $query->orderBy('name->' . $locale, $columnDirection)->select('*');
+            }
+        ]);
+    }
+}

--- a/app/Http/Controllers/Admin/TalentStreamCrudController.php
+++ b/app/Http/Controllers/Admin/TalentStreamCrudController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use Backpack\CRUD\app\Http\Controllers\CrudController;
+use Illuminate\Support\Facades\App;
+
+class TalentStreamCrudController extends CrudController
+{
+    use \Backpack\CRUD\app\Http\Controllers\Operations\ListOperation;
+    use \Backpack\Crud\app\Http\Controllers\Operations\CreateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\UpdateOperation;
+    use \Backpack\CRUD\app\Http\Controllers\Operations\DeleteOperation;
+
+    /**
+     * Prepare the admin interface by setting the associated
+     * model, setting the route, and adding custom columns/fields.
+     *
+     * @return void
+     */
+    public function setup(): void
+    {
+        // Eloquent model to associate with this collection of views and controller actions.
+        $this->crud->setModel('App\Models\Lookup\TalentStream');
+        // Custom backpack route.
+        $this->crud->setRoute('admin/talent-stream');
+        // Custom strings to display within the backpack UI.
+        $this->crud->setEntityNameStrings('talent stream', 'talent streams');
+
+        $this->crud->operation(['create', 'update'], function () {
+            $this->crud->addField([
+                'name' => 'key',
+                'type' => 'text',
+                'label' => 'key',
+            ]);
+            $this->crud->addField([
+                'name' => 'name',
+                'type' => 'text',
+                'label' => 'Name',
+                'limit' => 120,
+            ]);
+        });
+    }
+
+    public function setupListOperation()
+    {
+        // Required for order logic.
+        $locale = 'en';
+        if (null !== $this->request->input('locale')) {
+            $locale = $this->request->input('locale');
+        }
+        App::setLocale($locale);
+
+        $this->crud->addColumn([
+            'name' => 'id',
+            'type' => 'text',
+            'label' => 'ID',
+            'orderable' => true,
+        ]);
+        $this->crud->addColumn([
+            'name' => 'key',
+            'type' => 'text',
+            'label' => 'Key',
+            'orderable' => true,
+        ]);
+        $this->crud->addColumn([
+            'name' => 'name',
+            'type' => 'text',
+            'label' => 'Name',
+            'orderable' => true,
+            'limit' => 70,
+            'orderLogic' => function ($query, $column, $columnDirection) use ($locale) {
+                return $query->orderBy('name->' . $locale, $columnDirection)->select('*');
+            }
+        ]);
+    }
+}

--- a/app/Models/JobPoster.php
+++ b/app/Models/JobPoster.php
@@ -53,6 +53,9 @@ use Spatie\Translatable\HasTranslations;
  * @property int $priority_clearance_number
  * @property int $job_poster_status_id
  * @property \Jenssegers\Date\Date $loo_issuance_date
+ * @property int $talent_stream_id
+ * @property int $talent_stream_category_id
+ * @property int $job_skill_level_id
  * @property \Jenssegers\Date\Date $created_at
  * @property \Jenssegers\Date\Date $updated_at
  *
@@ -74,6 +77,9 @@ use Spatie\Translatable\HasTranslations;
  * @property \App\Models\Lookup\Frequency $telework_allowed_frequency
  * @property \App\Models\Lookup\Frequency $flexible_hours_frequency
  * @property \App\Models\Lookup\JobPosterStatus $job_poster_status
+ * @property \App\Models\Lookup\TalentStream|null $talent_stream
+ * @property \App\Models\Lookup\TalentStreamCategory|null $talent_stream_category
+ * @property \App\Models\Lookup\JobSkillLevel|null $job_skill_level
  *
  * Localized Properties:
  * @property string $city
@@ -219,6 +225,9 @@ class JobPoster extends BaseModel
         'work_env_description',
         'culture_summary',
         'culture_special',
+        'talent_stream_id',
+        'talent_stream_category_id',
+        'job_skill_level_id',
         'job_poster_status_id', // This really shouldn't be mass-editable, but its necesary for the admin crud portal to set it.
     ];
 
@@ -271,6 +280,9 @@ class JobPoster extends BaseModel
         'culture_summary',
         'culture_special',
         'job_poster_status_id',
+        'talent_stream_id',
+        'talent_stream_category_id',
+        'job_skill_level_id',
         'created_at',
     ];
 
@@ -398,6 +410,21 @@ class JobPoster extends BaseModel
     public function job_poster_status_histories() // phpcs:ignore
     {
         return $this->hasMany(\App\Models\JobPosterStatusHistory::class);
+    }
+
+    public function talent_stream() // phpcs:ignore
+    {
+        return $this->belongsTo(\App\Models\Lookup\TalentStream::class);
+    }
+
+    public function talent_stream_category() // phpcs:ignore
+    {
+        return $this->belongsTo(\App\Models\Lookup\TalentStreamCategory::class);
+    }
+
+    public function job_skill_level() // phpcs:ignore
+    {
+        return $this->belongsTo(\App\Models\Lookup\JobSkillLevel::class);
     }
 
     // @codeCoverageIgnoreEnd

--- a/app/Models/Lookup/JobSkillLevel.php
+++ b/app/Models/Lookup/JobSkillLevel.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models\Lookup;
+
+use App\Models\BaseModel;
+use Spatie\Translatable\HasTranslations;
+
+/**
+ * Class JobSkillLevel
+ *
+ * @property int $id
+ * @property string $key
+ * @property \Jenssegers\Date\Date $created_at
+ * @property \Jenssegers\Date\Date $updated_at
+ *
+ * @property \Illuminate\Database\Eloquent\Collection $job_posters
+ *
+ * Localized Properties:
+ * @property string $name
+ */
+class JobSkillLevel extends BaseModel
+{
+    use HasTranslations;
+
+    public $translatable = ['name'];
+    protected $fillable = [];
+
+    public function job_posters() //phpcs:ignore
+    {
+        return $this->hasMany(\App\Models\JobPoster::class);
+    }
+}

--- a/app/Models/Lookup/JobSkillLevel.php
+++ b/app/Models/Lookup/JobSkillLevel.php
@@ -3,7 +3,8 @@
 namespace App\Models\Lookup;
 
 use App\Models\BaseModel;
-use Spatie\Translatable\HasTranslations;
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Backpack\CRUD\app\Models\Traits\SpatieTranslatable\HasTranslations;
 
 /**
  * Class JobSkillLevel
@@ -20,10 +21,11 @@ use Spatie\Translatable\HasTranslations;
  */
 class JobSkillLevel extends BaseModel
 {
+    use CrudTrait;
     use HasTranslations;
 
     public $translatable = ['name'];
-    protected $fillable = [];
+    protected $fillable = ['key', 'name'];
 
     public function job_posters() //phpcs:ignore
     {

--- a/app/Models/Lookup/TalentStream.php
+++ b/app/Models/Lookup/TalentStream.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models\Lookup;
+
+use App\Models\BaseModel;
+use Spatie\Translatable\HasTranslations;
+
+/**
+ * Class TalentStream
+ *
+ * @property int $id
+ * @property string $key
+ * @property \Jenssegers\Date\Date $created_at
+ * @property \Jenssegers\Date\Date $updated_at
+ *
+ * @property \Illuminate\Database\Eloquent\Collection $job_posters
+ *
+ * Localized Properties:
+ * @property string $name
+ */
+class TalentStream extends BaseModel
+{
+    use HasTranslations;
+
+    public $translatable = ['name'];
+    protected $fillable = [];
+
+    public function job_posters() //phpcs:ignore
+    {
+        return $this->hasMany(\App\Models\JobPoster::class);
+    }
+}

--- a/app/Models/Lookup/TalentStream.php
+++ b/app/Models/Lookup/TalentStream.php
@@ -3,7 +3,8 @@
 namespace App\Models\Lookup;
 
 use App\Models\BaseModel;
-use Spatie\Translatable\HasTranslations;
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Backpack\CRUD\app\Models\Traits\SpatieTranslatable\HasTranslations;
 
 /**
  * Class TalentStream
@@ -20,10 +21,11 @@ use Spatie\Translatable\HasTranslations;
  */
 class TalentStream extends BaseModel
 {
+    use CrudTrait;
     use HasTranslations;
 
     public $translatable = ['name'];
-    protected $fillable = [];
+    protected $fillable = ['key', 'name'];
 
     public function job_posters() //phpcs:ignore
     {

--- a/app/Models/Lookup/TalentStreamCategory.php
+++ b/app/Models/Lookup/TalentStreamCategory.php
@@ -3,7 +3,8 @@
 namespace App\Models\Lookup;
 
 use App\Models\BaseModel;
-use Spatie\Translatable\HasTranslations;
+use Backpack\CRUD\app\Models\Traits\CrudTrait;
+use Backpack\CRUD\app\Models\Traits\SpatieTranslatable\HasTranslations;
 
 /**
  * Class TalentStreamCategory
@@ -20,10 +21,11 @@ use Spatie\Translatable\HasTranslations;
  */
 class TalentStreamCategory extends BaseModel
 {
+    use CrudTrait;
     use HasTranslations;
 
     public $translatable = ['name'];
-    protected $fillable = [];
+    protected $fillable = ['key', 'name'];
 
     public function job_posters() //phpcs:ignore
     {

--- a/app/Models/Lookup/TalentStreamCategory.php
+++ b/app/Models/Lookup/TalentStreamCategory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models\Lookup;
+
+use App\Models\BaseModel;
+use Spatie\Translatable\HasTranslations;
+
+/**
+ * Class TalentStreamCategory
+ *
+ * @property int $id
+ * @property string $key
+ * @property \Jenssegers\Date\Date $created_at
+ * @property \Jenssegers\Date\Date $updated_at
+ *
+ * @property \Illuminate\Database\Eloquent\Collection $job_posters
+ *
+ * Localized Properties:
+ * @property string $name
+ */
+class TalentStreamCategory extends BaseModel
+{
+    use HasTranslations;
+
+    public $translatable = ['name'];
+    protected $fillable = [];
+
+    public function job_posters() //phpcs:ignore
+    {
+        return $this->hasMany(\App\Models\JobPoster::class);
+    }
+}

--- a/database/migrations/2020_03_16_233228_create_talent_streams.php
+++ b/database/migrations/2020_03_16_233228_create_talent_streams.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTalentStreams extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('talent_streams', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+            $table->string('key');
+            $table->json('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('talent_streams');
+    }
+}

--- a/database/migrations/2020_03_16_233439_create_talent_stream_categories.php
+++ b/database/migrations/2020_03_16_233439_create_talent_stream_categories.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTalentStreamCategories extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('talent_stream_categories', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+            $table->string('key');
+            $table->json('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('talent_stream_categories');
+    }
+}

--- a/database/migrations/2020_03_16_233539_create_job_skill_levels.php
+++ b/database/migrations/2020_03_16_233539_create_job_skill_levels.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateJobSkillLevels extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('job_skill_levels', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+            $table->string('key');
+            $table->json('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('job_skill_levels');
+    }
+}

--- a/database/migrations/2020_03_16_233612_add_stream_details_to_job_posters.php
+++ b/database/migrations/2020_03_16_233612_add_stream_details_to_job_posters.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddStreamDetailsToJobPosters extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('job_posters', function (Blueprint $table) {
+            $table->integer('talent_stream_id')->nullable();
+            $table->integer('talent_stream_category_id')->nullable();
+            $table->integer('job_skill_level_id')->nullable();
+
+            $table->foreign('talent_stream_id')
+                ->references('id')
+                ->on('talent_streams')
+                ->onUpdate('CASCADE')
+                ->onDelete('NO ACTION');
+            $table->foreign('talent_stream_category_id')
+                ->references('id')
+                ->on('talent_stream_categories')
+                ->onUpdate('CASCADE')
+                ->onDelete('NO ACTION');
+            $table->foreign('job_skill_level_id')
+                ->references('id')
+                ->on('job_skill_levels')
+                ->onUpdate('CASCADE')
+                ->onDelete('NO ACTION');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('job_posters', function (Blueprint $table) {
+            $table->dropForeign(['talent_stream_id']);
+            $table->dropForeign(['talent_stream_category_id']);
+            $table->dropForeign(['job_skill_level_id']);
+
+            $table->dropColumn('talent_stream_id');
+            $table->dropColumn('talent_stream_category_id');
+            $table->dropColumn('job_skill_level_id');
+        });
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -17,6 +17,7 @@ class DatabaseSeeder extends Seeder //phpcs:ignore
             CommentSeeder::class,
             ExperienceSkillSeeder::class,
             ResourceSeeder::class,
+            TalentStreamSeeder::class,
         ]);
     }
 }

--- a/database/seeds/TalentStreamSeeder.php
+++ b/database/seeds/TalentStreamSeeder.php
@@ -1,0 +1,111 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class TalentStreamSeeder extends Seeder // phpcs:ignore
+{
+    /**
+     * Run the Skills Classification seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $talent_streams = [
+            [
+                'key' => 'communications',
+                'name' => json_encode([
+                    'en' => 'Communication Positions',
+                    'fr' => 'Positions de communications'
+                ])
+            ],
+            [
+                'key' => 'it',
+                'name' => json_encode([
+                    'en' => 'IT Positions',
+                    'fr' => 'Positions de IT'
+                ])
+            ],
+            [
+                'key' => 'admin',
+                'name' => json_encode([
+                    'en' => 'Administrative Positions',
+                    'fr' => 'Postes administratifs'
+                ])
+            ],
+        ];
+        foreach ($talent_streams as $stream) {
+            DB::table('talent_streams')->updateOrInsert(
+                ['key' => $stream['key']],
+                ['name' => $stream['name']]
+            );
+        }
+
+        $talent_categories = [
+            [
+                'key' => 'social_media',
+                'name' => json_encode([
+                    'en' => 'Social Media',
+                    'fr' => 'Les médias sociaux'
+                ])
+            ],
+            [
+                'key' => 'video',
+                'name' => json_encode([
+                    'en' => 'Video Editing',
+                    'fr' => 'Montage vidéo'
+                ])
+            ],
+            [
+                'key' => 'web_dev',
+                'name' => json_encode([
+                    'en' => 'Web Development',
+                    'fr' => 'Développement web'
+                ])
+            ],
+            [
+                'key' => 'dev_ops',
+                'name' => json_encode([
+                    'en' => 'Dev Ops',
+                    'fr' => 'Dev Ops (FR)'
+                ])
+            ],
+        ];
+        foreach ($talent_categories as $category) {
+            DB::table('talent_stream_categories')->updateOrInsert(
+                ['key' => $category['key']],
+                ['name' => $category['name']]
+            );
+        }
+
+        $job_skill_levels = [
+            [
+                'key' => 'junior',
+                'name' => json_encode([
+                    'en' => 'Junior',
+                    'fr' => 'Junior'
+                ])
+            ],
+            [
+                'key' => 'medium',
+                'name' => json_encode([
+                    'en' => 'Mid Level',
+                    'fr' => 'Niveau moyen'
+                ])
+            ],
+            [
+                'key' => 'expert',
+                'name' => json_encode([
+                    'en' => 'Expert',
+                    'fr' => 'Expert'
+                ])
+            ],
+        ];
+        foreach ($job_skill_levels as $skill_level) {
+            DB::table('job_skill_levels')->updateOrInsert(
+                ['key' => $skill_level['key']],
+                ['name' => $skill_level['name']]
+            );
+        }
+    }
+}

--- a/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
+++ b/resources/views/vendor/backpack/base/inc/sidebar_content.blade.php
@@ -7,12 +7,12 @@
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('skill') }}"><i class="nav-icon fa fa-list-alt"></i> <span>Skills</span></a></li>
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('department') }}"><i class="nav-icon fa fa-list-alt"></i> <span>Departments</span></a></li>
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('classification') }}"><i class="nav-icon fa fa-list-alt"></i> <span>Classifications</span></a></li>
-<<<<<<< HEAD
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('job-poster-status') }}"><i class="nav-icon fa fa-list-alt"></i> <span>Job Status</span></a></li>
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('job-poster-status-transition') }}"><i class="nav-icon fa fa-list-alt"></i> <span>Job Status Transitions</span></a></li>
-=======
+<li class="nav-item"><a class="nav-link" href="{{ backpack_url('talent-stream') }}"><i class="nav-icon fa fa-list-alt"></i> <span>Talent Streams</span></a></li>
+<li class="nav-item"><a class="nav-link" href="{{ backpack_url('talent-stream-category') }}"><i class="nav-icon fa fa-list-alt"></i> <span>Talent Stream Categories</span></a></li>
+<li class="nav-item"><a class="nav-link" href="{{ backpack_url('job-skill-level') }}"><i class="nav-icon fa fa-list-alt"></i> <span>Job Skill Levels</span></a></li>
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('resource') }}"><i class="nav-icon fa fa-folder"></i> <span>Resources</span></a></li>
->>>>>>> origin/dev
 <br />
 <li class="nav-item"><a class="nav-link" href="{{ backpack_url('2fa') }}"><i class="nav-icon fa fa-lock"></i> <span>Manage 2FA</span></a></li>
 <br />

--- a/routes/backpack/custom.php
+++ b/routes/backpack/custom.php
@@ -20,6 +20,9 @@ Route::group([
     Route::crud('classification', 'ClassificationCrudController');
     Route::crud('job-poster-status', 'JobPosterStatusCrudController');
     Route::crud('job-poster-status-transition', 'JobPosterStatusTransitionCrudController');
+    Route::crud('talent-stream', 'TalentStreamCrudController');
+    Route::crud('talent-stream-category', 'TalentStreamCategoryCrudController');
+    Route::crud('job-skill-level', 'JobSkillLevelCrudController');
     Route::crud('resource', 'ResourcesCrudController');
     Route::crud('2fa', 'TwoFactorCrudController');
 });


### PR DESCRIPTION
Resolves #3163.

### Notes:
- The new lookup tables are left empty. It will be up to admins to populate the Talent Stream, Talent Stream Categories, and Job Skill Level tables.
- However, I've set up a seeder to add some values to the tables for local development.
- These fields can be set in a job poster on the Edit Job Poster page in the admin portal.
