### PR TITLE
Update formatjs dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1988,9 +1988,9 @@
             }
         },
         "@formatjs/intl-getcanonicallocales": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.2.4.tgz",
-            "integrity": "sha512-sG7Yy9VMB+ASd6Mn0o5LzQktwmhEVCyNm5MZlK91pN0BQrjkAfKVu+e3MSfYggo8FaEfWLHSEYqf7EyveDTInw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.2.6.tgz",
+            "integrity": "sha512-ZO38NUZoGHAeIn0B4ZXMdpcgdH5i2pZUIMvrf/l2XLAB339x8Yxx+P6WHTD66bQhyntuFpry5iN6zPBqnMubdA==",
             "requires": {
                 "cldr-core": "36.0.0"
             }
@@ -2032,9 +2032,9 @@
             }
         },
         "@formatjs/intl-pluralrules": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-2.2.4.tgz",
-            "integrity": "sha512-8SGGS4Ef5O/aCuDsHWaqoKZEqKxI+n3FM9uYpm+N9DNVkUCKc+LkB91cfZ6/4dD2shsvGw1hwQW9DEXFKFGAeQ==",
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-2.2.6.tgz",
+            "integrity": "sha512-iSYp7/gy0OIcyMCtLjL35iPIOHtInytMwDG6e6BDDaeVjaR3MzNFmNZ7/8xBx6lImDxi7XQR+X6/DOYUSgxvUg==",
             "requires": {
                 "@formatjs/intl-utils": "^3.3.1"
             },
@@ -2050,9 +2050,9 @@
             }
         },
         "@formatjs/intl-relativetimeformat": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-5.2.4.tgz",
-            "integrity": "sha512-dY3KBGWT6fPa+JM9zEUNOjfsKWJPd58lME0UdC10NidGzvQS74AmmUB06Fa3vRZm+u/1m6hJycIh7qy38MHnZA==",
+            "version": "5.2.6",
+            "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-5.2.6.tgz",
+            "integrity": "sha512-UPCY7IoyeqieUxdbfhINVjbCGXCzRr4xZpoiNsr1da4Fwm4uV6l53OXsx1zDRXoiNmMtDuKCKkRzlSfBL89L1g==",
             "requires": {
                 "@formatjs/intl-utils": "^3.3.1"
             },

--- a/package.json
+++ b/package.json
@@ -92,9 +92,9 @@
         "webpack": "^4.43.0"
     },
     "dependencies": {
-        "@formatjs/intl-getcanonicallocales": "^1.2.4",
-        "@formatjs/intl-pluralrules": "^2.2.4",
-        "@formatjs/intl-relativetimeformat": "^5.2.4",
+        "@formatjs/intl-getcanonicallocales": "^1.2.6",
+        "@formatjs/intl-pluralrules": "^2.2.6",
+        "@formatjs/intl-relativetimeformat": "^5.2.6",
         "axios": "^0.19.2",
         "babel-plugin-react-intl": "^7.1.0",
         "classnames": "^2.2.6",


### PR DESCRIPTION
### Notes:
- @formatjs/intl-getcanonicallocales@1.2.4 -> 1.2.6
- @formatjs/intl-pluralrules@2.2.4 -> 2.2.6
- @formatjs/intl-relativetimeformat@5.2.4 -> 5.2.6
