### PR TITLE
Bugfix - Draft posters display on response page

### DIFF
--- a/app/Http/Controllers/StrategicResponseController.php
+++ b/app/Http/Controllers/StrategicResponseController.php
@@ -24,7 +24,9 @@ class StrategicResponseController extends Controller
         $job_skill_levels = JobSkillLevel::all();
 
         $strategic_response_id = config('app.strategic_response_department_id');
-        $strategic_response_jobs = JobPoster::where('department_id', $strategic_response_id)->get();
+        $strategic_response_jobs = JobPoster::where('department_id', $strategic_response_id)
+            ->where('job_poster_status_id', JobPosterStatus::where('key', 'live')->first()->id)
+            ->get();
 
         $streams = [];
         // Iterate through all talent streams.

--- a/app/Http/Controllers/StrategicResponseController.php
+++ b/app/Http/Controllers/StrategicResponseController.php
@@ -22,7 +22,7 @@ class StrategicResponseController extends Controller
 
         $stream_names = TalentStream::all();
         $stream_specialties = TalentStreamCategory::all();
-        $job_skill_levels = JobSkillLevel::all();
+        $job_skill_levels = JobSkillLevel::orderBy('id', 'asc')->get();
 
         $strategic_response_id = config('app.strategic_response_department_id');
         $strategic_response_jobs = JobPoster::where('department_id', $strategic_response_id)

--- a/app/Http/Controllers/StrategicResponseController.php
+++ b/app/Http/Controllers/StrategicResponseController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use App\Models\JobPoster;
+use App\Models\Lookup\JobPosterStatus;
 use App\Models\Lookup\JobSkillLevel;
 use App\Models\Lookup\TalentStream;
 use App\Models\Lookup\TalentStreamCategory;
@@ -33,6 +34,7 @@ class StrategicResponseController extends Controller
         foreach ($stream_names as $stream) {
             $stream_jobs = $strategic_response_jobs->where('talent_stream_id', $stream->id);
             $specialties = [];
+            $specialties_count = 0;
             foreach ($stream_specialties as $specialty) {
                 $stream_specialty_jobs = $stream_jobs->where('talent_stream_category_id', $specialty->id);
                 if ($stream_specialty_jobs->isNotEmpty()) {
@@ -41,6 +43,7 @@ class StrategicResponseController extends Controller
                         $job = $stream_specialty_jobs->firstWhere('job_skill_level_id', $level->id);
                         if ($job) {
                             $levels[$level->name] = ['title' => $level->name, 'job_id' => $job->id];
+                            $specialties_count += 1;
                         } else {
                             $levels[$level->name] = ['title' => $level->name, 'job_id' => null];
                         }
@@ -57,7 +60,11 @@ class StrategicResponseController extends Controller
                 ksort($specialties);
 
                 // Push stream title and specialties to streams array.
-                $streams[$stream->name] = ['title' => $stream->name, 'specialties' => $specialties];
+                $streams[$stream->name] = [
+                    'title' => $stream->name,
+                    'specialties' => $specialties,
+                    'count' => $specialties_count,
+                ];
             }
         }
         ksort($streams);

--- a/resources/views/response/index/stream.html.twig
+++ b/resources/views/response/index/stream.html.twig
@@ -7,11 +7,7 @@
             data-c-accordion-trigger
             tabindex="0"
             type="button">
-            {% set specialtyCount = 0 %}
-            {% for specialty in stream.specialties %}
-                {% set specialtyCount = specialtyCount + 1 %}
-            {% endfor %}
-            <h3 data-c-font-size="h4"><span data-c-font-weight="bold">{{response.stream.view}} {{ stream.title }}</span> ({{ specialtyCount }})</h4>
+            <h3 data-c-font-size="h4"><span data-c-font-weight="bold">{{response.stream.view}} {{ stream.title }}</span> ({{ stream.count }})</h4>
             <span data-c-visibility="invisible">
                 {{ response.stream.click_to_view }}
             </span>


### PR DESCRIPTION
### Notes:
Added a couple things in this PR since I was in the neighbourhood

- Restricted the JobPoster query to `live` postings only (root issue)
- Changed the count to reflect the total number of postings within a stream, rather than the number of categories in a stream with postings
- Added an explicit order to the Skill Level query, hopefully resolves the display issue on the live site (postings are in Junior > Mid > Expert order locally)
