### PR TITLE
Use a new response/header partial on STR applicatiom

### DIFF
--- a/app/Http/Controllers/ApplicationByJobController.php
+++ b/app/Http/Controllers/ApplicationByJobController.php
@@ -96,6 +96,12 @@ class ApplicationByJobController extends Controller
         $viewTemplate = $jobPoster->isInStrategicResponseDepartment()
             ? 'applicant/strategic_response_application/application_post_01'
             : 'applicant/application_post_01';
+
+        $jobTitle = $jobPoster->isInStrategicResponseDepartment()
+            ? "{$jobPoster->talent_stream_category->name} - {$jobPoster->job_skill_level->name}"
+            : $jobPoster->title;
+        $headerTitle = Lang::get('applicant/application_template')['title'] . ": {$jobTitle}";
+
         return view(
             $viewTemplate,
             [
@@ -109,6 +115,9 @@ class ApplicationByJobController extends Controller
                 'preferred_language_template' => Lang::get('common/preferred_language'),
                 'citizenship_declaration_template' => Lang::get('common/citizenship_declaration'),
                 'veteran_status_template' => Lang::get('common/veteran_status'),
+                'header' => [
+                    'title' => $headerTitle,
+                ],
                 // Job Data.
                 'job' => $jobPoster,
                 // Applicant Data.
@@ -138,12 +147,21 @@ class ApplicationByJobController extends Controller
         $viewTemplate = $jobPoster->isInStrategicResponseDepartment()
             ? 'applicant/strategic_response_application/application_post_02'
             : 'applicant/application_post_02';
+
+        $jobTitle = $jobPoster->isInStrategicResponseDepartment()
+            ? "{$jobPoster->talent_stream_category->name} - {$jobPoster->job_skill_level->name}"
+            : $jobPoster->title;
+        $headerTitle = Lang::get('applicant/application_template')['title'] . ": {$jobTitle}";
+
         return view(
             $viewTemplate,
             [
                 // Application Template Data.
                 'application_step' => 2,
                 'application_template' => Lang::get('applicant/application_template'),
+                'header' => [
+                    'title' => $headerTitle,
+                ],
                 // Job Data.
                 'job' => $jobPoster,
                 // Applicant Data.
@@ -178,12 +196,21 @@ class ApplicationByJobController extends Controller
         $viewTemplate = $jobPoster->isInStrategicResponseDepartment()
             ? 'applicant/strategic_response_application/application_post_03'
             : 'applicant/application_post_03';
+
+        $jobTitle = $jobPoster->isInStrategicResponseDepartment()
+            ? "{$jobPoster->talent_stream_category->name} - {$jobPoster->job_skill_level->name}"
+            : $jobPoster->title;
+        $headerTitle = Lang::get('applicant/application_template')['title'] . ": {$jobTitle}";
+
         return view(
             $viewTemplate,
             [
                 // Application Template Data.
                 'application_step' => 3,
                 'application_template' => Lang::get('applicant/application_template'),
+                'header' => [
+                    'title' => $headerTitle,
+                ],
                 // Job Data.
                 'job' => $jobPoster,
                 // Skills Data.
@@ -223,12 +250,21 @@ class ApplicationByJobController extends Controller
         $viewTemplate = $jobPoster->isInStrategicResponseDepartment()
             ? 'applicant/strategic_response_application/application_post_04'
             : 'applicant/application_post_04';
+
+        $jobTitle = $jobPoster->isInStrategicResponseDepartment()
+            ? "{$jobPoster->talent_stream_category->name} - {$jobPoster->job_skill_level->name}"
+            : $jobPoster->title;
+        $headerTitle = Lang::get('applicant/application_template')['title'] . ": {$jobTitle}";
+
         return view(
             $viewTemplate,
             [
                 // Application Template Data.
                 'application_step' => 4,
                 'application_template' => Lang::get('applicant/application_template'),
+                'header' => [
+                    'title' => $headerTitle,
+                ],
                 // Job Data.
                 'job' => $jobPoster,
                 // Skills Data.
@@ -282,6 +318,11 @@ class ApplicationByJobController extends Controller
         $viewTemplate = $jobPoster->isInStrategicResponseDepartment()
             ? 'applicant/strategic_response_application/application_post_05'
             : 'applicant/application_post_05';
+        $jobTitle = $jobPoster->isInStrategicResponseDepartment()
+            ? "{$jobPoster->talent_stream_category->name} - {$jobPoster->job_skill_level->name}"
+            : $jobPoster->title;
+        $headerTitle = Lang::get('applicant/application_template')['title'] . ": {$jobTitle}";
+
         return view(
             $viewTemplate,
             [
@@ -291,6 +332,9 @@ class ApplicationByJobController extends Controller
                 'preferred_language_template' => Lang::get('common/preferred_language'),
                 'citizenship_declaration_template' => Lang::get('common/citizenship_declaration'),
                 'veteran_status_template' => Lang::get('common/veteran_status'),
+                'header' => [
+                    'title' => $headerTitle,
+                ],
                 // Job Data.
                 'job' => $jobPoster,
                 // Skills Data.
@@ -327,12 +371,20 @@ class ApplicationByJobController extends Controller
         $viewTemplate = $jobPoster->isInStrategicResponseDepartment()
             ? 'applicant/strategic_response_application/application_post_06'
             : 'applicant/application_post_06';
+        $jobTitle = $jobPoster->isInStrategicResponseDepartment()
+            ? "{$jobPoster->talent_stream_category->name} - {$jobPoster->job_skill_level->name}"
+            : $jobPoster->title;
+        $headerTitle = Lang::get('applicant/application_template')['title'] . ": {$jobTitle}";
+
         return view(
             $viewTemplate,
             [
                 // Application Template Data.
                 'application_step' => 6,
                 'application_template' => Lang::get('applicant/application_template'),
+                'header' => [
+                    'title' => $headerTitle,
+                ],
                 // Used by tracker partial.
                 'job' => $jobPoster,
                 'job_application' => $application,
@@ -361,11 +413,20 @@ class ApplicationByJobController extends Controller
         $viewTemplate = $jobPoster->isInStrategicResponseDepartment()
             ? 'applicant/strategic_response_application/application_post_complete'
             : 'applicant/application_post_complete';
+
+        $jobTitle = $jobPoster->isInStrategicResponseDepartment()
+            ? "{$jobPoster->talent_stream_category->name} - {$jobPoster->job_skill_level->name}"
+            : $jobPoster->title;
+        $headerTitle = Lang::get('applicant/application_template')['title'] . ": {$jobTitle}";
+
         return view(
             $viewTemplate,
             [
                 // Application Template Data.
                 'application_template' => Lang::get('applicant/application_template'),
+                'header' => [
+                    'title' => $headerTitle,
+                ],
                 // Job Data.
                 'job' => $jobPoster,
                 // Applicant Data.

--- a/app/Providers/ViewComposerServiceProvider.php
+++ b/app/Providers/ViewComposerServiceProvider.php
@@ -26,7 +26,7 @@ class ViewComposerServiceProvider extends ServiceProvider
 
         // Governement of Canada header bar.
         View::composer(
-            ['common/goc', 'common/header'],
+            ['common/goc', 'common/header', 'response/header'],
             'App\Http\ViewComposers\GocComposer'
         );
 

--- a/resources/views/applicant/strategic_response_application/application_post_01.html.twig
+++ b/resources/views/applicant/strategic_response_application/application_post_01.html.twig
@@ -6,18 +6,22 @@
 ============================================================================= #}
 {% extends "layouts/base" %}
 {% block title %}
-	{{ application_template.step_01_title }}
+    {{ application_template.step_01_title }}
 {% endblock %}
 {% block body %}
-	{% include "common/goc" %}
-	{% include "common/alert" %}
-	{% include "common/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job.title})}} %}
-	<a id="skipLink"></a>
-	{# Form containing all about_me editable elements #}
-	<form action="{{ form_submit_action }}" method="post">
-		{% include "applicant/strategic_response_application/common/tracker" %}
-		{# Builds an input field for CSRF token validation #}
-		{{ csrf_field() }}
-		{% include "applicant/strategic_response_application/step_01/questions" %}
-	</form>
+    {% include "common/goc" %}
+    <div data-clone>
+        {% include "response/beta-banner" %}
+        {% include "response/menu" %}
+        {% set job_title = ":specialty - :level"|replace({':specialty': job.talent_stream_category.name, ':level': job.job_skill_level.name}) %}
+        {% include "response/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job_title})}} %}
+        <a id="skipLink"></a>
+        {# Form containing all about_me editable elements #}
+        <form action="{{ form_submit_action }}" method="post">
+            {% include "applicant/strategic_response_application/common/tracker" %}
+            {# Builds an input field for CSRF token validation #}
+            {{ csrf_field() }}
+            {% include "applicant/strategic_response_application/step_01/questions" %}
+        </form>
+    </div>
 {% endblock %}

--- a/resources/views/applicant/strategic_response_application/application_post_01.html.twig
+++ b/resources/views/applicant/strategic_response_application/application_post_01.html.twig
@@ -1,27 +1,17 @@
 {# =============================================================================
-
     Talent Cloud
     Applicant: Apply - Step 01
-
 ============================================================================= #}
-{% extends "layouts/base" %}
+{% extends "response/response-base" %}
 {% block title %}
     {{ application_template.step_01_title }}
 {% endblock %}
 {% block body %}
-    {% include "common/goc" %}
-    <div data-clone>
-        {% include "response/beta-banner" %}
-        {% include "response/menu" %}
-        {% set job_title = ":specialty - :level"|replace({':specialty': job.talent_stream_category.name, ':level': job.job_skill_level.name}) %}
-        {% include "response/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job_title})}} %}
-        <a id="skipLink"></a>
-        {# Form containing all about_me editable elements #}
-        <form action="{{ form_submit_action }}" method="post">
-            {% include "applicant/strategic_response_application/common/tracker" %}
-            {# Builds an input field for CSRF token validation #}
-            {{ csrf_field() }}
-            {% include "applicant/strategic_response_application/step_01/questions" %}
-        </form>
-    </div>
+    {# Form containing all about_me editable elements #}
+    <form action="{{ form_submit_action }}" method="post">
+        {% include "applicant/strategic_response_application/common/tracker" %}
+        {# Builds an input field for CSRF token validation #}
+        {{ csrf_field() }}
+        {% include "applicant/strategic_response_application/step_01/questions" %}
+    </form>
 {% endblock %}

--- a/resources/views/applicant/strategic_response_application/application_post_02.html.twig
+++ b/resources/views/applicant/strategic_response_application/application_post_02.html.twig
@@ -4,27 +4,19 @@
     Applicant: Apply - Step 02
 
 ============================================================================= #}
-{% extends "layouts/base" %}
+{% extends "response/response-base" %}
 {% block title %}
     {{ application_template.step_02_title }}
 {% endblock %}
 {% block body %}
-    {% include "common/goc" %}
-    <div data-clone>
-        {% include "response/beta-banner" %}
-        {% include "response/menu" %}
-        {% set job_title = ":specialty - :level"|replace({':specialty': job.talent_stream_category.name, ':level': job.job_skill_level.name}) %}
-        {% include "response/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job_title})}} %}
-        <a id="skipLink"></a>
-        {# Form containing all about_me editable elements #}
-        <form action="{{ form_submit_action }}" method="post">
-            {% include "applicant/strategic_response_application/common/tracker" %}
-            {% include "errors/form_errors" %}
-            {# Builds an input field for CSRF token validation #}
-            {{ csrf_field() }}
-            {% include "applicant/strategic_response_application/step_02/experience" %}
-        </form>
-    </div>
+    {# Form containing all about_me editable elements #}
+    <form action="{{ form_submit_action }}" method="post">
+        {% include "applicant/strategic_response_application/common/tracker" %}
+        {% include "errors/form_errors" %}
+        {# Builds an input field for CSRF token validation #}
+        {{ csrf_field() }}
+        {% include "applicant/strategic_response_application/step_02/experience" %}
+    </form>
     {# Modals #}
     {% include "common/modal" with {"page": application} %}
 {% endblock %}

--- a/resources/views/applicant/strategic_response_application/application_post_02.html.twig
+++ b/resources/views/applicant/strategic_response_application/application_post_02.html.twig
@@ -6,21 +6,25 @@
 ============================================================================= #}
 {% extends "layouts/base" %}
 {% block title %}
-	{{ application_template.step_02_title }}
+    {{ application_template.step_02_title }}
 {% endblock %}
 {% block body %}
-	{% include "common/goc" %}
-	{% include "common/alert" %}
-	{% include "common/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job.title})}} %}
-	<a id="skipLink"></a>
-	{# Form containing all about_me editable elements #}
-	<form action="{{ form_submit_action }}" method="post">
-		{% include "applicant/strategic_response_application/common/tracker" %}
-		{% include "errors/form_errors" %}
-		{# Builds an input field for CSRF token validation #}
-		{{ csrf_field() }}
-		{% include "applicant/strategic_response_application/step_02/experience" %}
-	</form>
-	{# Modals #}
-	{% include "common/modal" with {"page": application} %}
+    {% include "common/goc" %}
+    <div data-clone>
+        {% include "response/beta-banner" %}
+        {% include "response/menu" %}
+        {% set job_title = ":specialty - :level"|replace({':specialty': job.talent_stream_category.name, ':level': job.job_skill_level.name}) %}
+        {% include "response/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job_title})}} %}
+        <a id="skipLink"></a>
+        {# Form containing all about_me editable elements #}
+        <form action="{{ form_submit_action }}" method="post">
+            {% include "applicant/strategic_response_application/common/tracker" %}
+            {% include "errors/form_errors" %}
+            {# Builds an input field for CSRF token validation #}
+            {{ csrf_field() }}
+            {% include "applicant/strategic_response_application/step_02/experience" %}
+        </form>
+    </div>
+    {# Modals #}
+    {% include "common/modal" with {"page": application} %}
 {% endblock %}

--- a/resources/views/applicant/strategic_response_application/application_post_03.html.twig
+++ b/resources/views/applicant/strategic_response_application/application_post_03.html.twig
@@ -6,30 +6,32 @@
 ============================================================================= #}
 {% extends "layouts/base" %}
 {% block title %}
-	{{ application_template.step_03_title }}
+    {{ application_template.step_03_title }}
 {% endblock %}
 {% block body %}
-	{% include "common/goc" %}
-	{% include "common/alert" %}
-	{% include "common/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job.title})}} %}
-	<a id="skipLink"></a>
-	{% include "applicant/strategic_response_application/common/tracker-ajax" %}
-
-    <section class="application-post__skills-layout">
-        <div class="container--copy">
-            <h2>
-                {{ application_template.essential_title }}
-            </h2>
-            <p>{{ application_template.strategic_response.essential_context_1 | raw }}</p>
-            <p>{{ application_template.strategic_response.essential_context_2 | raw }}</p>
-        </div>
-	    {% include "applicant/strategic_response_application/common/skill-layout" %}
-    </section>
-
-	{# Modals #}
-	{% include "common/modal" with {"page": application} %}
-	{% include "common/modals/skills_need_help" %}
+    {% include "common/goc" %}
+    <div data-clone>
+        {% include "response/beta-banner" %}
+        {% include "response/menu" %}
+        {% set job_title = ":specialty - :level"|replace({':specialty': job.talent_stream_category.name, ':level': job.job_skill_level.name}) %}
+        {% include "response/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job_title})}} %}
+        <a id="skipLink"></a>
+        {% include "applicant/strategic_response_application/common/tracker-ajax" %}
+        <section class="application-post__skills-layout">
+            <div class="container--copy">
+                <h2>
+                    {{ application_template.essential_title }}
+                </h2>
+                <p>{{ application_template.strategic_response.essential_context_1 | raw }}</p>
+                <p>{{ application_template.strategic_response.essential_context_2 | raw }}</p>
+            </div>
+            {% include "applicant/strategic_response_application/common/skill-layout" %}
+        </section>
+    </div>
+    {# Modals #}
+    {% include "common/modal" with {"page": application} %}
+    {% include "common/modals/skills_need_help" %}
 {% endblock %}
 {% block scripts %}
-	<script async defer src="{{ mix('/js/SkillsWordCounter.js') }}"></script>
+    <script async defer src="{{ mix('/js/SkillsWordCounter.js') }}"></script>
 {% endblock %}

--- a/resources/views/applicant/strategic_response_application/application_post_03.html.twig
+++ b/resources/views/applicant/strategic_response_application/application_post_03.html.twig
@@ -4,30 +4,22 @@
     Applicant: Apply - Step 03
 
 ============================================================================= #}
-{% extends "layouts/base" %}
+{% extends "response/response-base" %}
 {% block title %}
     {{ application_template.step_03_title }}
 {% endblock %}
 {% block body %}
-    {% include "common/goc" %}
-    <div data-clone>
-        {% include "response/beta-banner" %}
-        {% include "response/menu" %}
-        {% set job_title = ":specialty - :level"|replace({':specialty': job.talent_stream_category.name, ':level': job.job_skill_level.name}) %}
-        {% include "response/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job_title})}} %}
-        <a id="skipLink"></a>
-        {% include "applicant/strategic_response_application/common/tracker-ajax" %}
-        <section class="application-post__skills-layout">
-            <div class="container--copy">
-                <h2>
-                    {{ application_template.essential_title }}
-                </h2>
-                <p>{{ application_template.strategic_response.essential_context_1 | raw }}</p>
-                <p>{{ application_template.strategic_response.essential_context_2 | raw }}</p>
-            </div>
-            {% include "applicant/strategic_response_application/common/skill-layout" %}
-        </section>
-    </div>
+    {% include "applicant/strategic_response_application/common/tracker-ajax" %}
+    <section class="application-post__skills-layout">
+        <div class="container--copy">
+            <h2>
+                {{ application_template.essential_title }}
+            </h2>
+            <p>{{ application_template.strategic_response.essential_context_1 | raw }}</p>
+            <p>{{ application_template.strategic_response.essential_context_2 | raw }}</p>
+        </div>
+        {% include "applicant/strategic_response_application/common/skill-layout" %}
+    </section>
     {# Modals #}
     {% include "common/modal" with {"page": application} %}
     {% include "common/modals/skills_need_help" %}

--- a/resources/views/applicant/strategic_response_application/application_post_04.html.twig
+++ b/resources/views/applicant/strategic_response_application/application_post_04.html.twig
@@ -6,31 +6,33 @@
 ============================================================================= #}
 {% extends "layouts/base" %}
 {% block title %}
-	{{ application_template.step_04_title }}
+    {{ application_template.step_04_title }}
 {% endblock %}
 {% block body %}
-	{% include "common/goc" %}
-	{% include "common/alert" %}
-	{% include "common/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job.title})}} %}
-	<a id="skipLink"></a>
-	{% include "applicant/strategic_response_application/common/tracker-ajax" %}
-
-    <section class="application-post__skills-layout">
-        <div class="container--copy">
-            <h2>
-                {{ application_template.asset_title }}
-            </h2>
-            <p>
-                {{ application_template.strategic_response.asset_context }}
-            </p>
-        </div>
-	    {% include "applicant/strategic_response_application/common/skill-layout" %}
-    </section>
-
-	{# Modals #}
-	{% include "common/modal" with {"page": application} %}
-	{% include "common/modals/skills_need_help" %}
+    {% include "common/goc" %}
+    <div data-clone>
+        {% include "response/beta-banner" %}
+        {% include "response/menu" %}
+        {% set job_title = ":specialty - :level"|replace({':specialty': job.talent_stream_category.name, ':level': job.job_skill_level.name}) %}
+        {% include "response/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job_title})}} %}
+        <a id="skipLink"></a>
+        {% include "applicant/strategic_response_application/common/tracker-ajax" %}
+        <section class="application-post__skills-layout">
+            <div class="container--copy">
+                <h2>
+                    {{ application_template.asset_title }}
+                </h2>
+                <p>
+                    {{ application_template.strategic_response.asset_context }}
+                </p>
+            </div>
+            {% include "applicant/strategic_response_application/common/skill-layout" %}
+        </section>
+    </div>
+    {# Modals #}
+    {% include "common/modal" with {"page": application} %}
+    {% include "common/modals/skills_need_help" %}
 {% endblock %}
 {% block scripts %}
-	<script async defer src="{{ mix('/js/SkillsWordCounter.js') }}"></script>
+    <script async defer src="{{ mix('/js/SkillsWordCounter.js') }}"></script>
 {% endblock %}

--- a/resources/views/applicant/strategic_response_application/application_post_04.html.twig
+++ b/resources/views/applicant/strategic_response_application/application_post_04.html.twig
@@ -4,31 +4,23 @@
     Applicant: Apply - Step 04
 
 ============================================================================= #}
-{% extends "layouts/base" %}
+{% extends "response/response-base" %}
 {% block title %}
     {{ application_template.step_04_title }}
 {% endblock %}
 {% block body %}
-    {% include "common/goc" %}
-    <div data-clone>
-        {% include "response/beta-banner" %}
-        {% include "response/menu" %}
-        {% set job_title = ":specialty - :level"|replace({':specialty': job.talent_stream_category.name, ':level': job.job_skill_level.name}) %}
-        {% include "response/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job_title})}} %}
-        <a id="skipLink"></a>
-        {% include "applicant/strategic_response_application/common/tracker-ajax" %}
-        <section class="application-post__skills-layout">
-            <div class="container--copy">
-                <h2>
-                    {{ application_template.asset_title }}
-                </h2>
-                <p>
-                    {{ application_template.strategic_response.asset_context }}
-                </p>
-            </div>
-            {% include "applicant/strategic_response_application/common/skill-layout" %}
-        </section>
-    </div>
+    {% include "applicant/strategic_response_application/common/tracker-ajax" %}
+    <section class="application-post__skills-layout">
+        <div class="container--copy">
+            <h2>
+                {{ application_template.asset_title }}
+            </h2>
+            <p>
+                {{ application_template.strategic_response.asset_context }}
+            </p>
+        </div>
+        {% include "applicant/strategic_response_application/common/skill-layout" %}
+    </section>
     {# Modals #}
     {% include "common/modal" with {"page": application} %}
     {% include "common/modals/skills_need_help" %}

--- a/resources/views/applicant/strategic_response_application/application_post_05.html.twig
+++ b/resources/views/applicant/strategic_response_application/application_post_05.html.twig
@@ -6,16 +6,20 @@
 ============================================================================= #}
 {% extends "layouts/base" %}
 {% block title %}
-	{{ application_template.step_05_title }}
+    {{ application_template.step_05_title }}
 {% endblock %}
 {% block body %}
-	{% include "common/goc" %}
-	{% include "common/alert" %}
-	{% include "common/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job.title})}} %}
-	<a id="skipLink"></a>
-	{% include "applicant/strategic_response_application/common/tracker-ajax" %}
-    <section class="application__view-layout">
-        {% include "applicant/strategic_response_application/application_view/application_layout" %}
-        {% include "applicant/strategic_response_application/step_05/view_05_actions" %}
-    </section>
+    {% include "common/goc" %}
+    <div data-clone>
+        {% include "response/beta-banner" %}
+        {% include "response/menu" %}
+        {% set job_title = ":specialty - :level"|replace({':specialty': job.talent_stream_category.name, ':level': job.job_skill_level.name}) %}
+        {% include "response/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job_title})}} %}
+        <a id="skipLink"></a>
+        {% include "applicant/strategic_response_application/common/tracker-ajax" %}
+        <section class="application__view-layout">
+            {% include "applicant/strategic_response_application/application_view/application_layout" %}
+            {% include "applicant/strategic_response_application/step_05/view_05_actions" %}
+        </section>
+    </div>
 {% endblock %}

--- a/resources/views/applicant/strategic_response_application/application_post_05.html.twig
+++ b/resources/views/applicant/strategic_response_application/application_post_05.html.twig
@@ -4,22 +4,14 @@
     Applicant: Summary - step 5
 
 ============================================================================= #}
-{% extends "layouts/base" %}
+{% extends "response/response-base" %}
 {% block title %}
     {{ application_template.step_05_title }}
 {% endblock %}
 {% block body %}
-    {% include "common/goc" %}
-    <div data-clone>
-        {% include "response/beta-banner" %}
-        {% include "response/menu" %}
-        {% set job_title = ":specialty - :level"|replace({':specialty': job.talent_stream_category.name, ':level': job.job_skill_level.name}) %}
-        {% include "response/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job_title})}} %}
-        <a id="skipLink"></a>
-        {% include "applicant/strategic_response_application/common/tracker-ajax" %}
-        <section class="application__view-layout">
-            {% include "applicant/strategic_response_application/application_view/application_layout" %}
-            {% include "applicant/strategic_response_application/step_05/view_05_actions" %}
-        </section>
-    </div>
+    {% include "applicant/strategic_response_application/common/tracker-ajax" %}
+    <section class="application__view-layout">
+        {% include "applicant/strategic_response_application/application_view/application_layout" %}
+        {% include "applicant/strategic_response_application/step_05/view_05_actions" %}
+    </section>
 {% endblock %}

--- a/resources/views/applicant/strategic_response_application/application_post_06.html.twig
+++ b/resources/views/applicant/strategic_response_application/application_post_06.html.twig
@@ -6,72 +6,67 @@
 ============================================================================= #}
 {% extends "layouts/base" %}
 {% block title %}
-	{{ application_template.complete.step_06_title }}
+    {{ application_template.complete.step_06_title }}
 {% endblock %}
 {% block body %}
-	{# Government of Canada Banner #}
-	{% include "common/goc" %}
-	{# Standard Alert #}
-	{% include "common/alert" %}{# Page Header #}
-	{# {% include "common/header" %} #}{% include "common/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job.title})}} %}
-	{# Skip to Content Link #}<a id="skipLink"> </a>
-	{# Application Tracker #}
-	{% include "applicant/strategic_response_application/common/tracker-ajax" %}
-	{# Body #}
-	<form
-		class="form-prevent-multiple-submit" action="{{ form_submit_action }}" method="post">
-		{# Builds an input field for CSRF token validation #}
-		{{ csrf_field() }}
-		{# Sections #}
-		<section class="application-06__wrapper">
-			<div class="container--copy">
-				<h3>{{ application_template.integrity.title }}</h3>
-				<p>{{ application_template.integrity.confirmation_copy }}</p>
-				<ul>
-                    {% for confirmation in application_template.strategic_response.confirmations %}
-					    <li>{{ confirmation }}</li>
-					{% endfor %}
-				</ul>
-				{% include "errors/form_errors" %}
-				<div class="flex-grid gutter">
-					<div class="box med-1of2">
-						<div class="form__input-wrapper--signature">
-							<label class="form__label" for="applicationReviewSignature">
-								{{ application_template.integrity.signature_label }}
-							</label>
-							<input class="form__input" id="applicationReviewSignature" name="submission_signature" required type="text"/>
-						</div>
-					</div>
-					<div class="box med-1of2">
-						<div class="form__input-wrapper--date">
-							<label class="form__label" for="applicationReviewDate">
-								{{ application_template.integrity.date_label }}
-							</label>
-							<input
-                                class="form__input"
-                                id="applicationReviewDate"
-                                name="submission_date"
-                                type="date"
-                                value={{ "now"|date("Y-m-d") }}
-                                required
-                            />
-						</div>
-					</div>
-				</div>
-				{# <p>{{ application_template.integrity.review }}</p> #}
-				<div class="flex-grid middle application-post__action-wrapper">
-					<div class="box med-1of2">
-						<button id="save_and_quit" class="button--blue light-bg button-prevent-multiple-submit" type="submit" name="submit" value="save_and_quit">
-							{{ application_template.integrity.save_label }}
-						</button>
-					</div>
-					<div class="box med-1of2">
-						<button class="button--blue light-bg button-prevent-multiple-submit" type="submit" name="submit" value="submit">
-							{{ application_template.integrity.submit_label }}
-						</button>
-					</div>
-				</div>
-			</div>
-		</section>
-	</form>
+    {# Government of Canada Banner #}
+    {% include "common/goc" %}
+    <div data-clone>
+        {% include "response/beta-banner" %}
+        {% include "response/menu" %}
+        {% set job_title = ":specialty - :level"|replace({':specialty': job.talent_stream_category.name, ':level': job.job_skill_level.name}) %}
+        {% include "response/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job_title})}} %}
+        <a id="skipLink"></a>
+        {% include "applicant/strategic_response_application/common/tracker-ajax" %}
+        {# Body #}
+        <form
+            class="form-prevent-multiple-submit" action="{{ form_submit_action }}" method="post">
+            {# Builds an input field for CSRF token validation #}
+            {{ csrf_field() }}
+            {# Sections #}
+            <section class="application-06__wrapper">
+                <div class="container--copy">
+                    <h3>{{ application_template.integrity.title }}</h3>
+                    <p>{{ application_template.integrity.confirmation_copy }}</p>
+                    <ul>
+                        {% for confirmation in application_template.strategic_response.confirmations %}
+                            <li>{{ confirmation }}</li>
+                        {% endfor %}
+                    </ul>
+                    {% include "errors/form_errors" %}
+                    <div class="flex-grid gutter">
+                        <div class="box med-1of2">
+                            <div class="form__input-wrapper--signature">
+                                <label class="form__label" for="applicationReviewSignature">
+                                    {{ application_template.integrity.signature_label }}
+                                </label>
+                                <input class="form__input" id="applicationReviewSignature" name="submission_signature" required type="text"/>
+                            </div>
+                        </div>
+                        <div class="box med-1of2">
+                            <div class="form__input-wrapper--date">
+                                <label class="form__label" for="applicationReviewDate">
+                                    {{ application_template.integrity.date_label }}
+                                </label>
+                                <input class="form__input" id="applicationReviewDate" name="submission_date" type="date" value={{ "now"|date("Y-m-d") }} required/>
+                            </div>
+                        </div>
+                    </div>
+                    {# <p>{{ application_template.integrity.review }}</p> #}
+                    <div class="flex-grid middle application-post__action-wrapper">
+                        <div class="box med-1of2">
+                            <button id="save_and_quit" class="button--blue light-bg button-prevent-multiple-submit" type="submit" name="submit" value="save_and_quit">
+                                {{ application_template.integrity.save_label }}
+                            </button>
+                        </div>
+                        <div class="box med-1of2">
+                            <button class="button--blue light-bg button-prevent-multiple-submit" type="submit" name="submit" value="submit">
+                                {{ application_template.integrity.submit_label }}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </form>
+    </div>
 {% endblock %}

--- a/resources/views/applicant/strategic_response_application/application_post_06.html.twig
+++ b/resources/views/applicant/strategic_response_application/application_post_06.html.twig
@@ -4,69 +4,60 @@
     Applicant: Application Step 06
 
 ============================================================================= #}
-{% extends "layouts/base" %}
+{% extends "response/response-base" %}
 {% block title %}
     {{ application_template.complete.step_06_title }}
 {% endblock %}
 {% block body %}
-    {# Government of Canada Banner #}
-    {% include "common/goc" %}
-    <div data-clone>
-        {% include "response/beta-banner" %}
-        {% include "response/menu" %}
-        {% set job_title = ":specialty - :level"|replace({':specialty': job.talent_stream_category.name, ':level': job.job_skill_level.name}) %}
-        {% include "response/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job_title})}} %}
-        <a id="skipLink"></a>
-        {% include "applicant/strategic_response_application/common/tracker-ajax" %}
-        {# Body #}
-        <form
-            class="form-prevent-multiple-submit" action="{{ form_submit_action }}" method="post">
-            {# Builds an input field for CSRF token validation #}
-            {{ csrf_field() }}
-            {# Sections #}
-            <section class="application-06__wrapper">
-                <div class="container--copy">
-                    <h3>{{ application_template.integrity.title }}</h3>
-                    <p>{{ application_template.integrity.confirmation_copy }}</p>
-                    <ul>
-                        {% for confirmation in application_template.strategic_response.confirmations %}
-                            <li>{{ confirmation }}</li>
-                        {% endfor %}
-                    </ul>
-                    {% include "errors/form_errors" %}
-                    <div class="flex-grid gutter">
-                        <div class="box med-1of2">
-                            <div class="form__input-wrapper--signature">
-                                <label class="form__label" for="applicationReviewSignature">
-                                    {{ application_template.integrity.signature_label }}
-                                </label>
-                                <input class="form__input" id="applicationReviewSignature" name="submission_signature" required type="text"/>
-                            </div>
-                        </div>
-                        <div class="box med-1of2">
-                            <div class="form__input-wrapper--date">
-                                <label class="form__label" for="applicationReviewDate">
-                                    {{ application_template.integrity.date_label }}
-                                </label>
-                                <input class="form__input" id="applicationReviewDate" name="submission_date" type="date" value={{ "now"|date("Y-m-d") }} required/>
-                            </div>
+    {% include "applicant/strategic_response_application/common/tracker-ajax" %}
+    {# Body #}
+    <form
+        class="form-prevent-multiple-submit" action="{{ form_submit_action }}" method="post">
+        {# Builds an input field for CSRF token validation #}
+        {{ csrf_field() }}
+        {# Sections #}
+        <section class="application-06__wrapper">
+            <div class="container--copy">
+                <h3>{{ application_template.integrity.title }}</h3>
+                <p>{{ application_template.integrity.confirmation_copy }}</p>
+                <ul>
+                    {% for confirmation in application_template.strategic_response.confirmations %}
+                        <li>{{ confirmation }}</li>
+                    {% endfor %}
+                </ul>
+                {% include "errors/form_errors" %}
+                <div class="flex-grid gutter">
+                    <div class="box med-1of2">
+                        <div class="form__input-wrapper--signature">
+                            <label class="form__label" for="applicationReviewSignature">
+                                {{ application_template.integrity.signature_label }}
+                            </label>
+                            <input class="form__input" id="applicationReviewSignature" name="submission_signature" required type="text"/>
                         </div>
                     </div>
-                    {# <p>{{ application_template.integrity.review }}</p> #}
-                    <div class="flex-grid middle application-post__action-wrapper">
-                        <div class="box med-1of2">
-                            <button id="save_and_quit" class="button--blue light-bg button-prevent-multiple-submit" type="submit" name="submit" value="save_and_quit">
-                                {{ application_template.integrity.save_label }}
-                            </button>
-                        </div>
-                        <div class="box med-1of2">
-                            <button class="button--blue light-bg button-prevent-multiple-submit" type="submit" name="submit" value="submit">
-                                {{ application_template.integrity.submit_label }}
-                            </button>
+                    <div class="box med-1of2">
+                        <div class="form__input-wrapper--date">
+                            <label class="form__label" for="applicationReviewDate">
+                                {{ application_template.integrity.date_label }}
+                            </label>
+                            <input class="form__input" id="applicationReviewDate" name="submission_date" type="date" value={{ "now"|date("Y-m-d") }} required/>
                         </div>
                     </div>
                 </div>
-            </section>
-        </form>
-    </div>
+                {# <p>{{ application_template.integrity.review }}</p> #}
+                <div class="flex-grid middle application-post__action-wrapper">
+                    <div class="box med-1of2">
+                        <button id="save_and_quit" class="button--blue light-bg button-prevent-multiple-submit" type="submit" name="submit" value="save_and_quit">
+                            {{ application_template.integrity.save_label }}
+                        </button>
+                    </div>
+                    <div class="box med-1of2">
+                        <button class="button--blue light-bg button-prevent-multiple-submit" type="submit" name="submit" value="submit">
+                            {{ application_template.integrity.submit_label }}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </form>
 {% endblock %}

--- a/resources/views/applicant/strategic_response_application/application_post_complete.html.twig
+++ b/resources/views/applicant/strategic_response_application/application_post_complete.html.twig
@@ -4,20 +4,10 @@
     Application: Success Message
 
 ============================================================================= #}
-{% extends "layouts/base" %}
+{% extends "response/response-base" %}
 {% block title %}
     {{ application_template.complete.step_06_title }}
 {% endblock %}
 {% block body %}
-    {# Government of Canada Block #}
-    {% include "common/goc" %}
-    <div data-clone>
-        {% include "response/beta-banner" %}
-        {% include "response/menu" %}
-        {% set job_title = ":specialty - :level"|replace({':specialty': job.talent_stream_category.name, ':level': job.job_skill_level.name}) %}
-        {% include "response/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job_title})}} %}
-        <a id="skipLink"></a>
-        {# Page Content #}
-        {% include "applicant/strategic_response_application/complete" %}
-    </div>
+    {% include "applicant/strategic_response_application/complete" %}
 {% endblock %}

--- a/resources/views/applicant/strategic_response_application/application_post_complete.html.twig
+++ b/resources/views/applicant/strategic_response_application/application_post_complete.html.twig
@@ -6,16 +6,18 @@
 ============================================================================= #}
 {% extends "layouts/base" %}
 {% block title %}
-	{{ application_template.complete.step_06_title }}
+    {{ application_template.complete.step_06_title }}
 {% endblock %}
 {% block body %}
-	{# Government of Canada Block #}
-	{% include "common/goc" %}
-	{# Alert #}
-	{% include "common/alert" %}
-	{# Page Header #}
-	{% include "common/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job.title})}} %}
-	<a id="skipLink"></a>
-	{# Page Content #}
-	{% include "applicant/strategic_response_application/complete" %}
+    {# Government of Canada Block #}
+    {% include "common/goc" %}
+    <div data-clone>
+        {% include "response/beta-banner" %}
+        {% include "response/menu" %}
+        {% set job_title = ":specialty - :level"|replace({':specialty': job.talent_stream_category.name, ':level': job.job_skill_level.name}) %}
+        {% include "response/header" with {'header': {'title': ":title: :job"|replace({':title': application_template.title, ':job': job_title})}} %}
+        <a id="skipLink"></a>
+        {# Page Content #}
+        {% include "applicant/strategic_response_application/complete" %}
+    </div>
 {% endblock %}

--- a/resources/views/response/header.html.twig
+++ b/resources/views/response/header.html.twig
@@ -1,0 +1,27 @@
+{# =============================================================================
+
+    Talent Cloud
+    Header
+
+============================================================================= #}
+<header>
+    <div data-c-overlay="white(80)" style="background-image: url('/images/response-wall.jpg')">
+        <div data-c-container="large" data-c-padding="tb(3)" data-c-align="base(center) tl(left)">
+            <h1 data-c-heading="h1" data-c-color="black" data-c-margin="bottom(1)">
+                {{ header.title }}
+            </h1>
+            {% if header.subtitle %}
+                <p data-c-color="black" data-c-margin="top(1)">{{ header.subtitle }}</p>
+            {% endif %}
+            <div data-c-margin="top(2)">
+                <div data-c-grid="gutter(all, 1)">
+                    <div data-c-grid-item="tl(1of2)"></div>
+                    <div data-c-grid-item="tl(1of2)" data-c-align="base(center) tl(right)">
+                        <span data-c-colour="black">{{ goc.pilot }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</header>
+

--- a/resources/views/response/response-base.html.twig
+++ b/resources/views/response/response-base.html.twig
@@ -1,0 +1,32 @@
+{# =============================================================================
+    Talent Cloud / Response Layout
+============================================================================= #}
+<!DOCTYPE html>
+<html
+    lang="{{ appLocale }}">
+    {# Note that the </head> and <body> tags are located inside the common/head
+        file due to Google Tag Manager being required on all pages. #}
+    <head>
+        <title>
+            {% block title %}{% endblock %}
+        </title>
+        {% block socialMeta %}{% endblock %}
+        {% include "common/head" %}
+        {# /head #}
+        {# Page Body #}
+        {% include "common/goc" %}
+            <div data-clone> {% include "response/beta-banner" %}
+            {% include "response/menu" %}
+            {% block header %}
+                {% include "response/header" %}
+            {% endblock %}
+            <a id="skipLink"></a>
+            {% block body %}{% endblock %}
+        </div>
+        {# Footer #}
+        {% include "common/footer" %}
+        {# Scripts #}
+        {% include "common/scripts" %}
+        {% block scripts %}{% endblock %}
+    </head>
+</html></body></html>


### PR DESCRIPTION
Use the new STR specific menu, and a header with new banner and no breadcrumbs, on every page of an STR application.

Resolves #3347.

### Notes:
- response/header can be used on other STR pages, potentially.
