### PR TITLE
Add API endpoint for getting and updating basic application info

### DIFF
--- a/app/Http/Controllers/Api/ApplicationController.php
+++ b/app/Http/Controllers/Api/ApplicationController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\UpdateJobApplicationBasic;
 use App\Http\Resources\JobApplication as JobApplicationResource;
+use App\Http\Resources\JobApplicationBasic as JobApplicationBasicResource;
 use App\Models\ApplicationReview;
 use App\Models\JobApplication;
 use App\Models\JobPoster;
@@ -16,6 +18,42 @@ use Illuminate\Validation\Rule;
 
 class ApplicationController extends Controller
 {
+    /**
+     * Retrieve Application properties, not including relationships.
+     *
+     * @param JobApplication $application Incoming Job Application object.
+     *
+     * @return mixed
+     */
+    public function getBasic(JobApplication $application)
+    {
+        return new JobApplicationBasicResource($application);
+    }
+
+    /**
+     * Update Application properties, not including relationships.
+     *
+     * @param UpdateJobApplicationBasic $request     Form Validation casted request object.
+     * @param JobApplication            $application Incoming Job Application object.
+     *
+     * @return mixed
+     */
+    public function updateBasic(UpdateJobApplicationBasic $request, JobApplication $application)
+    {
+        $request->validated();
+        $application->fill([
+            'citizenship_declaration_id' => $request->input('citizenship_declaration_id'),
+            'veteran_status_id' => $request->input('veteran_status_id'),
+            'preferred_language_id' => $request->input('preferred_language_id'),
+            'language_requirement_confirmed' => $request->input('language_requirement_confirmed', false),
+            'language_test_confirmed' => $request->input('language_test_confirmed', false),
+            'education_requirement_confirmed' => $request->input('education_requirement_confirmed', false),
+        ]);
+        $application->save();
+
+        return new JobApplicationBasicResource($application);
+    }
+
     /**
      * Return a single Job Application.
      *
@@ -87,8 +125,7 @@ class ApplicationController extends Controller
         ]);
         $review->save();
 
-        if (
-            $application->job_poster->department_id === $strategicResponseDepartmentId
+        if ($application->job_poster->department_id === $strategicResponseDepartmentId
             && in_array($review->review_status_id, $availabilityStatuses->toArray())
         ) {
             $this->setAvailability($application);

--- a/app/Http/Controllers/Api/ApplicationController.php
+++ b/app/Http/Controllers/Api/ApplicationController.php
@@ -44,7 +44,6 @@ class ApplicationController extends Controller
         $application->fill([
             'citizenship_declaration_id' => $request->input('citizenship_declaration_id'),
             'veteran_status_id' => $request->input('veteran_status_id'),
-            'preferred_language_id' => $request->input('preferred_language_id'),
             'language_requirement_confirmed' => $request->input('language_requirement_confirmed', false),
             'language_test_confirmed' => $request->input('language_test_confirmed', false),
             'education_requirement_confirmed' => $request->input('education_requirement_confirmed', false),

--- a/app/Http/Requests/UpdateJobApplicationBasic.php
+++ b/app/Http/Requests/UpdateJobApplicationBasic.php
@@ -3,7 +3,6 @@
 namespace App\Http\Requests;
 
 use App\Models\Lookup\CitizenshipDeclaration;
-use App\Models\Lookup\PreferredLanguage;
 use App\Models\Lookup\VeteranStatus;
 use App\Services\Validation\Rules\ValidIdRule;
 use Illuminate\Foundation\Http\FormRequest;
@@ -39,12 +38,6 @@ class UpdateJobApplicationBasic extends FormRequest
                 'required',
                 'numeric',
                 new ValidIdRule(VeteranStatus::class)
-            ],
-            'preferred_language_id' => [
-                'bail',
-                'required',
-                'numeric',
-                new ValidIdRule(PreferredLanguage::class)
             ],
             'language_requirement_confirmed' => 'required|boolean',
             'language_test_confirmed' => 'required|boolean',

--- a/app/Http/Requests/UpdateJobApplicationBasic.php
+++ b/app/Http/Requests/UpdateJobApplicationBasic.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Lookup\CitizenshipDeclaration;
+use App\Models\Lookup\PreferredLanguage;
+use App\Models\Lookup\VeteranStatus;
+use App\Services\Validation\Rules\ValidIdRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateJobApplicationBasic extends FormRequest
+{
+    /**
+     * User authorization handled in routes/web.php.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'citizenship_declaration_id' => [
+                'bail',
+                'required',
+                'numeric',
+                new ValidIdRule(CitizenshipDeclaration::class)
+            ],
+            'veteran_status_id' => [
+                'bail',
+                'required',
+                'numeric',
+                new ValidIdRule(VeteranStatus::class)
+            ],
+            'preferred_language_id' => [
+                'bail',
+                'required',
+                'numeric',
+                new ValidIdRule(PreferredLanguage::class)
+            ],
+            'language_requirement_confirmed' => 'required|boolean',
+            'language_test_confirmed' => 'required|boolean',
+            'education_requirement_confirmed' => 'required|boolean',
+        ];
+    }
+}

--- a/app/Http/Resources/JobApplicationBasic.php
+++ b/app/Http/Resources/JobApplicationBasic.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class JobApplicationBasic extends JsonResource
+{
+    /**
+     * Transform the resource into an array. Returns
+     * a subset of the Application properties used on the Basic
+     * Info Application step.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'job_poster_id' => $this->job_poster_id,
+            'application_status_id' => $this->application_status_id,
+            'citizenship_declaration_id' => $this->citizenship_declaration_id,
+            'veteran_status_id' => $this->veteran_status_id,
+            'preferred_language_id' => $this->preferred_language_id,
+            'applicant_id' => $this->applicant_id,
+            'applicant_snapshot_id' => $this->applicant_snapshot_id,
+            'language_requirement_confirmed' => $this->language_requirement_confirmed,
+            'language_test_confirmed' => $this->language_test_confirmed,
+            'education_requirement_confirmed' => $this->education_requirement_confirmed,
+            'user_name' => $this->user_name,
+            'user_email' => $this->user_email,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Http/Resources/JobApplicationBasic.php
+++ b/app/Http/Resources/JobApplicationBasic.php
@@ -22,7 +22,6 @@ class JobApplicationBasic extends JsonResource
             'application_status_id' => $this->application_status_id,
             'citizenship_declaration_id' => $this->citizenship_declaration_id,
             'veteran_status_id' => $this->veteran_status_id,
-            'preferred_language_id' => $this->preferred_language_id,
             'applicant_id' => $this->applicant_id,
             'applicant_snapshot_id' => $this->applicant_snapshot_id,
             'language_requirement_confirmed' => $this->language_requirement_confirmed,

--- a/app/Models/JobApplication.php
+++ b/app/Models/JobApplication.php
@@ -31,6 +31,8 @@ use App\Traits\TalentCloudCrudTrait as CrudTrait;
  * @property string $submission_date
  * @property boolean $experience_saved
  * @property boolean $language_requirement_confirmed
+ * @property boolean $language_test_confirmed
+ * @property boolean $education_requirement_confirmed
  * @property string $user_name
  * @property string $user_email
  * @property int $version_id
@@ -96,6 +98,8 @@ class JobApplication extends BaseModel
         'submission_date' => 'string',
         'experience_saved' => 'boolean',
         'language_requirement_confirmed' => 'boolean',
+        'language_test_confirmed' => 'boolean',
+        'education_requirement_confirmed' => 'boolean',
         'version_id' => 'int',
         'director_name' => 'string',
         'director_title' => 'string',
@@ -109,7 +113,11 @@ class JobApplication extends BaseModel
     ];
     protected $fillable = [
         'citizenship_declaration_id',
+        'veteran_status_id',
+        'preferred_language_id',
         'language_requirement_confirmed',
+        'language_test_confirmed',
+        'education_requirement_confirmed',
         'veteran_status_id',
         'preferred_language_id',
         'submission_signature',
@@ -303,8 +311,7 @@ class JobApplication extends BaseModel
                 }
                 break;
             case 'preview':
-                if (
-                    $validator->basicsComplete($this) &&
+                if ($validator->basicsComplete($this) &&
                     $validator->experienceComplete($this) &&
                     $validator->essentialSkillsComplete($this) &&
                     $validator->assetSkillsComplete($this)
@@ -354,8 +361,7 @@ class JobApplication extends BaseModel
         $source = $this->isDraft() ? $this->applicant : $this;
         foreach ($essentialCriteria as $criterion) {
             $skillDeclaration = $source->skill_declarations->where('skill_id', $criterion->skill_id)->first();
-            if (
-                $skillDeclaration === null ||
+            if ($skillDeclaration === null ||
                 $skillDeclaration->skill_level_id < $criterion->skill_level_id
             ) {
                 return false;

--- a/database/migrations/2020_06_10_183107_add_confirmation_fields_to_job_applications_table.php
+++ b/database/migrations/2020_06_10_183107_add_confirmation_fields_to_job_applications_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddConfirmationFieldsToJobApplicationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('job_applications', function (Blueprint $table) {
+            $table->boolean('language_test_confirmed')->default(false);
+            $table->boolean('education_requirement_confirmed')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('job_applications', function (Blueprint $table) {
+            $table->dropColumn('language_test_confirmed');
+            $table->dropColumn('education_requirement_confirmed');
+        });
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -909,6 +909,14 @@ Route::prefix('api/v2')->name('api.v2.')->group(function (): void {
         ->where('application', '[0-9]+')
         ->middleware('can:view,application')
         ->name('application.show');
+    Route::get('applications/{application}/basic', 'Api\ApplicationController@getBasic')
+        ->where('application', '[0-9]+')
+        ->middleware('can:view,application')
+        ->name('application.basic');
+    Route::post('applications/{application}/basic', 'Api\ApplicationController@updateBasic')
+        ->where('application', '[0-9]+')
+        ->middleware('can:view,application')
+        ->name('application.basic.update');
     Route::get('jobs/{jobPoster}/applications', 'Api\ApplicationController@index')
         ->where('jobPoster', '[0-9]+')
         ->middleware('can:reviewApplicationsFor,jobPoster')

--- a/tests/Feature/Api/ApplicationControllerTest.php
+++ b/tests/Feature/Api/ApplicationControllerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\Applicant;
+use App\Models\JobApplication;
+use App\Models\Lookup\CitizenshipDeclaration;
+use App\Models\Lookup\PreferredLanguage;
+use App\Models\Lookup\VeteranStatus;
+
+class ApplicationControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Base route for the API calls.
+     *
+     * @var string
+     */
+    protected $baseUrl;
+
+    /**
+     * Run parent setup and set global values.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->baseUrl = 'api/v2';
+    }
+
+    public function testGetBasics(): void
+    {
+        $applicant = factory(Applicant::class)->create();
+        $application = factory(JobApplication::class)->states('draft')->create([
+            'applicant_id' => $applicant->id
+        ]);
+
+        $response = $this->actingAs($applicant->user)
+            ->json('get', "$this->baseUrl/applications/$application->id/basic");
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'id',
+            'job_poster_id',
+            'application_status_id',
+            'citizenship_declaration_id',
+            'veteran_status_id',
+            'preferred_language_id',
+            'applicant_id',
+            'applicant_snapshot_id',
+            'language_requirement_confirmed',
+            'language_test_confirmed',
+            'education_requirement_confirmed',
+            'user_name',
+            'user_email',
+            'created_at',
+            'updated_at',
+        ]);
+    }
+
+    public function testUnauthorizedBasics(): void
+    {
+        $application = factory(JobApplication::class)->states('draft')->create();
+
+        $response = $this->json('get', "$this->baseUrl/applications/$application->id/basic");
+        $response->assertStatus(403);
+    }
+
+    public function testUpdateBasics(): void
+    {
+        $applicant = factory(Applicant::class)->create();
+        $application = factory(JobApplication::class)->states('draft')->create([
+            'applicant_id' => $applicant->id
+        ]);
+
+        $citizenship = CitizenshipDeclaration::where('name', 'citizen')->value('id');
+        $preferredLanguage = PreferredLanguage::where('name', 'en')->value('id');
+        $veteranStatus = VeteranStatus::where('name', 'none')->value('id');
+
+        $expected = [
+            'citizenship_declaration_id' => $citizenship,
+            'veteran_status_id' => $veteranStatus,
+            'preferred_language_id' => $preferredLanguage,
+            'language_requirement_confirmed' => true,
+            'language_test_confirmed' => true,
+            'education_requirement_confirmed' => true,
+        ];
+
+        $response = $this->actingAs($applicant->user)
+            ->json('post', "$this->baseUrl/applications/$application->id/basic", $expected);
+        $response->assertOk();
+        $response->assertJsonFragment($expected);
+    }
+
+    public function testUpdateBasicsValidation(): void
+    {
+        $applicant = factory(Applicant::class)->create();
+        $application = factory(JobApplication::class)->states('draft')->create([
+            'applicant_id' => $applicant->id
+        ]);
+
+        $invalid = [
+            'citizenship_declaration_id' => 'text',
+            'preferred_language_id' => 17,
+            'language_requirement_confirmed' => 2,
+            'education_requirement_confirmed' => 'text',
+        ];
+
+        $response = $this->actingAs($applicant->user)
+            ->json('post', "$this->baseUrl/applications/$application->id/basic", $invalid);
+        $response->assertStatus(422);
+        $response->assertJsonFragment(['message' => 'The given data was invalid.']);
+    }
+}

--- a/tests/Feature/Api/ApplicationControllerTest.php
+++ b/tests/Feature/Api/ApplicationControllerTest.php
@@ -7,7 +7,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Models\Applicant;
 use App\Models\JobApplication;
 use App\Models\Lookup\CitizenshipDeclaration;
-use App\Models\Lookup\PreferredLanguage;
 use App\Models\Lookup\VeteranStatus;
 
 class ApplicationControllerTest extends TestCase
@@ -48,7 +47,6 @@ class ApplicationControllerTest extends TestCase
             'application_status_id',
             'citizenship_declaration_id',
             'veteran_status_id',
-            'preferred_language_id',
             'applicant_id',
             'applicant_snapshot_id',
             'language_requirement_confirmed',
@@ -77,13 +75,11 @@ class ApplicationControllerTest extends TestCase
         ]);
 
         $citizenship = CitizenshipDeclaration::where('name', 'citizen')->value('id');
-        $preferredLanguage = PreferredLanguage::where('name', 'en')->value('id');
         $veteranStatus = VeteranStatus::where('name', 'none')->value('id');
 
         $expected = [
             'citizenship_declaration_id' => $citizenship,
             'veteran_status_id' => $veteranStatus,
-            'preferred_language_id' => $preferredLanguage,
             'language_requirement_confirmed' => true,
             'language_test_confirmed' => true,
             'education_requirement_confirmed' => true,
@@ -104,7 +100,6 @@ class ApplicationControllerTest extends TestCase
 
         $invalid = [
             'citizenship_declaration_id' => 'text',
-            'preferred_language_id' => 17,
             'language_requirement_confirmed' => 2,
             'education_requirement_confirmed' => 'text',
         ];


### PR DESCRIPTION
### Notes:

- Added a couple confirmation fields for the UI: `language_test_confirmed` and `education_requirement_confirmed`
- Added a new Resource class for returning basic Application info... I waffled a bit between using the existing Application Resource but this seemed an easier way to control what fields are returned
- Added a form validator for posted fields, this doesn't check the validity in terms of business rules (i.e. that an applicant is legally able to work in Canada), just that the fields are present and are of the correct data type