### PR TITLE
Strategic Job Poster cleanup

### DIFF
--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -155,17 +155,33 @@ class JobController extends Controller
         }
 
         // TODO: replace route('manager.show',manager.id) in templates with link using slug.
+        $essential_hard = $jobPoster->criteria->filter(
+            function ($value, $key) {
+                return $value->criteria_type->name == 'essential' &&
+                    $value->skill->skill_type->name == 'hard';
+            }
+        )->sortBy('skill.name');
+        $essential_soft = $jobPoster->criteria->filter(
+            function ($value, $key) {
+                return $value->criteria_type->name == 'essential' &&
+                    $value->skill->skill_type->name == 'soft';
+            }
+        )->sortBy('skill.name');
+        $asset_hard = $jobPoster->criteria->filter(
+            function ($value, $key) {
+                return $value->criteria_type->name == 'asset' &&
+                    $value->skill->skill_type->name == 'hard';
+            }
+        )->sortBy('skill.name');
+        $asset_soft = $jobPoster->criteria->filter(
+            function ($value, $key) {
+                return $value->criteria_type->name == 'asset' &&
+                    $value->skill->skill_type->name == 'soft';
+            }
+        )->sortBy('skill.name');
         $criteria = [
-            'essential' => $jobPoster->criteria->filter(
-                function ($value, $key) {
-                    return $value->criteria_type->name == 'essential';
-                }
-            ),
-            'asset' => $jobPoster->criteria->filter(
-                function ($value, $key) {
-                    return $value->criteria_type->name == 'asset';
-                }
-            ),
+            'essential' => $essential_hard->merge($essential_soft),
+            'asset' => $asset_hard->merge($asset_soft),
         ];
 
         $jobLang = Lang::get('applicant/job_post');

--- a/app/Http/Controllers/StrategicResponseController.php
+++ b/app/Http/Controllers/StrategicResponseController.php
@@ -43,6 +43,7 @@ class StrategicResponseController extends Controller
                             $levels[$level->name] = ['title' => $level->name, 'job_id' => null];
                         }
                     }
+
                     // Push specialty title and associated levels to specialty array.
                     $specialties[$specialty->name] = [
                         'title' => $specialty->name,
@@ -51,11 +52,13 @@ class StrategicResponseController extends Controller
                 }
             }
             if (!empty($specialties)) {
+                ksort($specialties);
+
                 // Push stream title and specialties to streams array.
                 $streams[$stream->name] = ['title' => $stream->name, 'specialties' => $specialties];
             }
-
         }
