### PR TITLE
Bugfix - Allow localizeField to return null or an empty string

### DIFF
--- a/resources/assets/js/helpers/localize.ts
+++ b/resources/assets/js/helpers/localize.ts
@@ -14,9 +14,6 @@ export function localizeField<T>(
   field: TranslatableKeys<T>,
 ): string | null {
   if (model[field] !== null) {
-    if (model[field][locale] === ("" || null || undefined)) {
-      return locale === "en" ? "TRANSLATION MISSING" : "TRADUCTION MANQUANTE";
-    }
     return model[field][locale];
   }
   return null;


### PR DESCRIPTION
# Notes:
-  https://github.com/GCTC-NTGC/TalentCloud/pull/4009#issuecomment-658195060
 