### PR TITLE
Fix updateApplication overwriting Applicant object in redux store

### DIFF
--- a/app/Http/Resources/JobApplication.php
+++ b/app/Http/Resources/JobApplication.php
@@ -5,7 +5,7 @@ namespace App\Http\Resources;
 use App\Http\Resources\Applicant as ApplicantResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 
-class JobApplication extends JsonResource
+class JobApplication extends JobApplicationBasic
 {
     /**
      * Transform the resource into an array.
@@ -22,6 +22,7 @@ class JobApplication extends JsonResource
             'veteran_status' => new JsonResource($this->whenLoaded('veteran_status')),
             'job_application_answers' => new JsonResource($this->whenLoaded('job_application_answers')),
             'job_application_steps' => new JsonResource($this->jobApplicationSteps()),
+            'meets_essential_criteria' => $this->meets_essential_criteria,
         ]);
     }
 }

--- a/app/Http/Resources/JobApplicationBasic.php
+++ b/app/Http/Resources/JobApplicationBasic.php
@@ -36,7 +36,7 @@ class JobApplicationBasic extends JsonResource
             'user_email' => $this->user_email,
             'share_with_managers' => $this->share_with_managers,
             'created_at' => $this->created_at,
-            'updated_at' => $this->updated_at,
+            'updated_at' => $this->updated_at
         ];
     }
 }

--- a/resources/assets/js/api/application.ts
+++ b/resources/assets/js/api/application.ts
@@ -3,6 +3,7 @@
 import { ApplicationStep, ProgressBarStatus } from "../models/lookupConstants";
 import {
   Application,
+  ApplicationBasic,
   ApplicationNormalized,
   ApplicationReview,
   Email,
@@ -13,6 +14,7 @@ import { baseUrl } from "./base";
 export const parseApplication = (data: any): Application => data;
 export const parseApplicationNormalized = (data: any): ApplicationNormalized =>
   data;
+export const parseApplicationBasic = (data: any): ApplicationBasic => data;
 
 export const parseApplicationResponse = (
   data: any,

--- a/resources/assets/js/components/Application/BasicInfo/BasicInfoPage.tsx
+++ b/resources/assets/js/components/Application/BasicInfo/BasicInfoPage.tsx
@@ -51,13 +51,8 @@ const BasicInfoPage: React.FunctionComponent<BasicInfoPageProps> = ({
 
   const updateApplication = async (
     editedApplication: ApplicationNormalized,
-  ): Promise<ApplicationNormalized> => {
-    const result = await dispatch(updateApplicationAction(editedApplication));
-    if (!result.error) {
-      const payload = await result.payload;
-      return payload;
-    }
-    return Promise.reject(result.payload);
+  ): Promise<void> => {
+    await dispatch(updateApplicationAction(editedApplication));
   };
 
   const handleContinue = async (

--- a/resources/assets/js/fakeData/fakeApplications.ts
+++ b/resources/assets/js/fakeData/fakeApplications.ts
@@ -44,6 +44,13 @@ export const fakeApplicationNormalized = (
   created_at: new Date("2020-01-01"),
   updated_at: new Date("2020-01-01"),
   share_with_managers: false,
+  language_requirement_confirmed: true,
+  language_test_confirmed: true,
+  education_requirement_confirmed: true,
+  version_id: 2,
+  user_email: null,
+  user_name: null,
+
   veteran_status: {
     id: 1,
     name: "none",
@@ -90,9 +97,6 @@ export const fakeApplicationNormalized = (
     },
   },
   meets_essential_criteria: true,
-  language_requirement_confirmed: true,
-  language_test_confirmed: true,
-  education_requirement_confirmed: true,
   ...overrides,
 });
 

--- a/resources/assets/js/models/types.ts
+++ b/resources/assets/js/models/types.ts
@@ -19,7 +19,7 @@ export interface Applicant {
   user: User;
 }
 
-export type Application = {
+export interface ApplicationBasic {
   id: number;
   job_poster_id: number;
   application_status_id: number;
@@ -27,22 +27,28 @@ export type Application = {
   veteran_status_id: number | null;
   preferred_language_id: number;
   applicant_id: number;
-  applicant_snapshot_id: number;
   submission_signature: string;
   submission_date: string;
   experience_saved: boolean;
+  applicant_snapshot_id: number;
   language_requirement_confirmed: boolean;
   language_test_confirmed: boolean;
   education_requirement_confirmed: boolean;
+  version_id: number | null;
+  user_name: string | null;
+  user_email: string | null;
+  share_with_managers: boolean;
   created_at: Date;
   updated_at: Date;
-  veteran_status: VeteranStatus;
-  citizenship_declaration: CitizenshipDeclaration;
+}
+
+export interface Application extends ApplicationBasic {
   applicant: Applicant;
   application_review: ApplicationReview | undefined;
+  veteran_status: VeteranStatus;
+  citizenship_declaration: CitizenshipDeclaration;
   meets_essential_criteria: boolean;
-  share_with_managers: boolean;
-};
+}
 
 export type ApplicationNormalized = Omit<Application, "application_review">;
 

--- a/resources/assets/js/store/Application/applicationActions.ts
+++ b/resources/assets/js/store/Application/applicationActions.ts
@@ -7,6 +7,7 @@ import {
 } from "../asyncAction";
 import {
   Application,
+  ApplicationBasic,
   ApplicationNormalized,
   ApplicationReview,
   Email,
@@ -29,6 +30,7 @@ import {
   getTouchApplicationStepEndpoint,
   parseApplicationStep,
   getApplicationSubmitEndpoint,
+  parseApplicationBasic,
 } from "../../api/application";
 import {
   CreateJobApplicationAnswerAction,
@@ -85,7 +87,7 @@ export type UpdateApplicationAction = AsyncFsaActions<
   typeof UPDATE_APPLICATION_STARTED,
   typeof UPDATE_APPLICATION_SUCCEEDED,
   typeof UPDATE_APPLICATION_FAILED,
-  ApplicationNormalized,
+  ApplicationBasic,
   { id: number }
 >;
 
@@ -95,7 +97,7 @@ export const updateApplication = (
   typeof UPDATE_APPLICATION_STARTED,
   typeof UPDATE_APPLICATION_SUCCEEDED,
   typeof UPDATE_APPLICATION_FAILED,
-  ApplicationNormalized,
+  ApplicationBasic,
   { id: number }
 > =>
   asyncPut(
@@ -104,7 +106,7 @@ export const updateApplication = (
     UPDATE_APPLICATION_STARTED,
     UPDATE_APPLICATION_SUCCEEDED,
     UPDATE_APPLICATION_FAILED,
-    parseApplication,
+    parseApplicationBasic,
     { id: application.id },
   );
 

--- a/resources/assets/js/store/Application/applicationReducer.ts
+++ b/resources/assets/js/store/Application/applicationReducer.ts
@@ -207,7 +207,10 @@ export const entitiesReducer = (
         ...state,
         applications: {
           ...state.applications,
-          [action.payload.id]: action.payload,
+          [action.payload.id]: {
+            ...state.applications[action.payload.id],
+            ...action.payload,
+          },
         },
       };
     case UPDATE_APPLICATION_REVIEW_SUCCEEDED:


### PR DESCRIPTION
Resolves #4659.

The issue was that if you visited the review step, saved, and revisted the Review step, it would be stuck in the loading state.
This was caused by the fact the the matching Applicant object, and therefor the matching User object, disappeared from the redux store. It disappeared because the updateApplication request returns a simplified version of the Application, which does not include the Applicant or User model. This new, basic Application overwrote the previous one and the User object was lost.

For now, I've simply been a bit more explicit about the types returned by the different endpoints, and ensured the result of the updateApplication request doesn't overwrite values in the pre-existing Application in the redux store, if they don't appear in the new Basic Application.

### Notes:
- If you run the updateApplication redux action with an application that doesn't yet exist in the redux store, the resulting redux store will not match its TypeScript definition 😬 
- Use of multiple versions of the Application object is definitely a bit confusing. A fully normalized API & Redux store would offer more clarity, but will require more work. This could be another refactoring task.