+        ksort($streams);
 
         return view('response/index/index', [
             'response' => Lang::get('response/index'),

--- a/resources/views/applicant/strategic_response_job_post/criteria.html.twig
+++ b/resources/views/applicant/strategic_response_job_post/criteria.html.twig
@@ -12,7 +12,6 @@
             {% for criterion in criteria.essential %}
                 <li data-c-margin="bottom(1)">
                     <p data-c-font-weight="bold" data-c-margin="bottom(.5)">{{ criterion.skill.name }}</p>
-                    <p data-c-margin="bottom(.5)">{{ job_post.criteria.requirement_label }}<a href="/faq#levels" title="{{ job_post.criteria.level_link_title }}" target="_blank">{{ skill_template.skill_levels[criterion.skill.skill_type.name][criterion.skill_level.name] }}</a></p>
                     <p data-c-margin="bottom(.5)">{{ criterion.description ? criterion.description|nl2br : criterion.skill.description|nl2br }}</p>
                     <p>{{ criterion.specificity|nl2br }}</p>
                 </li>

--- a/resources/views/applicant/strategic_response_job_post/header.html.twig
+++ b/resources/views/applicant/strategic_response_job_post/header.html.twig
@@ -24,7 +24,12 @@
                 </div>
             </div>
             <div data-c-grid="gutter(all, 1)">
-                <div data-c-grid-item="tl(2of3)"></div>
+                <div data-c-grid-item="tl(2of3)">
+                    <p data-c-color="black">
+                        <i class="fas fa-home" data-c-color="c2" data-c-margin="right(.25)"></i>
+                        {{ job_post.header.remote_work_allowed[job.remote_work_allowed] }}
+                    </p>
+                </div>
                 <div data-c-grid-item="tl(1of3)" data-c-align="base(center) tl(right)">
                     <p data-c-color="black">{{ job_post.header.reference_id|replace({':id':job.id}) }}</p>
                 </div>

--- a/resources/views/applicant/strategic_response_job_post/header.html.twig
+++ b/resources/views/applicant/strategic_response_job_post/header.html.twig
@@ -10,8 +10,7 @@
 <header>
     <div data-c-overlay="white(80)" style="background-image: url('/images/response-wall.jpg')">
         <div data-c-container="large" data-c-padding="tb(3)" data-c-align="base(center) tl(left)">
-            <h1 data-c-heading="h1" data-c-color="black" data-c-margin="bottom(1)">{{ job.talent_stream.name }}
-                -
+            <h1 data-c-heading="h1" data-c-color="black" data-c-margin="bottom(1)">
                 {{ job.talent_stream_category.name }}
                 -
                 {{ job.job_skill_level.name }}</h1>

--- a/resources/views/applicant/strategic_response_job_post/layout.html.twig
+++ b/resources/views/applicant/strategic_response_job_post/layout.html.twig
@@ -14,7 +14,7 @@
             {% include "applicant/strategic_response_job_post/sidebar" %}
         </div>
         <div data-c-grid-item="tl(3of4)">
-            <div data-c-container="medium(left)">
+            <div data-c-container="medium(center)">
                 {# Job Poster Content #}
                 {% include "applicant/strategic_response_job_post/basics" %}
                 {% include "applicant/strategic_response_job_post/impact" %}

--- a/resources/views/applicant/strategic_response_job_post/sidebar.html.twig
+++ b/resources/views/applicant/strategic_response_job_post/sidebar.html.twig
@@ -7,24 +7,18 @@
 <div class="sidebar" data-c-padding="top(3)">
     <nav>
         <p data-c-font-weight="bold" data-c-font-size="h4" data-c-margin="bottom(1)">On this page:</p>
-        <p data-c-color="c1" data-c-font-weight="bold" data-c-margin="bottom(.25)">{{ job.title }}</p>
-        <p data-c-margin="bottom(1)">{{ job.department.name }}</p>
+        <p data-c-color="c1" data-c-font-weight="bold" data-c-margin="bottom(.25)">
+            {{ job.talent_stream_category.name }}
+            -
+            {{ job.job_skill_level.name }}
+        </p>
+        <p data-c-margin="bottom(1)">{{ job_post.strategic_response.various_departments }}</p>
         <ul>
-            <li>
-                <a href="#basics" title="{{ job_post.basics.sidebar_title }}">{{ job_post.basics.title }}</a>
-            </li>
-            <li>
-                <a href="#impact" title="{{ job_post.impact.sidebar_title }}">{{ job_post.impact.title }}</a>
-            </li>
-            <li>
-                <a href="#work" title="{{ job_post.work.sidebar_title }}">{{ job_post.work.title }}</a>
-            </li>
-            <li>
-                <a href="#criteria" title="{{ job_post.criteria.sidebar_title }}">{{ job_post.criteria.title }}</a>
-            </li>
-            <li>
-                <a href="#apply" title="{{ job_post.apply.sidebar_title }}">{{ job_post.apply.title }}</a>
-            </li>
+            <li><a href="#basics"title="{{ job_post.basics.sidebar_title }}">{{ job_post.basics.title }}</a></li>
+            <li><a href="#impact"title="{{ job_post.impact.sidebar_title }}">{{ job_post.impact.title }}</a></li>
+            <li><a href="#work"title="{{ job_post.work.sidebar_title }}">{{ job_post.work.title }}</a></li>
+            <li><a href="#criteria"title="{{ job_post.criteria.sidebar_title }}">{{ job_post.criteria.title }}</a></li>
+            <li><a href="#apply"title="{{ job_post.apply.sidebar_title }}">{{ job_post.apply.title }}</a></li>
         </ul>
     </nav>
 </div>

--- a/resources/views/applicant/strategic_response_job_post/sidebar.html.twig
+++ b/resources/views/applicant/strategic_response_job_post/sidebar.html.twig
@@ -4,7 +4,7 @@
     Applicant: Jobs - Post: Sidebar
 
 ============================================================================= #}
-<div class="sidebar" data-c-padding="top(3)">
+<div class="sidebar" data-c-padding="top(3)" data-c-container="medium(center)">
     <nav>
         <p data-c-font-weight="bold" data-c-font-size="h4" data-c-margin="bottom(1)">On this page:</p>
         <p data-c-color="c1" data-c-font-weight="bold" data-c-margin="bottom(.25)">


### PR DESCRIPTION
Resolves #3272.

# Notes:
Skill levels are still showing up for skill criteria on STR job posters. Remove the skill level, since its no longer part of the application.

Show the actual remote work value.

Order criteria so Hard skills appear before soft skills.

Construct the job title from Stream, Specialty and Level, instead of using actual job title.

On job index page, order streams and specialties alphabetically.