### PR TITLE
Redirect /en/response to /response

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -52,12 +52,6 @@ class LoginController extends AuthController
             $redirectTo = route('home');
         }
 
-        // Redirect to Response landing page if user logged in from that page.
-        $previous_url = session()->get('response.index');
-        if ($previous_url == route('response.index')) {
-            $redirectTo = route('response.index');
-        }
-
         return $redirectTo;
     }
 
@@ -87,14 +81,6 @@ class LoginController extends AuthController
             $home_url = route('home');
         };
 
-        // If user came from response landing page then save url to session.
-        // Set the "Return home" link back to Response page.
-        $previous_url = session()->get('_previous')['url'];
-        if ($previous_url == route('response.index')) {
-            session()->put('response.index', route('response.index'));
-            $home_url = route('response.index');
-        }
-
         return view('auth/login', [
             'routes' => $this->auth_routes(),
             'login' => Lang::get('common/auth/login'),
@@ -112,13 +98,6 @@ class LoginController extends AuthController
     public function logout(Request $request)
     {
         $this->guard()->logout();
-
-        // Redirect user back to Response landing page on logout and flush the session data.
-        $previous_url = session()->get('response.index');
-        if ($previous_url == route('response.index')) {
-            $request->session()->invalidate();
-            return redirect(route('response.index'));
-        }
 
         $request->session()->invalidate();
 

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -46,12 +46,6 @@ class RegisterController extends AuthController
             $redirectTo = route('home');
         }
 
-        // Redirect to Response landing page if user registered from that page.
-        $response_url = session()->get('response.index');
-        if ($response_url == route('response.index')) {
-            $redirectTo = route('response.index');
-        }
-
         return $redirectTo;
     }
 
@@ -72,19 +66,6 @@ class RegisterController extends AuthController
      */
     public function showRegistrationForm()
     {
-        // If user came from response landing page then save url to session.
-        // Set the "Return home" link back to Response page.
-        $previous_url = session()->get('_previous')['url'];
-        if ($previous_url == route('response.index')) {
-            session()->put('response.index', route('response.index'));
-
-            return view('auth.register', [
-                'routes' => $this->auth_routes(),
-                'register' => Lang::get('common/auth/register'),
-                'home_url' => route('response.index'),
-            ]);
-        }
-
         return view('auth.register', [
             'routes' => $this->auth_routes(),
             'register' => Lang::get('common/auth/register'),

--- a/app/Mail/MicroReferenceMail.php
+++ b/app/Mail/MicroReferenceMail.php
@@ -56,8 +56,8 @@ class MicroReferenceMail extends Mailable implements ShouldQueue
             ->from(config('mail.from.address'), config('mail.from.name'))
             ->markdown('emails.micro_reference', [
                 'reference_name' => $reference_name,
-                'homepage_url' => route('response.index'),
-                'homepage_url_fr' => LaravelLocalization::getLocalizedURL('fr', route('response.index')),
+                'homepage_url' => route('home'),
+                'homepage_url_fr' => LaravelLocalization::getLocalizedURL('fr', route('home')),
                 'applicant_name' => $this->application->applicant->user->full_name,
                 'is_director' => $this->is_director,
                 'criteria' => $essential_criteria,

--- a/resources/views/applicant/strategic_response_application/complete.html.twig
+++ b/resources/views/applicant/strategic_response_application/complete.html.twig
@@ -11,7 +11,7 @@
             <div data-c-grid-item="tl(4of7)">
                 <p data-c-margin="bottom(1)">{{ application_template.strategic_response.complete_copy_1 }}</p>
                 <p data-c-margin="bottom(1)">{{ application_template.strategic_response.complete_copy_2 }}</p>
-                <p><a href="{{ route('response.index') }}" data-c-button="solid(c1)" data-c-radius="rounded">{{ application_template.strategic_response.complete_return_label }}</a></p>
+                <p><a href="{{ route('home') }}" data-c-button="solid(c1)" data-c-radius="rounded">{{ application_template.strategic_response.complete_return_label }}</a></p>
             </div>
             <div data-c-grid-item="tl(3of7)">
                 <div data-c-background="c1(10)" data-c-color="c1" data-c-border="all(thin, solid, c1)" data-c-radius="rounded" data-c-padding="all(1)">
@@ -24,7 +24,7 @@
                             <a href="{{ route('profile.about.edit', applicant.id) }}" title="{{ application_template.complete.update_profile_link_title }}">{{ application_template.complete.update_profile_link_label }}</a>
                         </li>
                         <li>
-                            <a href="{{ route('response.index') }}#apply" title="{{ application_template.complete.browse_jobs_title }}">{{ application_template.complete.browse_jobs_label }}</a>
+                            <a href="{{ route('home') }}#apply" title="{{ application_template.complete.browse_jobs_title }}">{{ application_template.complete.browse_jobs_label }}</a>
                         </li>
                     </ul>
                 </div>

--- a/resources/views/response/menu.html.twig
+++ b/resources/views/response/menu.html.twig
@@ -4,10 +4,10 @@
             <div data-c-grid-item="base(1of1) tl(2of4)">
                 <ul data-c-align="base(center) tl(left)">
                     <li>
-                        <a href="{{ route('response.index') }}" title="{{ response.menu.home.title }}" data-c-padding="all(.5)" data-c-color="white" data-c-hover-color="white">{{ response.menu.home.text }}</a>
+                        <a href="{{ route('home') }}" title="{{ response.menu.home.title }}" data-c-padding="all(.5)" data-c-color="white" data-c-hover-color="white">{{ response.menu.home.text }}</a>
                     </li>
                     <li>
-                        <a href="{{ route('response.index') }}#apply" title="{{ response.menu.apply.title }}" data-c-padding="all(.5)" data-c-color="white" data-c-hover-color="white">{{ response.menu.apply.text }}</a>
+                        <a href="{{ route('home') }}#apply" title="{{ response.menu.apply.title }}" data-c-padding="all(.5)" data-c-color="white" data-c-hover-color="white">{{ response.menu.apply.text }}</a>
                     </li>
                     <li>
                         <a href="https://canada.ca/coronavirus" title="{{ response.menu.info.title }}" target="_blank" data-c-padding="all(.5)" data-c-color="white" data-c-hover-color="white">{{ response.menu.info.text }}</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -116,15 +116,15 @@ Route::group(
                     ->name('jobs.summary');
 
                 /* Response Home */
-                Route::get('response', 'StrategicResponseController@index')->name('response.index');
+                // Redirect /en/response to /response so it reaches the Talent Reserve app.
+                Route::get('response', function () {
+                    return redirect(URL::to('/response'));
+                });
 
                 /* Reserve Redirect */
                 Route::get('reserve', function () {
                     return redirect('response');
                 });
-
-            /* Response Home */
-                Route::get('response/faq', 'StrategicResponseController@faq')->name('response.faq');
 
                 /* Require being logged in as applicant */
                 Route::middleware(['auth', 'role:applicant'])->group(function (): void {


### PR DESCRIPTION
This is in preparation for setting up both sites on the prod server. If the user tries to visit /en/response, which has been the correct url so far, they will be redirected to /response/en, which will connect to the TalentReserve app.

### Notes:
- This will make the response homepage innaccessible in this repo. You can checkout the TalentReserve repo to work on the response homepage.
- This may cause an infinite loop of redirects if you're just hosting this repo locally... not sure what to do about that.