### PR TITLE
Bugfix - IE11 broken due to webpack resolve config

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -118,7 +118,6 @@ mix.webpackConfig({
     alias: {
       "@": path.resolve(__dirname, "resources/assets/js"),
     },
-    mainFields: ["browser", "main", "module"],
   },
 });
 


### PR DESCRIPTION
Resolves #4582 

### Notes:
- Uses the solution mentioned here: https://github.com/uuidjs/uuid/issues/516#issuecomment-690080241
- It seems that the default value for `mainFields` works fine.