### PR TITLE
Bugfix - Blank JPB review page for new manager accounts

### DIFF
--- a/resources/assets/js/helpers/localize.ts
+++ b/resources/assets/js/helpers/localize.ts
@@ -13,7 +13,7 @@ export function localizeField<T>(
   model: T,
   field: TranslatableKeys<T>,
 ): string | null {
-  if (model[field] && model[field][locale]) {
+  if (model[field] !== null) {
     return model[field][locale];
   }
   return null;

--- a/resources/assets/js/helpers/localize.ts
+++ b/resources/assets/js/helpers/localize.ts
@@ -13,7 +13,10 @@ export function localizeField<T>(
   model: T,
   field: TranslatableKeys<T>,
 ): string | null {
-  return model[field][locale];
+  if (model[field] && model[field][locale]) {
+    return model[field][locale];
+  }
+  return null;
 }
 export function localizeFieldNonNull<T>(
   locale: Locales,


### PR DESCRIPTION
Added another check on the `localizeField` function in the event `model[field]` is null (which was the case here).