### PR TITLE
Fixes bug #4548 by making the level spans inline-block.

### DIFF
--- a/resources/assets/js/components/JobBuilder/Skills/JobSkills.tsx
+++ b/resources/assets/js/components/JobBuilder/Skills/JobSkills.tsx
@@ -518,6 +518,7 @@ export const JobSkills: React.FunctionComponent<JobSkillsProps> = ({
                   data-c-border="all(thin, solid, c1)"
                   data-c-colour="c1"
                   data-c-font-size="small"
+                  style={{ display: "inline-block" }}
                 >
                   {intl.formatMessage(getSkillLevelName(criterion, skill))}
                 </span>


### PR DESCRIPTION
Text wraps inside of spans.