### PR TITLE
Add strategic response default questions

### DIFF
--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -16,6 +16,7 @@ use App\Models\Lookup\CitizenshipDeclaration;
 use App\Models\Lookup\JobPosterStatus;
 use App\Models\Lookup\VeteranStatus;
 use App\Models\Manager;
+use App\Services\JobPosterDefaultQuestions;
 use Mcamara\LaravelLocalization\Facades\LaravelLocalization;
 use App\Services\Validation\JobPosterValidator;
 use Facades\App\Services\WhichPortal;
@@ -269,10 +270,8 @@ class JobController extends Controller
     {
         $manager = $jobPoster->manager;
 
-        if ($jobPoster->job_poster_questions === null || $jobPoster->job_poster_questions->count() === 0) {
-            $jobPoster->job_poster_questions()->saveMany($this->populateDefaultQuestions());
-            $jobPoster->refresh();
-        }
+        $defaultQuestionManager = new JobPosterDefaultQuestions();
+        $defaultQuestionManager->initializeQuestionsIfEmpty($jobPoster);
 
         return view(
             'manager/job_create',
@@ -390,41 +389,6 @@ class JobController extends Controller
             $jobPoster->save();
             $jobQuestion->save();
         }
-    }
-
-    /**
-     * Get the localized default questions and add them to an array.
-     *
-     * @return mixed[]|void
-     */
-    protected function populateDefaultQuestions()
-    {
-        $defaultQuestions = [
-            'en' => array_values(Lang::get('manager/job_create', [], 'en')['questions']),
-            'fr' => array_values(Lang::get('manager/job_create', [], 'fr')['questions']),
-        ];
-
-        if (count($defaultQuestions['en']) !== count($defaultQuestions['fr'])) {
-            Log::warning('There must be the same number of French and English default questions for a Job Poster.');
-            return;
-        }
-
-        $jobQuestions = [];
-
-        for ($i = 0; $i < count($defaultQuestions['en']); $i++) {
-            $jobQuestion = new JobPosterQuestion();
-            $jobQuestion->fill(
-                [
-                    'question' => [
-                        'en' => $defaultQuestions['en'][$i],
-                        'fr' => $defaultQuestions['fr'][$i],
-                    ]
-                ]
-            );
-            $jobQuestions[] = $jobQuestion;
-        }
-
-        return $jobQuestions;
     }
 
     /**

--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Models\JobApplication;

--- a/app/Listeners/JobPosterQuestionInitializer.php
+++ b/app/Listeners/JobPosterQuestionInitializer.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\JobSaved;
+use App\Models\Lookup\JobPosterStatus;
+use App\Services\JobPosterDefaultQuestions;
+
+class JobPosterQuestionInitializer
+{
+    /**
+     * When Job enters approved state, where an Admin must to a final look over,
+     * ensure default questions are added.
+     *
+     * @param  JobSaved  $event
+     * @return void
+     */
+    public function handle(JobSaved $event)
+    {
+        $job = $event->job;
+
+        if ($job->isDirty('job_poster_status_id')) {
+            $toStatusId = $job->job_poster_status_id;
+            $approvedId = JobPosterStatus::where('key', 'approved')->first()->id;
+            if ($toStatusId == $approvedId) {
+                $defaultQuestionManager = new JobPosterDefaultQuestions();
+                $defaultQuestionManager->initializeQuestionsIfEmpty($job);
+            }
+        }
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -25,6 +25,7 @@ class EventServiceProvider extends ServiceProvider
         ],
         'App\Events\JobSaved' => [
             'App\Listeners\RecordJobStatusTransition',
+            'App\Listeners\JobPosterQuestionInitializer',
         ],
         'App\Events\ApplicationRetrieved' => [
             'App\Listeners\LogApplicationRetrieved',

--- a/app/Services/JobPosterDefaultQuestions.php
+++ b/app/Services/JobPosterDefaultQuestions.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\JobPoster;
+use App\Models\JobPosterQuestion;
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Facades\Log;
+
+class JobPosterDefaultQuestions
+{
+    /**
+     * Get the localized default questions and add them to an array.
+     *
+     * @return mixed[]|void
+     */
+    public function createDefaultQuestions(bool $isStrategicResponseJob = false)
+    {
+
+        $question_key = $isStrategicResponseJob
+            ? 'strategic_response_questions'
+            : 'questions';
+
+        $defaultQuestions = [
+            'en' => array_values(Lang::get('manager/job_create', [], 'en')[$question_key]),
+            'fr' => array_values(Lang::get('manager/job_create', [], 'fr')[$question_key]),
+        ];
+
+        if (count($defaultQuestions['en']) !== count($defaultQuestions['fr'])) {
+            Log::warning('There must be the same number of French and English default questions for a Job Poster.');
+            return;
+        }
+
+        $jobQuestions = [];
+
+        for ($i = 0; $i < count($defaultQuestions['en']); $i++) {
+            $jobQuestion = new JobPosterQuestion();
+            $jobQuestion->fill(
+                [
+                    'question' => [
+                        'en' => $defaultQuestions['en'][$i],
+                        'fr' => $defaultQuestions['fr'][$i],
+                    ]
+                ]
+            );
+            $jobQuestions[] = $jobQuestion;
+        }
+
+        return $jobQuestions;
+    }
+
+    public function initializeQuestionsIfEmpty(JobPoster $jobPoster)
+    {
+        if ($jobPoster->job_poster_questions === null || $jobPoster->job_poster_questions->count() === 0) {
+            $questions = $this->createDefaultQuestions($jobPoster->isInStrategicResponseDepartment());
+            $jobPoster->job_poster_questions()->saveMany($questions);
+            $jobPoster->refresh();
+        }
+    }
+}

--- a/resources/lang/en/manager/job_create.php
+++ b/resources/lang/en/manager/job_create.php
@@ -94,5 +94,18 @@ return [
     'questions' => [
         '00' => 'Why are you interested in this job?',
         '01' => 'Why do you think you would be a good fit for this job?'
+    ],
+    'strategic_response_questions' => [
+        'What is your active GC email account (must end in .ca)',
+        'What is your current classification and level? (e.g. IS-03)',
+        'What is your current security clearance level? (Reliability, Enhanced, Secret)',
+        'What are your current levels in English and French? (e.g. BBB/BBB)',
+        'What is your current work location? (City, Province)',
+        'What is your home department and branch? (Department, Branch)',
+        'What is your current director’s name and email? (We’ll need approval that you can be loaned to another team for a bit to help out.)',
+        'What is the name and email of an additional reference who can confirm your skill set? (Preferably a current or recent Government of Canada supervisor.)',
+        'Are you willing to come to work in a physical office?',
+        'Will the team you’re helping to need to provide any additional accommodation measures to ensure you can apply your skills to the work required?',
+        'Do you have any experience or skills (other than those required for this position) that might be an asset to a team under the current circumstances?',
     ]
 ];

--- a/resources/lang/fr/manager/job_create.php
+++ b/resources/lang/fr/manager/job_create.php
@@ -94,5 +94,18 @@ return [
     'questions' => [
         '00' => 'Pourquoi êtes-vous intéressé par ce travail?',
         '01' => 'Pourquoi pensez-vous que vous serez un bon candidat pour ce poste?'
+    ],
+    'strategic_response_questions' => [
+        'What is your active GC email account (must end in .ca)',
+        'What is your current classification and level? (e.g. IS-03)',
+        'What is your current security clearance level? (Reliability, Enhanced, Secret)',
+        'What are your current levels in English and French? (e.g. BBB/BBB)',
+        'What is your current work location? (City, Province)',
+        'What is your home department and branch? (Department, Branch)',
+        'What is your current director’s name and email? (We’ll need approval that you can be loaned to another team for a bit to help out.)',
+        'What is the name and email of an additional reference who can confirm your skill set? (Preferably a current or recent Government of Canada supervisor.)',
+        'Are you willing to come to work in a physical office?',
+        'Will the team you’re helping to need to provide any additional accommodation measures to ensure you can apply your skills to the work required?',
+        'Do you have any experience or skills (other than those required for this position) that might be an asset to a team under the current circumstances?',
     ]
 ];


### PR DESCRIPTION
Resolves #3165.

Changes the default questions for Strategic Response jobs. Adds default questions when a job enters the "approved" status, without having to view the Edit Questions page.

### Notes:
- Still missing translations
- The previous process was to save the default questions when a user views the Edit Questions page, if there are no existing questions. This still works the same.
- I've added a listener that adds default questions if the job changes to "approved" status (this is normally when the admin would add questions) and the there are no questions yet.
