### PR TITLE
SQL scripts for creating new database and resetting applicant data

### DIFF
--- a/etc/sql/create-talent-reserve-db.sql
+++ b/etc/sql/create-talent-reserve-db.sql
@@ -1,0 +1,14 @@
+ALTER ROLE postgres WITH CREATEDB CREATEROLE;
+
+\c postgres postgres;
+
+CREATE ROLE talentcloud WITH SUPERUSER LOGIN PASSWORD 'talentcloud';
+CREATE DATABASE talent_reserve
+    WITH OWNER = "talentcloud"
+        ENCODING = 'UTF8'
+        TABLESPACE = pg_default
+        CONNECTION LIMIT = 25;
+GRANT CONNECT, TEMPORARY ON DATABASE talent_reserve TO public;
+GRANT ALL ON DATABASE talent_reserve TO talentcloud;
+
+\c talent_reserve talentcloud;

--- a/etc/sql/delete-all-applicant-data.sql
+++ b/etc/sql/delete-all-applicant-data.sql
@@ -1,0 +1,130 @@
+-- Delete all content in tables exlcusively related to applicants & applications.
+TRUNCATE TABLE
+    applicant_profile_answers,
+    applicants,
+    application_reviews,
+    courses,
+    degrees,
+    experience_skills,
+    experiences_award,
+    experiences_community,
+    experiences_education,
+    experiences_personal,
+    experiences_work,
+    job_application_answers,
+    job_applications,
+    profile_pics,
+    project_reference,
+    projects,
+    reference_skill_declaration,
+    "references",
+    skill_declaration_work_sample,
+    skill_declarations,
+    work_experiences,
+    work_samples;
+
+/*
+* As Applicant users (ie Basic users) can act as Demo Managers,
+* we also need to delete all jobs - and related content - created by basic users.
+*/
+DELETE FROM assessment_plan_notifications
+    WHERE job_poster_id IN (
+        SELECT job_posters.id from job_posters
+            JOIN managers on job_posters.manager_id=managers.id
+            JOIN users on managers.user_id=users.id
+            JOIN user_roles on users.user_role_id=user_roles.id
+            WHERE user_roles.key='basic'
+    );
+DELETE FROM claimed_jobs
+    WHERE job_poster_id IN (
+        SELECT job_posters.id from job_posters
+            JOIN managers on job_posters.manager_id=managers.id
+            JOIN users on managers.user_id=users.id
+            JOIN user_roles on users.user_role_id=user_roles.id
+            WHERE user_roles.key='basic'
+    );
+DELETE FROM comments
+    WHERE job_poster_id IN (
+        SELECT job_posters.id from job_posters
+            JOIN managers on job_posters.manager_id=managers.id
+            JOIN users on managers.user_id=users.id
+            JOIN user_roles on users.user_role_id=user_roles.id
+            WHERE user_roles.key='basic'
+    );
+DELETE FROM assessments
+    WHERE criterion_id IN (
+        SELECT criteria.id from criteria
+            JOIN job_posters on criteria.job_poster_id=job_posters.id
+            JOIN managers on job_posters.manager_id=managers.id
+            JOIN users on managers.user_id=users.id
+            JOIN user_roles on users.user_role_id=user_roles.id
+            WHERE user_roles.key='basic'
+    );
+DELETE FROM rating_guide_answers
+    WHERE criterion_id IN (
+        SELECT criteria.id from criteria
+            JOIN job_posters on criteria.job_poster_id=job_posters.id
+            JOIN managers on job_posters.manager_id=managers.id
+            JOIN users on managers.user_id=users.id
+            JOIN user_roles on users.user_role_id=user_roles.id
+            WHERE user_roles.key='basic'
+    );
+DELETE FROM criteria
+    WHERE job_poster_id IN (
+        SELECT job_posters.id from job_posters
+            JOIN managers on job_posters.manager_id=managers.id
+            JOIN users on managers.user_id=users.id
+            JOIN user_roles on users.user_role_id=user_roles.id
+            WHERE user_roles.key='basic'
+    );
+DELETE FROM rating_guide_questions
+    WHERE job_poster_id IN (
+        SELECT job_posters.id from job_posters
+            JOIN managers on job_posters.manager_id=managers.id
+            JOIN users on managers.user_id=users.id
+            JOIN user_roles on users.user_role_id=user_roles.id
+            WHERE user_roles.key='basic'
+    );
+DELETE FROM job_poster_key_tasks
+    WHERE job_poster_id IN (
+        SELECT job_posters.id from job_posters
+            JOIN managers on job_posters.manager_id=managers.id
+            JOIN users on managers.user_id=users.id
+            JOIN user_roles on users.user_role_id=user_roles.id
+            WHERE user_roles.key='basic'
+    );
+DELETE FROM job_poster_questions
+    WHERE job_poster_id IN (
+        SELECT job_posters.id from job_posters
+            JOIN managers on job_posters.manager_id=managers.id
+            JOIN users on managers.user_id=users.id
+            JOIN user_roles on users.user_role_id=user_roles.id
+            WHERE user_roles.key='basic'
+    );
+DELETE FROM job_poster_status_histories
+    WHERE job_poster_id IN (
+        SELECT job_posters.id from job_posters
+            JOIN managers on job_posters.manager_id=managers.id
+            JOIN users on managers.user_id=users.id
+            JOIN user_roles on users.user_role_id=user_roles.id
+            WHERE user_roles.key='basic'
+    );
+DELETE FROM job_posters
+    WHERE manager_id IN (
+        SELECT managers.id FROM managers
+            JOIN users on managers.user_id=users.id
+            JOIN user_roles on users.user_role_id=user_roles.id
+            WHERE user_roles.key='basic'
+    );
+
+-- Delete all Demo Manager profiles.
+DELETE FROM managers
+    WHERE user_id IN (
+        SELECT users.id FROM users
+            JOIN user_roles on users.user_role_id=user_roles.id
+            WHERE user_roles.key='basic'
+    );
+
+-- Delete all Basic users.
+DELETE FROM users
+    WHERE user_role_id IN (SELECT id FROM user_roles WHERE key = 'basic');


### PR DESCRIPTION
Add sql scripts for creating new talent_reserve db, and wiping applicant data

### Notes:
The following commands should give you a second database called `talent_reserve`, identical to `talentcloud` but without any applicant data:
- `psql -U postgres -d postgres < create-talent-reserve-db.sql`
- `pg_dump -U talentcloud talentcloud > backup.psql`
- `psql -U talentcloud talent_reserve < backup.psql`
- `psql -U talentcloud talent_reserve < delete-all-applicant-data.sql`
