### PR TITLE
Bugfix - Old Job Posters 403 error fix  

### DIFF
--- a/resources/views/applicant/job_post/culture.html.twig
+++ b/resources/views/applicant/job_post/culture.html.twig
@@ -26,11 +26,11 @@
 				<span>{{ manager.user.department.name }}</span>
 			</div>
 			{% if auth_guest() %}
-				<a class="job-post__culture-manager-profile-link gtag-applicant-job-poster-to-manager-profile" href="{{ route('managers.show', job_post) }}" title="{{ job_post.manager.link_title|replace({":name": manager.user.first_name}) }}">
+				<a class="job-post__culture-manager-profile-link gtag-applicant-job-poster-to-manager-profile" href="{{ route('managers.show', job) }}" title="{{ job_post.manager.link_title|replace({":name": manager.user.first_name}) }}">
 					{{ job_post.culture.guest_manager_link_label|replace({":name": manager.user.first_name}) }}
 				</a>
 			{% else %}
-				<a class="job-post__culture-manager-profile-link gtag-applicant-job-poster-to-manager-profile" href="{{ route('managers.show', job_post) }}" title="{{ job_post.manager.link_title|replace({":name": manager.user.first_name}) }}">
+				<a class="job-post__culture-manager-profile-link gtag-applicant-job-poster-to-manager-profile" href="{{ route('managers.show', job) }}" title="{{ job_post.manager.link_title|replace({":name": manager.user.first_name}) }}">
 					{{ job_post.culture.manager_link_label|replace({":name": manager.user.first_name}) }}
 				</a>
 			{% endif %}


### PR DESCRIPTION
Resolves #3233 

### Notes:
- This might be the reason for the 403 error on jobs with id between 1-18. They could be using the old job posters templates (jobs made before the JPB). A route method had a lang file object getting passed as the required parameter instead of the actual job. 
