### PR TITLE
Improved Strategic Response seeder & job api test page

### DIFF
--- a/database/factories/JobPosterFactory.php
+++ b/database/factories/JobPosterFactory.php
@@ -13,8 +13,11 @@ use App\Models\JobPosterQuestion;
 use App\Models\Lookup\Frequency;
 use App\Models\Classification;
 use App\Models\Lookup\JobPosterStatus;
+use App\Models\Lookup\JobSkillLevel;
 use App\Models\Lookup\TravelRequirement;
 use App\Models\Lookup\OvertimeRequirement;
+use App\Models\Lookup\TalentStream;
+use App\Models\Lookup\TalentStreamCategory;
 
 $faker_fr = Faker\Factory::create('fr');
 
@@ -197,9 +200,15 @@ $factory->state(
 $factory->state(
     JobPoster::class,
     'strategic_response',
-    [
-        'department_id' => config('app.strategic_response_department_id'),
-    ]
+    function () {
+        return [
+            'department_id' => config('app.strategic_response_department_id'),
+            'close_date_time' => null,
+            'talent_stream_id' => TalentStream::inRandomOrder()->first()->id,
+            'talent_stream_category_id' => TalentStreamCategory::inRandomOrder()->first()->id,
+            'job_skill_level_id' => JobSkillLevel::inRandomOrder()->first()->id,
+        ];
+    }
 );
 
 $factory->state(

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -17,8 +17,8 @@ class DatabaseSeeder extends Seeder //phpcs:ignore
             CommentSeeder::class,
             ExperienceSkillSeeder::class,
             ResourceSeeder::class,
-            StrategicResponseSeeder::class,
             TalentStreamSeeder::class,
+            StrategicResponseSeeder::class,
         ]);
     }
 }

--- a/database/seeds/StrategicResponseSeeder.php
+++ b/database/seeds/StrategicResponseSeeder.php
@@ -75,7 +75,7 @@ class StrategicResponseSeeder extends Seeder // phpcs:ignore
             ]));
         }
 
-        factory(JobPoster::class, 3)->states(['live', 'strategic_response'])->create([
+        factory(JobPoster::class, 100)->states(['live', 'strategic_response'])->create([
             'manager_id' => $managerUser->manager->id
         ])->each(function ($job): void {
             $job->job_applications()->saveMany(factory(JobApplication::class, 5))->create([

--- a/resources/assets/js/components/StrategicResponse/StrApiTestPage.tsx
+++ b/resources/assets/js/components/StrategicResponse/StrApiTestPage.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect } from "react";
+import { RootContainer } from "../RootContainer";
+import ReactDOM from "react-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { fetchJobIndex } from "../../store/Job/jobActions";
+import { getAllJobsInDept } from "../../store/Job/jobSelector";
+import { RootState } from "../../store/store";
+import { localizeField, getLocale } from "../../helpers/localize";
+import { Job } from "../../models/types";
+import { useIntl } from "react-intl";
+import JobIndexHrPage from "../HRPortal/JobIndexHrPage";
+
+const StrJobListing: React.FC<{ jobs: Job[] }> = ({ jobs }) => {
+  const intl = useIntl();
+  const locale = getLocale(intl.locale);
+  return (
+    <>
+    <h1>{`${jobs.length} jobs loaded.`}</h1>
+    <ul>
+      {jobs.map(job => (
+        <li key={job.id}>
+          <p>{localizeField(locale, job, "title")}</p>
+        </li>
+      ))}
+    </ul>
+    </>
+  );
+};
+
+const StrJobFetcher: React.FC<{ strDeptId: number }> = ({ strDeptId }) => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const jobFilter = new Map();
+    jobFilter.set("department_id", strDeptId);
+    dispatch(fetchJobIndex(jobFilter));
+  }, [strDeptId, dispatch]);
+
+  const jobs = useSelector((state: RootState) =>
+    getAllJobsInDept(state, { departmentId: strDeptId }),
+  );
+
+  return <StrJobListing jobs={jobs} />;
+};
+
+const container = document.getElementById("str-api-test");
+if (container !== null) {
+  if ("strDeptId" in container.dataset) {
+    const strDeptId = Number(container.dataset.strDeptId as string);
+    ReactDOM.render(
+      <RootContainer>
+        <StrJobFetcher strDeptId={strDeptId} />
+      </RootContainer>,
+      container,
+    );
+  }
+}
+
+export default JobIndexHrPage;

--- a/resources/assets/js/store/Job/jobSelector.ts
+++ b/resources/assets/js/store/Job/jobSelector.ts
@@ -38,6 +38,14 @@ export const getAllJobs = createSelector(getJobState, (jobState): Job[] =>
   Object.values(jobState),
 );
 
+export const getAllJobsInDept = createCachedSelector(
+  getAllJobs,
+  (state: RootState, ownProps: { departmentId: number }): number =>
+    ownProps.departmentId,
+  (jobs, departmentId): Job[] =>
+    jobs.filter(job => job.department_id === departmentId),
+)((state, ownProps): number => ownProps.departmentId);
+
 export const getJob = createCachedSelector(
   getJobState,
   (state: RootState, ownProps: { jobId: number }): number => ownProps.jobId,

--- a/resources/views/applicant/str_api_test.html.twig
+++ b/resources/views/applicant/str_api_test.html.twig
@@ -1,0 +1,20 @@
+{# =============================================================================
+
+    Talent Cloud
+    Applicant: Job Post
+
+============================================================================= #}
+{% extends "layouts/base" %}
+{% block title %}
+    API Test
+{% endblock %}
+
+{% block body %}
+    {% include "common/goc" %}
+    <div data-clone>
+		<div id="str-api-test" data-str-dept-id="18"></div>
+	</div>
+{% endblock %}
+{% block scripts %}
+    <script async defer src="{{ mix('/js/StrApiTestPage.js') }}"></script>
+{% endblock %}

--- a/routes/web.php
+++ b/routes/web.php
@@ -75,6 +75,8 @@ Route::group(
             /* Profile (Experience) */
             /* Temp Resources */
             Route::view('resources', 'common/resources')->middleware('localOnly')->name('resources');
+
+            Route::view('response/api-test', 'applicant/str_api_test')->middleware('localOnly');
         });
 
         Route::group(['prefix' => config('app.applicant_prefix')], function (): void {

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -53,6 +53,10 @@ mix
     "resources/assets/js/components/HRPortal/JobSummaryActivityFeed.tsx",
     "public/js",
   )
+  .ts(
+    "resources/assets/js/components/StrategicResponse/StrApiTestPage.tsx",
+    "public/js",
+  )
   .sass("resources/assets/sass/app.scss", "public/css", {
     implementation: sass,
     sassOptions: {


### PR DESCRIPTION
The Strategic Response seeder now creates 100 live jobs in correct department, with correct extra fields.

As a bonus, https://talent.test/en/demo/response/api-test on a local env will load all those jobs with redux+react.