### PR TITLE
Show the job's custom Education requirement in Application steps

### DIFF
--- a/resources/assets/js/components/Application/BasicInfo/BasicInfo.tsx
+++ b/resources/assets/js/components/Application/BasicInfo/BasicInfo.tsx
@@ -10,7 +10,11 @@ import messages, {
   languageRequirementDescription,
   languageRequirementLabel,
 } from "./basicInfoMessages";
-import { basicInfoMessages, navigationMessages } from "../applicationMessages";
+import {
+  basicInfoMessages,
+  navigationMessages,
+  educationRequirementMessages,
+} from "../applicationMessages";
 import SelectInput from "../../Form/SelectInput";
 import {
   CitizenshipId,
@@ -25,6 +29,7 @@ import CheckboxInput from "../../Form/CheckboxInput";
 import { educationMessages } from "../../JobBuilder/Details/JobDetailsMessages";
 import textToParagraphs from "../../../helpers/textToParagraphs";
 import { getLocale, localizeField } from "../../../helpers/localize";
+import { hasKey } from "../../../helpers/queries";
 
 interface BasicInfoProps {
   application: ApplicationNormalized;
@@ -75,9 +80,9 @@ export const BasicInfo: React.FunctionComponent<BasicInfoProps> = ({
   };
 
   const jobEducationReq = localizeField(locale, job, "education");
-  const defaultEducationReq = intl.formatMessage(
-    educationMessages[classification],
-  );
+  const defaultEducationReq = hasKey(educationMessages, classification)
+    ? intl.formatMessage(educationMessages[classification])
+    : intl.formatMessage(educationRequirementMessages.missingClassification);
   // If the job is using the default education requirements (for its classification) then we
   //  can predictably style it, by setting the right lines to bold. Otherwise, all we can do is
   //  split it into paragraphs.

--- a/resources/assets/js/components/Application/BasicInfo/BasicInfo.tsx
+++ b/resources/assets/js/components/Application/BasicInfo/BasicInfo.tsx
@@ -24,6 +24,7 @@ import { Job, ApplicationNormalized } from "../../../models/types";
 import CheckboxInput from "../../Form/CheckboxInput";
 import { educationMessages } from "../../JobBuilder/Details/JobDetailsMessages";
 import textToParagraphs from "../../../helpers/textToParagraphs";
+import { getLocale, localizeField } from "../../../helpers/localize";
 
 interface BasicInfoProps {
   application: ApplicationNormalized;
@@ -49,6 +50,7 @@ export const BasicInfo: React.FunctionComponent<BasicInfoProps> = ({
   handleQuit,
 }) => {
   const intl = useIntl();
+  const locale = getLocale(intl.locale);
   const classification: string = getKeyByValue(
     ClassificationId,
     job.classification_id,
@@ -71,6 +73,25 @@ export const BasicInfo: React.FunctionComponent<BasicInfoProps> = ({
       ? application.education_requirement_confirmed
       : false,
   };
+
+  const jobEducationReq = localizeField(locale, job, "education");
+  const defaultEducationReq = intl.formatMessage(
+    educationMessages[classification],
+  );
+  // If the job is using the default education requirements (for its classification) then we
+  //  can predictably style it, by setting the right lines to bold. Otherwise, all we can do is
+  //  split it into paragraphs.
+  const educationRequirements =
+    jobEducationReq === null || jobEducationReq === defaultEducationReq
+      ? textToParagraphs(
+          defaultEducationReq,
+          {},
+          {
+            0: { "data-c-font-weight": "bold" },
+            5: { "data-c-font-weight": "bold" },
+          },
+        )
+      : textToParagraphs(jobEducationReq);
 
   const validationSchema = Yup.object().shape({
     citizenship: Yup.number()
@@ -235,14 +256,7 @@ export const BasicInfo: React.FunctionComponent<BasicInfoProps> = ({
               data-c-padding="all(1)"
               data-c-margin="bottom(1)"
             >
-              {textToParagraphs(
-                intl.formatMessage(educationMessages[classification]),
-                {},
-                {
-                  0: { "data-c-font-weight": "bold" },
-                  5: { "data-c-font-weight": "bold" },
-                },
-              )}
+              {educationRequirements}
             </div>
             <div data-c-margin="left(2)">
               <FastField

--- a/resources/assets/js/components/Application/Experience/Experience.test.tsx
+++ b/resources/assets/js/components/Application/Experience/Experience.test.tsx
@@ -13,6 +13,8 @@ import fakeExperiences from "../../../fakeData/fakeExperience";
 import IntlContainer from "../../../IntlContainer";
 import ExperienceIntro from "./ExperienceIntro";
 import { fakeCriteria } from "../../../fakeData/fakeCriteria";
+import { educationMessages } from "../../JobBuilder/Details/JobDetailsMessages";
+import { ClassificationId } from "../../../models/lookupConstants";
 
 describe("Application Timeline - My Experience", (): void => {
   it("should render MyExperience with items", (): void => {
@@ -30,7 +32,8 @@ describe("Application Timeline - My Experience", (): void => {
           handleReturn={() => {}}
           handleSubmitExperience={async () => {}}
           jobId={1}
-          jobClassificationId={1}
+          jobClassificationId={ClassificationId.CS}
+          jobEducationRequirements={educationMessages.CS.defaultMessage}
           recipientTypes={recipientTypes}
           recognitionTypes={recogntitionTypes}
           skills={fakeSkills()}
@@ -56,7 +59,8 @@ describe("Application Timeline - My Experience", (): void => {
           handleReturn={() => {}}
           handleSubmitExperience={async () => {}}
           jobId={1}
-          jobClassificationId={1}
+          jobClassificationId={ClassificationId.CS}
+          jobEducationRequirements={educationMessages.CS.defaultMessage}
           recipientTypes={recipientTypes}
           recognitionTypes={recogntitionTypes}
           skills={fakeSkills()}

--- a/resources/assets/js/components/Application/Experience/Experience.tsx
+++ b/resources/assets/js/components/Application/Experience/Experience.tsx
@@ -103,6 +103,7 @@ interface ExperienceProps {
   skills: Skill[];
   jobId: number;
   jobClassificationId: number | null;
+  jobEducationRequirements: string | null;
   recipientTypes: AwardRecipientType[];
   recognitionTypes: AwardRecognitionType[];
   handleSubmitExperience: (data: ExperienceSubmitData) => Promise<void>;
@@ -126,6 +127,7 @@ const MyExperience: React.FunctionComponent<ExperienceProps> = ({
   handleDeleteExperience,
   jobId,
   jobClassificationId,
+  jobEducationRequirements,
   recipientTypes,
   recognitionTypes,
   handleContinue,
@@ -642,6 +644,7 @@ const MyExperience: React.FunctionComponent<ExperienceProps> = ({
         }
         jobId={jobId}
         jobClassification={jobClassification}
+        jobEducationRequirements={jobEducationRequirements}
         modalId={modalButtons.education.id}
         onModalCancel={closeModal}
         onModalConfirm={submitExperience}
@@ -663,6 +666,7 @@ const MyExperience: React.FunctionComponent<ExperienceProps> = ({
         }
         jobId={jobId}
         jobClassification={jobClassification}
+        jobEducationRequirements={jobEducationRequirements}
         modalId={modalButtons.work.id}
         onModalCancel={closeModal}
         onModalConfirm={submitExperience}
@@ -683,6 +687,7 @@ const MyExperience: React.FunctionComponent<ExperienceProps> = ({
         }
         jobId={jobId}
         jobClassification={jobClassification}
+        jobEducationRequirements={jobEducationRequirements}
         modalId={modalButtons.community.id}
         onModalCancel={closeModal}
         onModalConfirm={submitExperience}
@@ -704,6 +709,7 @@ const MyExperience: React.FunctionComponent<ExperienceProps> = ({
         }
         jobId={jobId}
         jobClassification={jobClassification}
+        jobEducationRequirements={jobEducationRequirements}
         modalId={modalButtons.personal.id}
         onModalCancel={closeModal}
         onModalConfirm={submitExperience}
@@ -725,6 +731,7 @@ const MyExperience: React.FunctionComponent<ExperienceProps> = ({
         }
         jobId={jobId}
         jobClassification={jobClassification}
+        jobEducationRequirements={jobEducationRequirements}
         modalId={modalButtons.award.id}
         onModalCancel={closeModal}
         onModalConfirm={submitExperience}

--- a/resources/assets/js/components/Application/Experience/ExperiencePage.tsx
+++ b/resources/assets/js/components/Application/Experience/ExperiencePage.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { useDispatch } from "react-redux";
-import { getLocale } from "../../../helpers/localize";
+import { getLocale, localizeField } from "../../../helpers/localize";
 import { navigate } from "../../../helpers/router";
 import {
   applicationSkillsIntro,
@@ -224,6 +224,7 @@ export const ExperiencePage: React.FC<ExperiencePageProps> = ({
           skills={skills}
           jobId={job.id}
           jobClassificationId={job.classification_id}
+          jobEducationRequirements={localizeField(locale, job, "education")}
           recipientTypes={awardRecipientTypes}
           recognitionTypes={awardRecognitionTypes}
           handleSubmitExperience={handleSubmit}

--- a/resources/assets/js/components/Application/Experience/__snapshots__/Experience.test.tsx.snap
+++ b/resources/assets/js/components/Application/Experience/__snapshots__/Experience.test.tsx.snap
@@ -354,7 +354,14 @@ exports[`Application Timeline - My Experience should render MyExperience with it
     handleQuit={[Function]}
     handleReturn={[Function]}
     handleSubmitExperience={[Function]}
-    jobClassificationId={1}
+    jobClassificationId={5}
+    jobEducationRequirements="2 years post-secondary, or equivalent:
+Successful completion of two years of post-secondary education in computer science, information technology, information management or another specialty relevant to this position.
+
+or
+
+Equivalent experience:
+If you have on-the-job learning or other non-conventional training that you believe is equivalent to the 2 year post-secondary requirement, put it forward for consideration. The manager may accept a combination of education, training and/or experience in a related field as an alternative to the minimum post-secondary education stated above."
     jobId={1}
     recipientTypes={
       Array [
@@ -771,7 +778,14 @@ exports[`Application Timeline - My Experience should render MyExperience without
     handleQuit={[Function]}
     handleReturn={[Function]}
     handleSubmitExperience={[Function]}
-    jobClassificationId={1}
+    jobClassificationId={5}
+    jobEducationRequirements="2 years post-secondary, or equivalent:
+Successful completion of two years of post-secondary education in computer science, information technology, information management or another specialty relevant to this position.
+
+or
+
+Equivalent experience:
+If you have on-the-job learning or other non-conventional training that you believe is equivalent to the 2 year post-secondary requirement, put it forward for consideration. The manager may accept a combination of education, training and/or experience in a related field as an alternative to the minimum post-secondary education stated above."
     jobId={1}
     recipientTypes={
       Array [

--- a/resources/assets/js/components/Application/ExperienceModals/AwardExperienceModal.tsx
+++ b/resources/assets/js/components/Application/ExperienceModals/AwardExperienceModal.tsx
@@ -49,6 +49,7 @@ interface AwardExperienceModalProps {
   recognitionTypes: AwardRecognitionType[];
   jobId: number;
   jobClassification: string;
+  jobEducationRequirements: string | null;
   requiredSkills: Skill[];
   savedRequiredSkills: Skill[];
   optionalSkills: Skill[];
@@ -224,6 +225,7 @@ export const AwardExperienceModal: React.FC<AwardExperienceModalProps> = ({
   recognitionTypes,
   jobId,
   jobClassification,
+  jobEducationRequirements,
   requiredSkills,
   savedRequiredSkills,
   optionalSkills,
@@ -368,6 +370,7 @@ export const AwardExperienceModal: React.FC<AwardExperienceModalProps> = ({
               <EducationSubform
                 keyPrefix="award"
                 jobClassification={jobClassification}
+                jobEducationRequirements={jobEducationRequirements}
               />
             </Modal.Body>
             <ExperienceModalFooter buttonsDisabled={formikProps.isSubmitting} />

--- a/resources/assets/js/components/Application/ExperienceModals/CommunityExperienceModal.tsx
+++ b/resources/assets/js/components/Application/ExperienceModals/CommunityExperienceModal.tsx
@@ -36,6 +36,7 @@ interface CommunityExperienceModalProps {
   experienceCommunity: ExperienceCommunity | null;
   jobId: number;
   jobClassification: string;
+  jobEducationRequirements: string | null;
   requiredSkills: Skill[];
   savedRequiredSkills: Skill[];
   optionalSkills: Skill[];
@@ -225,6 +226,7 @@ export const CommunityExperienceModal: React.FC<CommunityExperienceModalProps> =
   experienceCommunity,
   jobId,
   jobClassification,
+  jobEducationRequirements,
   requiredSkills,
   savedRequiredSkills,
   optionalSkills,
@@ -366,6 +368,7 @@ export const CommunityExperienceModal: React.FC<CommunityExperienceModalProps> =
               <EducationSubform
                 keyPrefix="community"
                 jobClassification={jobClassification}
+                jobEducationRequirements={jobEducationRequirements}
               />
             </Modal.Body>
             <ExperienceModalFooter buttonsDisabled={formikProps.isSubmitting} />

--- a/resources/assets/js/components/Application/ExperienceModals/EducationExperienceModal.tsx
+++ b/resources/assets/js/components/Application/ExperienceModals/EducationExperienceModal.tsx
@@ -50,6 +50,7 @@ interface EducationExperienceModalProps {
   educationStatuses: EducationStatus[];
   jobId: number;
   jobClassification: string;
+  jobEducationRequirements: string | null;
   requiredSkills: Skill[];
   savedRequiredSkills: Skill[];
   optionalSkills: Skill[];
@@ -291,6 +292,7 @@ export const EducationExperienceModal: React.FC<EducationExperienceModalProps> =
   educationStatuses,
   jobId,
   jobClassification,
+  jobEducationRequirements,
   requiredSkills,
   savedRequiredSkills,
   optionalSkills,
@@ -469,6 +471,7 @@ export const EducationExperienceModal: React.FC<EducationExperienceModalProps> =
               <EducationSubform
                 keyPrefix="education"
                 jobClassification={jobClassification}
+                jobEducationRequirements={jobEducationRequirements}
               />
             </Modal.Body>
             <ExperienceModalFooter buttonsDisabled={formikProps.isSubmitting} />

--- a/resources/assets/js/components/Application/ExperienceModals/EducationSubform.tsx
+++ b/resources/assets/js/components/Application/ExperienceModals/EducationSubform.tsx
@@ -6,6 +6,7 @@ import CheckboxInput from "../../Form/CheckboxInput";
 import textToParagraphs from "../../../helpers/textToParagraphs";
 import { educationMessages } from "../../JobBuilder/Details/JobDetailsMessages";
 import { hasKey } from "../../../helpers/queries";
+import { educationRequirementMessages } from "../applicationMessages";
 
 export interface EducationFormValues {
   useAsEducationRequirement: boolean;
@@ -42,7 +43,7 @@ export function EducationSubform({
   const jobEducationReq = jobEducationRequirements;
   const defaultEducationReq = hasKey(educationMessages, jobClassification)
     ? intl.formatMessage(educationMessages[jobClassification])
-    : "CLASSIFICATION MISSING";
+    : intl.formatMessage(educationRequirementMessages.missingClassification);
   // If the job is using the default education requirements (for its classification) then we
   //  can predictably style it, by setting the right lines to bold. Otherwise, all we can do is
   //  split it into paragraphs.

--- a/resources/assets/js/components/Application/ExperienceModals/EducationSubform.tsx
+++ b/resources/assets/js/components/Application/ExperienceModals/EducationSubform.tsx
@@ -18,6 +18,7 @@ export const validationShape = {
 export interface EducationSubformProps {
   keyPrefix: string;
   jobClassification: string;
+  jobEducationRequirements: string | null;
 }
 
 const messages = defineMessages({
@@ -34,8 +35,28 @@ const messages = defineMessages({
 export function EducationSubform({
   keyPrefix,
   jobClassification,
+  jobEducationRequirements,
 }: EducationSubformProps): React.ReactElement {
   const intl = useIntl();
+
+  const jobEducationReq = jobEducationRequirements;
+  const defaultEducationReq = hasKey(educationMessages, jobClassification)
+    ? intl.formatMessage(educationMessages[jobClassification])
+    : "CLASSIFICATION MISSING";
+  // If the job is using the default education requirements (for its classification) then we
+  //  can predictably style it, by setting the right lines to bold. Otherwise, all we can do is
+  //  split it into paragraphs.
+  const educationRequirements =
+    jobEducationReq === null || jobEducationReq === defaultEducationReq
+      ? textToParagraphs(
+          defaultEducationReq,
+          {},
+          {
+            0: { "data-c-font-weight": "bold" },
+            5: { "data-c-font-weight": "bold" },
+          },
+        )
+      : textToParagraphs(jobEducationReq);
 
   const checkboxKey = "useAsEducationRequirement";
   return (
@@ -81,16 +102,7 @@ export function EducationSubform({
             data-c-padding="all(1)"
             data-c-margin="bottom(1)"
           >
-            {textToParagraphs(
-              hasKey(educationMessages, jobClassification)
-                ? intl.formatMessage(educationMessages[jobClassification])
-                : "CLASSIFICATION MISSING",
-              {},
-              {
-                0: { "data-c-font-weight": "bold" },
-                5: { "data-c-font-weight": "bold" },
-              },
-            )}
+            {educationRequirements}
           </div>
         </div>
       </div>

--- a/resources/assets/js/components/Application/ExperienceModals/PersonalExperienceModal.tsx
+++ b/resources/assets/js/components/Application/ExperienceModals/PersonalExperienceModal.tsx
@@ -38,6 +38,7 @@ interface PersonalExperienceModalProps {
   experiencePersonal: ExperiencePersonal | null;
   jobId: number;
   jobClassification: string;
+  jobEducationRequirements: string | null;
   requiredSkills: Skill[];
   savedRequiredSkills: Skill[];
   optionalSkills: Skill[];
@@ -233,6 +234,7 @@ export const PersonalExperienceModal: React.FC<PersonalExperienceModalProps> = (
   experiencePersonal,
   jobId,
   jobClassification,
+  jobEducationRequirements,
   requiredSkills,
   savedRequiredSkills,
   optionalSkills,
@@ -376,6 +378,7 @@ export const PersonalExperienceModal: React.FC<PersonalExperienceModalProps> = (
               <EducationSubform
                 keyPrefix="personal"
                 jobClassification={jobClassification}
+                jobEducationRequirements={jobEducationRequirements}
               />
             </Modal.Body>
             <ExperienceModalFooter buttonsDisabled={formikProps.isSubmitting} />

--- a/resources/assets/js/components/Application/ExperienceModals/WorkExperienceModal.tsx
+++ b/resources/assets/js/components/Application/ExperienceModals/WorkExperienceModal.tsx
@@ -36,6 +36,7 @@ interface WorkExperienceModalProps {
   experienceWork: ExperienceWork | null;
   jobId: number;
   jobClassification: string;
+  jobEducationRequirements: string | null;
   requiredSkills: Skill[];
   savedRequiredSkills: Skill[];
   optionalSkills: Skill[];
@@ -221,6 +222,7 @@ export const WorkExperienceModal: React.FC<WorkExperienceModalProps> = ({
   experienceWork,
   jobId,
   jobClassification,
+  jobEducationRequirements,
   requiredSkills,
   savedRequiredSkills,
   optionalSkills,
@@ -361,6 +363,7 @@ export const WorkExperienceModal: React.FC<WorkExperienceModalProps> = ({
               <EducationSubform
                 keyPrefix="work"
                 jobClassification={jobClassification}
+                jobEducationRequirements={jobEducationRequirements}
               />
             </Modal.Body>
             <ExperienceModalFooter buttonsDisabled={formikProps.isSubmitting} />

--- a/resources/assets/js/components/Application/applicationMessages.ts
+++ b/resources/assets/js/components/Application/applicationMessages.ts
@@ -204,6 +204,14 @@ export const basicInfoMessages = defineMessages({
   },
 });
 
+export const experienceMessages = defineMessages({
+  heading: {
+    id: "application.experience.heading",
+    defaultMessage: "My Experience",
+    description: "Heading for the Experience section of the Application.",
+  },
+});
+
 export const educationRequirementMessages = defineMessages({
   missingClassification: {
     id: "application.education.missingClassification",

--- a/resources/assets/js/components/Application/applicationMessages.ts
+++ b/resources/assets/js/components/Application/applicationMessages.ts
@@ -204,11 +204,12 @@ export const basicInfoMessages = defineMessages({
   },
 });
 
-export const experienceMessages = defineMessages({
-  heading: {
-    id: "application.experience.heading",
-    defaultMessage: "My Experience",
-    description: "Heading for the Experience section of the Application.",
+export const educationRequirementMessages = defineMessages({
+  missingClassification: {
+    id: "application.education.missingClassification",
+    defaultMessage: "UNKNOWN CLASSIFICATION",
+    description:
+      "This is shown in place of Education Requirements, if the job's classification has no matching justification. It's the result of an error and indicates a bug, and should never be see.",
   },
 });
 

--- a/resources/assets/js/stories/Application/Experience.stories.tsx
+++ b/resources/assets/js/stories/Application/Experience.stories.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withIntl } from "storybook-addon-intl";
 import { action } from "@storybook/addon-actions";
+import { useIntl } from "react-intl";
 import MyExperience, {
   ExperienceSubmitData,
 } from "../../components/Application/Experience/Experience";
@@ -20,6 +21,8 @@ import fakeExperienceSkills, {
 } from "../../fakeData/fakeExperienceSkills";
 import { Experience, Skill } from "../../models/types";
 import { fakeCriteria } from "../../fakeData/fakeCriteria";
+import { ClassificationId } from "../../models/lookupConstants";
+import { educationMessages } from "../../components/JobBuilder/Details/JobDetailsMessages";
 
 const stories = storiesOf("Application|My Experience", module).addDecorator(
   withIntl,
@@ -84,29 +87,33 @@ const handleDeleteExperience = async (
 
 stories.add(
   "Experience Step",
-  (): React.ReactElement => (
-    <MyExperience
-      experiences={experiences}
-      experienceSkills={experienceSkills}
-      criteria={fakeCriteria()}
-      skills={fakeSkills()}
-      educationStatuses={educationStatuses}
-      educationTypes={educationTypes}
-      handleSubmitExperience={async (data) => {
-        handleSubmitExperience(data);
-        action("Confirmed")(data);
-      }}
-      handleDeleteExperience={async (id, type) => {
-        handleDeleteExperience(id, type);
-        action("Experience Deleted")(id);
-      }}
-      jobId={1}
-      jobClassificationId={1}
-      recipientTypes={recipientTypes}
-      recognitionTypes={recogntitionTypes}
-      handleContinue={action("Save and Continue")}
-      handleQuit={action("Save and Quit")}
-      handleReturn={action("Save and Return")}
-    />
-  ),
+  (): React.ReactElement => {
+    const intl = useIntl();
+    return (
+      <MyExperience
+        experiences={experiences}
+        experienceSkills={experienceSkills}
+        criteria={fakeCriteria()}
+        skills={fakeSkills()}
+        educationStatuses={educationStatuses}
+        educationTypes={educationTypes}
+        handleSubmitExperience={async (data) => {
+          handleSubmitExperience(data);
+          action("Confirmed")(data);
+        }}
+        handleDeleteExperience={async (id, type) => {
+          handleDeleteExperience(id, type);
+          action("Experience Deleted")(id);
+        }}
+        jobId={1}
+        jobClassificationId={ClassificationId.CS}
+        jobEducationRequirements={intl.formatMessage(educationMessages.CS)}
+        recipientTypes={recipientTypes}
+        recognitionTypes={recogntitionTypes}
+        handleContinue={action("Save and Continue")}
+        handleQuit={action("Save and Quit")}
+        handleReturn={action("Save and Return")}
+      />
+    );
+  },
 );

--- a/resources/assets/js/stories/Application/ExperienceModals.stories.tsx
+++ b/resources/assets/js/stories/Application/ExperienceModals.stories.tsx
@@ -3,6 +3,7 @@ import { storiesOf } from "@storybook/react";
 import { withIntl } from "storybook-addon-intl";
 import { number, boolean, select } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
+import { useIntl } from "react-intl";
 import WorkExperienceModal from "../../components/Application/ExperienceModals/WorkExperienceModal";
 import {
   fakeExperienceWork,
@@ -23,6 +24,7 @@ import PersonalExperienceModal from "../../components/Application/ExperienceModa
 import AwardExperienceModal from "../../components/Application/ExperienceModals/AwardExperienceModal";
 import { ClassificationId } from "../../models/lookupConstants";
 import { mapToObject } from "../../helpers/queries";
+import { educationMessages } from "../../components/JobBuilder/Details/JobDetailsMessages";
 
 const stories = storiesOf("Application|Experience Modals", module).addDecorator(
   withIntl,
@@ -148,12 +150,18 @@ const classificationOptions = mapToObject(
   (x) => x,
 );
 
+const jobClassification = select(
+  "Job Classification",
+  classificationOptions,
+  "CS",
+  groupIds.details,
+);
 stories.add(
   "Work Experience Modal",
   (): React.ReactElement => {
     const isModalVisible = boolean("Visible", true, groupIds.switches);
     const modalParent = document.querySelector("#modal-root");
-
+    const intl = useIntl();
     return (
       <div id="work-modal-container">
         <div
@@ -169,11 +177,9 @@ stories.add(
             savedRequiredSkills={[requiredSkills[2], requiredSkills[3]]}
             optionalSkills={optionalSkills}
             savedOptionalSkills={[optionalSkills[0]]}
-            jobClassification={select(
-              "Job Classification",
-              classificationOptions,
-              "CS",
-              groupIds.details,
+            jobClassification={jobClassification}
+            jobEducationRequirements={intl.formatMessage(
+              educationMessages[jobClassification],
             )}
             experienceableId={1}
             experienceableType="application"
@@ -195,7 +201,7 @@ stories.add(
   (): React.ReactElement => {
     const isModalVisible = boolean("Visible", true, groupIds.switches);
     const modalParent = document.querySelector("#modal-root");
-
+    const intl = useIntl();
     return (
       <div id="education-modal-container">
         <div
@@ -213,11 +219,9 @@ stories.add(
             savedRequiredSkills={[requiredSkills[2], requiredSkills[3]]}
             optionalSkills={optionalSkills}
             savedOptionalSkills={[optionalSkills[0]]}
-            jobClassification={select(
-              "Job Classification",
-              classificationOptions,
-              "CS",
-              groupIds.details,
+            jobClassification={jobClassification}
+            jobEducationRequirements={intl.formatMessage(
+              educationMessages[jobClassification],
             )}
             experienceableId={1}
             experienceableType="application"
@@ -239,7 +243,7 @@ stories.add(
   (): React.ReactElement => {
     const isModalVisible = boolean("Visible", true, groupIds.switches);
     const modalParent = document.querySelector("#modal-root");
-
+    const intl = useIntl();
     return (
       <div id="education-modal-container">
         <div
@@ -257,11 +261,9 @@ stories.add(
             savedRequiredSkills={[requiredSkills[2], requiredSkills[3]]}
             optionalSkills={optionalSkills}
             savedOptionalSkills={[optionalSkills[0]]}
-            jobClassification={select(
-              "Job Classification",
-              classificationOptions,
-              "CS",
-              groupIds.details,
+            jobClassification={jobClassification}
+            jobEducationRequirements={intl.formatMessage(
+              educationMessages[jobClassification],
             )}
             experienceableId={1}
             experienceableType="application"
@@ -283,7 +285,7 @@ stories.add(
   (): React.ReactElement => {
     const isModalVisible = boolean("Visible", true, groupIds.switches);
     const modalParent = document.querySelector("#modal-root");
-
+    const intl = useIntl();
     return (
       <div id="community-modal-container">
         <div
@@ -299,11 +301,9 @@ stories.add(
             savedRequiredSkills={[requiredSkills[2], requiredSkills[3]]}
             optionalSkills={optionalSkills}
             savedOptionalSkills={[optionalSkills[0]]}
-            jobClassification={select(
-              "Job Classification",
-              classificationOptions,
-              "CS",
-              groupIds.details,
+            jobClassification={jobClassification}
+            jobEducationRequirements={intl.formatMessage(
+              educationMessages[jobClassification],
             )}
             experienceableId={1}
             experienceableType="application"
@@ -325,7 +325,7 @@ stories.add(
   (): React.ReactElement => {
     const isModalVisible = boolean("Visible", true, groupIds.switches);
     const modalParent = document.querySelector("#modal-root");
-
+    const intl = useIntl();
     return (
       <div id="personal-modal-container">
         <div
@@ -341,11 +341,9 @@ stories.add(
             savedRequiredSkills={[requiredSkills[2], requiredSkills[3]]}
             optionalSkills={optionalSkills}
             savedOptionalSkills={[optionalSkills[0]]}
-            jobClassification={select(
-              "Job Classification",
-              classificationOptions,
-              "CS",
-              groupIds.details,
+            jobClassification={jobClassification}
+            jobEducationRequirements={intl.formatMessage(
+              educationMessages[jobClassification],
             )}
             experienceableId={1}
             experienceableType="application"
@@ -367,7 +365,7 @@ stories.add(
   (): React.ReactElement => {
     const isModalVisible = boolean("Visible", true, groupIds.switches);
     const modalParent = document.querySelector("#modal-root");
-
+    const intl = useIntl();
     return (
       <div id="award-modal-container">
         <div
@@ -385,11 +383,9 @@ stories.add(
             savedRequiredSkills={[requiredSkills[2], requiredSkills[3]]}
             optionalSkills={optionalSkills}
             savedOptionalSkills={[optionalSkills[0]]}
-            jobClassification={select(
-              "Job Classification",
-              classificationOptions,
-              "CS",
-              groupIds.details,
+            jobClassification={jobClassification}
+            jobEducationRequirements={intl.formatMessage(
+              educationMessages[jobClassification],
             )}
             experienceableId={1}
             experienceableType="application"
@@ -411,6 +407,7 @@ stories.add(
   (): React.ReactElement => {
     const isModalVisible = boolean("Visible", true, groupIds.switches);
     const modalParent = document.querySelector("#modal-root");
+    const intl = useIntl();
     return (
       <div id="award-new-modal-container">
         <div
@@ -428,11 +425,9 @@ stories.add(
             savedRequiredSkills={[requiredSkills[2], requiredSkills[3]]}
             optionalSkills={optionalSkills}
             savedOptionalSkills={[optionalSkills[0]]}
-            jobClassification={select(
-              "Job Classification",
-              classificationOptions,
-              "CS",
-              groupIds.details,
+            jobClassification={jobClassification}
+            jobEducationRequirements={intl.formatMessage(
+              educationMessages[jobClassification],
             )}
             experienceableId={1}
             experienceableType="application"


### PR DESCRIPTION
Resolves #4335.

### Notes:
- This affects the Basic Info step, and the Education section of the Experience modals.
- If the education requirements of the job are identical to the default for its classification, they will be presented with appropriate bolding.
- If the education requirements do not match the default, they will be present with correct paragraph formatting but no bolding.
