### PR TITLE
Update front-end Application and Experience types, to match backend models better

### DIFF
--- a/resources/assets/js/fakeData/fakeApplications.ts
+++ b/resources/assets/js/fakeData/fakeApplications.ts
@@ -86,6 +86,9 @@ export const fakeApplicationNormalized = (
     },
   },
   meets_essential_criteria: true,
+  language_requirement_confirmed: true,
+  language_test_confirmed: true,
+  education_requirement_confirmed: true,
   ...overrides,
 });
 

--- a/resources/assets/js/fakeData/fakeExperience.ts
+++ b/resources/assets/js/fakeData/fakeExperience.ts
@@ -18,6 +18,9 @@ export const fakeExperienceWork = (
   is_active: false,
   start_date: dayjs("01/07/2015").toDate(),
   end_date: dayjs("12/13/2019").toDate(),
+  experienceable_id: 1,
+  experienceable_type: "applicant",
+  is_education_requirement: false,
   ...overrides,
 });
 
@@ -34,6 +37,9 @@ export const fakeExperienceEducation = (
   end_date: dayjs("04/30/2015").toDate(),
   thesis_title: "How do concrete structures withstand hurricane wind stress?",
   has_blockcert: true,
+  experienceable_id: 1,
+  experienceable_type: "applicant",
+  is_education_requirement: false,
   ...overrides,
 });
 
@@ -47,6 +53,9 @@ export const fakeExperienceCommunity = (
   is_active: true,
   start_date: dayjs("04/01/2018").toDate(),
   end_date: null,
+  experienceable_id: 1,
+  experienceable_type: "applicant",
+  is_education_requirement: false,
   ...overrides,
 });
 
@@ -59,6 +68,9 @@ export const fakeExperienceAward = (
   issued_by: "McGill University",
   award_recognition_type_id: 1,
   awarded_date: dayjs("01/27/2016").toDate(),
+  experienceable_id: 1,
+  experienceable_type: "applicant",
+  is_education_requirement: false,
   ...overrides,
 });
 
@@ -73,5 +85,8 @@ export const fakeExperiencePersonal = (
   is_active: true,
   start_date: dayjs("04/01/2013").toDate(),
   end_date: null,
+  experienceable_id: 1,
+  experienceable_type: "applicant",
+  is_education_requirement: false,
   ...overrides,
 });

--- a/resources/assets/js/models/types.ts
+++ b/resources/assets/js/models/types.ts
@@ -31,6 +31,9 @@ export type Application = {
   submission_signature: string;
   submission_date: string;
   experience_saved: boolean;
+  language_requirement_confirmed: boolean;
+  language_test_confirmed: boolean;
+  education_requirement_confirmed: boolean;
   created_at: Date;
   updated_at: Date;
   veteran_status: VeteranStatus;
@@ -271,7 +274,13 @@ export interface JobPosterStatus {
   description: localizedFieldNonNull;
 }
 
-export interface ExperienceWork {
+interface ExperienceBase {
+  experienceable_id: number;
+  experienceable_type: "applicant" | "application";
+  is_education_requirement: boolean;
+}
+
+export interface ExperienceWork extends ExperienceBase {
   id: number;
   title: string;
   organization: string;
@@ -281,20 +290,20 @@ export interface ExperienceWork {
   end_date: Date | null;
 }
 
-export interface ExperienceEducation {
+export interface ExperienceEducation extends ExperienceBase {
   id: number;
   education_type_id: number;
   area_of_study: string;
   institution: string;
   education_status_id: number;
   is_active: boolean;
+  thesis_title: string;
+  has_blockcert: boolean;
   start_date: Date;
   end_date: Date | null;
-  thesis_title: string | null;
-  has_blockcert: boolean;
 }
 
-export interface ExperienceCommunity {
+export interface ExperienceCommunity extends ExperienceBase {
   id: number;
   title: string;
   group: string;
@@ -304,7 +313,7 @@ export interface ExperienceCommunity {
   end_date: Date | null;
 }
 
-export interface ExperienceAward {
+export interface ExperienceAward extends ExperienceBase {
   id: number;
   title: string;
   award_recipient_type_id: number;
@@ -313,7 +322,7 @@ export interface ExperienceAward {
   awarded_date: Date;
 }
 
-export interface ExperiencePersonal {
+export interface ExperiencePersonal extends ExperienceBase {
   id: number;
   title: string;
   description: string;
@@ -322,6 +331,13 @@ export interface ExperiencePersonal {
   start_date: Date;
   end_date: Date | null;
 }
+
+export type Experience =
+  | (ExperienceWork & { type: "work" })
+  | (ExperienceEducation & { type: "education" })
+  | (ExperienceCommunity & { type: "community" })
+  | (ExperienceAward & { type: "award" })
+  | (ExperiencePersonal & { type: "personal" });
 
 export interface EmailAddress {
   name: string;


### PR DESCRIPTION
### Notes:
- I believe we'll want to setup an endpoint that returns all Experiences for an applicant or application, regardless of experience type. That endpoint will need to add a label to each object to distinguish between different types, which is what the new `Experience` typescript type is meant to represent.
