### PR TITLE
Bugfix - Intermittent test failures around Skill Declaration description validation

### DIFF
--- a/database/factories/SkillDeclarationFactory.php
+++ b/database/factories/SkillDeclarationFactory.php
@@ -15,6 +15,6 @@ $factory->define(SkillDeclaration::class, function (Faker\Generator $faker) {
             return factory(Applicant::class)->create()->id;
         },
         'skillable_type' => 'applicant',
-        'description' => $faker->paragraphs(3, true),
+        'description' => $faker->text(100),
     ];
 });


### PR DESCRIPTION
### Notes:
- Previously using `$faker->paragraphs(3, true);` would occasionally generate more than the 100 character max validation limit, causing a test failure
- Unsure if this is responsible for all the failures relating to the skillsComplete step, but I ran this test consecutively for over an hour locally with no failures
