### PR TITLE
Changes order of apply criteria on response homepage

### DIFF
--- a/resources/lang/en/response/index.php
+++ b/resources/lang/en/response/index.php
@@ -90,9 +90,9 @@ return [
         ],
         'apply_list_title' => 'You should apply to be in the GC Talent Reserve if:',
         'apply_list' => [
-            1 =>  "You're not currently in a critical role in your own department, and your manager would support a temporary placement.",
-            2 => 'You want to help Canadians by going where you’re most needed',
-            3 => 'You’re currently a Government of Canada employee (indeterminate or term)',
+            1 => 'You’re currently a Government of Canada employee (indeterminate or term)',
+            2 => "You're not currently in a critical role in your own department, and your manager would support a temporary placement.",
+            3 => 'You want to help Canadians by going where you’re most needed',
             4 => 'You have specialized skills to share (see list below)',
             5 => 'You want to support your colleagues in other teams or departments',
             6 => 'You’re good at adapting to new environments and processes',

--- a/resources/lang/fr/response/index.php
+++ b/resources/lang/fr/response/index.php
@@ -90,9 +90,9 @@ return [
         ],
         'apply_list_title' => 'Vous pouvez demander de faire partie de la Réserve de talents du GC si :',
         'apply_list' => [
-            1 =>  "Vous êtes dans une fonction essentielle dans votre propre ministère et que votre gestionnaire appuie un placement temporaire",
-            2 => 'Vous voulez aider les Canadiens en allant là où votre présence est le plus nécessaire',
-            3 => 'Vous êtes actuellement un employé du gouvernement du Canada (pour une période indéterminée ou déterminée)',
+            1 => 'Vous êtes actuellement un employé du gouvernement du Canada (pour une période indéterminée ou déterminée)',
+            2 =>  "Vous êtes dans une fonction essentielle dans votre propre ministère et que votre gestionnaire appuie un placement temporaire",
+            3 => 'Vous voulez aider les Canadiens en allant là où votre présence est le plus nécessaire',
             4 => 'Vous avez des compétences spécialisées à partager (voir la liste ci-dessous)',
             5 => 'Vous voulez appuyer vos collègues dans d’autres équipes ou ministères',
             6 => 'Vous êtes capable de vous adapter à un nouvel environnement et à de nouveaux processus',


### PR DESCRIPTION
Puts "you are an employee" check first in the "apply if" section of the response landing page