### PR TITLE
Changes alert banner messaging

### DIFF
--- a/resources/lang/en/response/beta_banner.php
+++ b/resources/lang/en/response/beta_banner.php
@@ -7,7 +7,7 @@ return [
     |
     */
     'beta_banner' => [
-        'message' => 'In our effort to get this site up and running quickly, we expect there to be a few glitches. ',
+        'message' => 'Talent Cloud has been temporarily taken down to support this project. Please expect it to return alongside the Talent Reserve sometime in May. ',
         'need_help' => [
             'text' => 'Need help? Get in touch.',
             'title' => 'Click here to get support.',

--- a/resources/lang/fr/response/beta_banner.php
+++ b/resources/lang/fr/response/beta_banner.php
@@ -7,7 +7,7 @@ return [
     |
     */
     'beta_banner' => [
-        'message' => 'Dans notre tentative de rendre ce site opérationnel rapidement, nous nous attendons à ce quelques problèmes surviennent. ',
+        'message' => 'Le Nuage de talents a été temporairement retiré pour soutenir ce projet. Il devrait revenir avec la Réserve de talents au mois de mai. ',
         'need_help' => [
             'text' => 'Besoin d’aide? Communiquez avec nous.',
             'title' => 'Cliquez ici pour obtenir de l’aide.',


### PR DESCRIPTION
Changes the alert banner on response pages to be clear about Talent Cloud's status and return timeframe.