### PR TITLE
Avoid extra data fetches in JPB and improve navigation between steps

### DIFF
--- a/resources/assets/js/components/JobBuilder/JobBuilderProgressTracker.tsx
+++ b/resources/assets/js/components/JobBuilder/JobBuilderProgressTracker.tsx
@@ -58,8 +58,9 @@ const stepComesBefore = (
   return comesBefore;
 };
 
-export const JobBuilderProgressTracker: React.FunctionComponent<JobBuilderProgressTrackerProps &
-  WrappedComponentProps> = ({
+export const JobBuilderProgressTracker: React.FunctionComponent<
+  JobBuilderProgressTrackerProps & WrappedComponentProps
+> = ({
   job,
   jobId,
   tasks,
@@ -73,49 +74,46 @@ export const JobBuilderProgressTracker: React.FunctionComponent<JobBuilderProgre
     throw new Error("Unexpected locale");
   }
   const pageStates: { [page in JobBuilderPage]: ProgressTrackerState } = {
-    intro: dataIsLoading
-      ? "null"
-      : jobBuilderIntroProgressState(
-          job,
-          stepComesBefore(currentPage, "intro"),
-        ),
-    details: dataIsLoading
-      ? "null"
-      : jobBuilderDetailsProgressState(
-          job,
-          locale,
-          stepComesBefore(currentPage, "details"),
-        ),
-    env: dataIsLoading
-      ? "null"
-      : jobBuilderEnvProgressState(
-          job,
-          locale,
-          stepComesBefore(currentPage, "env"),
-        ),
-    impact: dataIsLoading
-      ? "null"
-      : jobImpactProgressState(
-          job,
-          locale,
-          stepComesBefore(currentPage, "impact"),
-        ),
-    tasks: dataIsLoading
-      ? "null"
-      : jobTasksProgressState(
-          tasks,
-          locale,
-          stepComesBefore(currentPage, "tasks"),
-        ),
-    skills: dataIsLoading
-      ? "null"
-      : criteriaProgressState(
-          criteria,
-          locale,
-          stepComesBefore(currentPage, "skills"),
-        ),
+    intro: jobBuilderIntroProgressState(
+      job,
+      stepComesBefore(currentPage, "intro"),
+    ),
+    details: jobBuilderDetailsProgressState(
+      job,
+      locale,
+      stepComesBefore(currentPage, "details"),
+    ),
+    env: jobBuilderEnvProgressState(
+      job,
+      locale,
+      stepComesBefore(currentPage, "env"),
+    ),
+    impact: jobImpactProgressState(
+      job,
+      locale,
+      stepComesBefore(currentPage, "impact"),
+    ),
+    tasks: jobTasksProgressState(
+      tasks,
+      locale,
+      stepComesBefore(currentPage, "tasks"),
+    ),
+    skills: criteriaProgressState(
+      criteria,
+      locale,
+      stepComesBefore(currentPage, "skills"),
+    ),
     review: "null",
   };
+
+  if (dataIsLoading) {
+    Object.keys(pageStates).forEach((key) => {
+      if (pageStates[key] === "error") {
+        pageStates[key] = "null";
+      }
+    });
+  }
+
   if (currentPage) {
     pageStates[currentPage] = "active";
   }

--- a/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
+++ b/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
@@ -1,147 +1,37 @@
-import React, { useEffect, useState } from "react";
+import React, { FunctionComponent, useEffect } from "react";
 import { FormattedMessage } from "react-intl";
-import { connect } from "react-redux";
+import { useDispatch } from "react-redux";
 import nprogress from "nprogress";
-import {
-  Job,
-  JobPosterKeyTask,
-  Criteria,
-  Skill,
-  Department,
-} from "../../models/types";
+import { Job, JobPosterKeyTask, Criteria } from "../../models/types";
 import { JobBuilderPage } from "./jobBuilderHelpers";
-import {
-  getJob,
-  getTasksByJob,
-  getCriteriaByJob,
-} from "../../store/Job/jobSelector";
-import { getSkills } from "../../store/Skill/skillSelector";
 import { DispatchType } from "../../configureStore";
-import {
-  fetchJob,
-  fetchJobTasks,
-  fetchCriteria,
-  setSelectedJob,
-} from "../../store/Job/jobActions";
-import { fetchSkills } from "../../store/Skill/skillActions";
 import JobBuilderProgressTracker from "./JobBuilderProgressTracker";
-import { getDepartments } from "../../store/Department/deptSelector";
-import { getDepartments as fetchDepartments } from "../../store/Department/deptActions";
-import { RootState } from "../../store/store";
+import {
+  useLoadCriteria,
+  useLoadDepartments,
+  useLoadJob,
+  useLoadSkills,
+  useLoadTasks,
+} from "./jobBuilderHooks";
 
 interface JobBuilderStepProps {
   jobId: number | null;
   job: Job | null;
-  loadJob: (jobId: number) => Promise<void>;
   keyTasks: JobPosterKeyTask[];
-  loadTasks: (jobId: number) => Promise<void>;
   criteria: Criteria[];
-  loadCriteria: (jobId: number) => Promise<void>;
-  // List of known department options.
-  departments: Department[];
-  // This is called when departments is empty to fetch departments.
-  loadDepartments: () => Promise<void>;
-  skills: Skill[];
-  loadSkills: () => Promise<void>;
   currentPage: JobBuilderPage | null;
-  forceIsLoading?: boolean;
-  children: React.ReactNode;
+  dataIsLoading: boolean;
 }
 
 const JobBuilderStep: React.FunctionComponent<JobBuilderStepProps> = ({
   jobId,
   job,
-  loadJob,
   keyTasks,
-  loadTasks,
   criteria,
-  skills,
-  loadCriteria,
-  loadSkills,
-  departments,
-  loadDepartments,
   currentPage,
-  forceIsLoading,
+  dataIsLoading,
   children,
 }): React.ReactElement => {
-  // Trigger fetching of job details
-  const [isLoadingJob, setIsLoadingJob] = useState(false);
-  useEffect((): (() => void) => {
-    let isSubscribed = true;
-    if (jobId && (job === null || job.id !== jobId) && !isLoadingJob) {
-      setIsLoadingJob(true);
-      loadJob(jobId).finally((): void => {
-        if (isSubscribed) {
-          setIsLoadingJob(false);
-        }
-      });
-    }
-    return (): void => {
-      isSubscribed = false;
-    };
-  }, [jobId, loadJob, job, isLoadingJob]);
-  const [isLoadingTasks, setIsLoadingTasks] = useState(false);
-  const [hasFetchedTasks, setHasFetchedTasks] = useState(false);
-  useEffect((): (() => void) => {
-    let isSubscribed = true;
-    if (jobId && !hasFetchedTasks) {
-      setIsLoadingTasks(true);
-      setHasFetchedTasks(true);
-      loadTasks(jobId)
-        .catch((): void => {
-          if (isSubscribed) {
-            setHasFetchedTasks(false);
-          }
-        })
-        .finally((): void => {
-          if (isSubscribed) {
-            setIsLoadingTasks(false);
-          }
-        });
-    }
-    return (): void => {
-      isSubscribed = false;
-    };
-  }, [jobId, loadTasks, hasFetchedTasks]);
-  const [isLoadingCriteria, setIsLoadingCriteria] = useState(false);
-  const [hasFetchedCriteria, setHasFetchedCriteria] = useState(false);
-  useEffect((): (() => void) => {
-    let isSubscribed = true;
-    if (jobId && !hasFetchedCriteria) {
-      setIsLoadingCriteria(true);
-      setHasFetchedCriteria(true);
-      loadCriteria(jobId)
-        .catch((): void => {
-          if (isSubscribed) {
-            setHasFetchedCriteria(false);
-          }
-        })
-        .finally((): void => {
-          if (isSubscribed) {
-            setIsLoadingCriteria(false);
-          }
-        });
-    }
-    return (): void => {
-      isSubscribed = false;
-    };
-  }, [jobId, loadCriteria, hasFetchedCriteria]);
-
-  const dataIsLoading =
-    forceIsLoading || isLoadingJob || isLoadingTasks || isLoadingCriteria;
-
-  // Trigger fetching of other resources needed for Job Builder
-  useEffect((): void => {
-    if (departments.length === 0) {
-      loadDepartments();
-    }
-  }, [departments, loadDepartments]);
-  useEffect((): void => {
-    if (skills.length === 0) {
-      loadSkills();
-    }
-  }, [skills, loadSkills]);
-
   useEffect((): void => {
     if (jobId !== null && job === null) {
       nprogress.start();
@@ -187,53 +77,42 @@ const JobBuilderStep: React.FunctionComponent<JobBuilderStepProps> = ({
   );
 };
 
-const mapStateToProps = (
-  state: RootState,
-  { jobId }: { jobId: number | null },
-): {
-  job: Job | null;
-  keyTasks: JobPosterKeyTask[];
-  criteria: Criteria[];
-  skills: Skill[];
-  departments: Department[];
-} => ({
-  job: jobId !== null ? getJob(state, { jobId }) : null,
-  keyTasks: jobId !== null ? getTasksByJob(state, { jobId }) : [],
-  criteria: jobId !== null ? getCriteriaByJob(state, { jobId }) : [],
-  skills: getSkills(state),
-  departments: getDepartments(state),
-});
+export const JobBuilderStepContainer: FunctionComponent<{
+  jobId: number | null;
+  currentPage: JobBuilderPage | null;
+  forceIsLoading?: boolean;
+}> = ({ jobId, currentPage, forceIsLoading, children }) => {
+  const dispatch = useDispatch<DispatchType>();
 
-const mapDispatchToProps = (
-  dispatch: DispatchType,
-): {
-  loadJob: (jobId: number) => Promise<void>;
-  loadTasks: (jobId: number) => Promise<void>;
-  loadCriteria: (jobId: number) => Promise<void>;
-  loadSkills: () => Promise<void>;
-  loadDepartments: () => Promise<void>;
-} => ({
-  loadJob: async (jobId: number): Promise<void> => {
-    await dispatch(fetchJob(jobId));
-    dispatch(setSelectedJob(jobId));
-  },
-  loadTasks: async (jobId: number): Promise<void> => {
-    await dispatch(fetchJobTasks(jobId));
-  },
-  loadCriteria: async (jobId: number): Promise<void> => {
-    await dispatch(fetchCriteria(jobId));
-  },
-  loadSkills: async (): Promise<void> => {
-    await dispatch(fetchSkills());
-  },
-  loadDepartments: async (): Promise<void> => {
-    await dispatch(fetchDepartments());
-  },
-});
+  // Trigger fetching of job details
+  const { job, isLoadingJob } = useLoadJob(jobId, dispatch);
+  const { tasks, isLoadingTasks } = useLoadTasks(jobId, dispatch);
+  const { criteria, isLoadingCriteria } = useLoadCriteria(jobId, dispatch);
 
-export const JobBuilderStepContainer = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(JobBuilderStep);
+  // Trigger fetching of other resources needed for Job Builder
+  const { isLoadingDepartments } = useLoadDepartments(dispatch);
+  const { isLoadingSkills } = useLoadSkills(dispatch);
+
+  const dataIsLoading =
+    forceIsLoading ||
+    isLoadingJob ||
+    isLoadingTasks ||
+    isLoadingCriteria ||
+    isLoadingDepartments ||
+    isLoadingSkills;
+
+  return (
+    <JobBuilderStep
+      jobId={jobId}
+      currentPage={currentPage}
+      job={job}
+      keyTasks={tasks}
+      criteria={criteria}
+      dataIsLoading={dataIsLoading}
+    >
+      {children}
+    </JobBuilderStep>
+  );
+};
 
 export default JobBuilderStepContainer;

--- a/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
+++ b/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
@@ -66,65 +66,43 @@ const JobBuilderStep: React.FunctionComponent<JobBuilderStepProps> = ({
 }): React.ReactElement => {
   // Trigger fetching of job details
   const [isLoadingJob, setIsLoadingJob] = useState(false);
-  useEffect((): (() => void) => {
-    let isSubscribed = true;
+  useEffect((): void => {
     if (jobId && (job === null || job.id !== jobId) && !isLoadingJob) {
       setIsLoadingJob(true);
       loadJob(jobId).finally((): void => {
-        if (isSubscribed) {
-          setIsLoadingJob(false);
-        }
+        setIsLoadingJob(false);
       });
     }
-    return (): void => {
-      isSubscribed = false;
-    };
   }, [jobId, loadJob, job, isLoadingJob]);
   const [isLoadingTasks, setIsLoadingTasks] = useState(false);
   const [hasFetchedTasks, setHasFetchedTasks] = useState(false);
-  useEffect((): (() => void) => {
-    let isSubscribed = true;
+  useEffect((): void => {
     if (jobId && !hasFetchedTasks) {
       setIsLoadingTasks(true);
       setHasFetchedTasks(true);
       loadTasks(jobId)
         .catch((): void => {
-          if (isSubscribed) {
-            setHasFetchedTasks(false);
-          }
+          setHasFetchedTasks(false);
         })
         .finally((): void => {
-          if (isSubscribed) {
-            setIsLoadingTasks(false);
-          }
+          setIsLoadingTasks(false);
         });
     }
-    return (): void => {
-      isSubscribed = false;
-    };
   }, [jobId, loadTasks, hasFetchedTasks]);
   const [isLoadingCriteria, setIsLoadingCriteria] = useState(false);
   const [hasFetchedCriteria, setHasFetchedCriteria] = useState(false);
-  useEffect((): (() => void) => {
-    let isSubscribed = true;
+  useEffect((): void => {
     if (jobId && !hasFetchedCriteria) {
       setIsLoadingCriteria(true);
       setHasFetchedCriteria(true);
       loadCriteria(jobId)
         .catch((): void => {
-          if (isSubscribed) {
-            setHasFetchedCriteria(false);
-          }
+          setHasFetchedCriteria(false);
         })
         .finally((): void => {
-          if (isSubscribed) {
-            setIsLoadingCriteria(false);
-          }
+          setIsLoadingCriteria(false);
         });
     }
-    return (): void => {
-      isSubscribed = false;
-    };
   }, [jobId, loadCriteria, hasFetchedCriteria]);
 
   const dataIsLoading =

--- a/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
+++ b/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
@@ -66,43 +66,65 @@ const JobBuilderStep: React.FunctionComponent<JobBuilderStepProps> = ({
 }): React.ReactElement => {
   // Trigger fetching of job details
   const [isLoadingJob, setIsLoadingJob] = useState(false);
-  useEffect((): void => {
+  useEffect((): (() => void) => {
+    let isSubscribed = true;
     if (jobId && (job === null || job.id !== jobId) && !isLoadingJob) {
       setIsLoadingJob(true);
       loadJob(jobId).finally((): void => {
-        setIsLoadingJob(false);
+        if (isSubscribed) {
+          setIsLoadingJob(false);
+        }
       });
     }
+    return (): void => {
+      isSubscribed = false;
+    };
   }, [jobId, loadJob, job, isLoadingJob]);
   const [isLoadingTasks, setIsLoadingTasks] = useState(false);
   const [hasFetchedTasks, setHasFetchedTasks] = useState(false);
-  useEffect((): void => {
+  useEffect((): (() => void) => {
+    let isSubscribed = true;
     if (jobId && !hasFetchedTasks) {
       setIsLoadingTasks(true);
       setHasFetchedTasks(true);
       loadTasks(jobId)
         .catch((): void => {
-          setHasFetchedTasks(false);
+          if (isSubscribed) {
+            setHasFetchedTasks(false);
+          }
         })
         .finally((): void => {
-          setIsLoadingTasks(false);
+          if (isSubscribed) {
+            setIsLoadingTasks(false);
+          }
         });
     }
+    return (): void => {
+      isSubscribed = false;
+    };
   }, [jobId, loadTasks, hasFetchedTasks]);
   const [isLoadingCriteria, setIsLoadingCriteria] = useState(false);
   const [hasFetchedCriteria, setHasFetchedCriteria] = useState(false);
-  useEffect((): void => {
+  useEffect((): (() => void) => {
+    let isSubscribed = true;
     if (jobId && !hasFetchedCriteria) {
       setIsLoadingCriteria(true);
       setHasFetchedCriteria(true);
       loadCriteria(jobId)
         .catch((): void => {
-          setHasFetchedCriteria(false);
+          if (isSubscribed) {
+            setHasFetchedCriteria(false);
+          }
         })
         .finally((): void => {
-          setIsLoadingCriteria(false);
+          if (isSubscribed) {
+            setIsLoadingCriteria(false);
+          }
         });
     }
+    return (): void => {
+      isSubscribed = false;
+    };
   }, [jobId, loadCriteria, hasFetchedCriteria]);
 
   const dataIsLoading =

--- a/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
+++ b/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
@@ -55,6 +55,7 @@ const JobBuilderStep: React.FunctionComponent<JobBuilderStepProps> = ({
   keyTasks,
   loadTasks,
   criteria,
+  skills,
   loadCriteria,
   loadSkills,
   departments,
@@ -67,7 +68,7 @@ const JobBuilderStep: React.FunctionComponent<JobBuilderStepProps> = ({
   const [isLoadingJob, setIsLoadingJob] = useState(false);
   useEffect((): (() => void) => {
     let isSubscribed = true;
-    if (jobId) {
+    if (jobId && (job === null || job.id !== jobId) && !isLoadingJob) {
       setIsLoadingJob(true);
       loadJob(jobId).finally((): void => {
         if (isSubscribed) {
@@ -78,37 +79,53 @@ const JobBuilderStep: React.FunctionComponent<JobBuilderStepProps> = ({
     return (): void => {
       isSubscribed = false;
     };
-  }, [jobId, loadJob]);
+  }, [jobId, loadJob, job, isLoadingJob]);
   const [isLoadingTasks, setIsLoadingTasks] = useState(false);
+  const [hasFetchedTasks, setHasFetchedTasks] = useState(false);
   useEffect((): (() => void) => {
     let isSubscribed = true;
-    if (jobId) {
+    if (jobId && !hasFetchedTasks) {
       setIsLoadingTasks(true);
-      loadTasks(jobId).finally((): void => {
-        if (isSubscribed) {
-          setIsLoadingTasks(false);
-        }
-      });
+      setHasFetchedTasks(true);
+      loadTasks(jobId)
+        .catch((): void => {
+          if (isSubscribed) {
+            setHasFetchedTasks(false);
+          }
+        })
+        .finally((): void => {
+          if (isSubscribed) {
+            setIsLoadingTasks(false);
+          }
+        });
     }
     return (): void => {
       isSubscribed = false;
     };
-  }, [jobId, loadTasks]);
+  }, [jobId, loadTasks, hasFetchedTasks]);
   const [isLoadingCriteria, setIsLoadingCriteria] = useState(false);
+  const [hasFetchedCriteria, setHasFetchedCriteria] = useState(false);
   useEffect((): (() => void) => {
     let isSubscribed = true;
-    if (jobId) {
+    if (jobId && !hasFetchedCriteria) {
       setIsLoadingCriteria(true);
-      loadCriteria(jobId).finally((): void => {
-        if (isSubscribed) {
-          setIsLoadingCriteria(false);
-        }
-      });
+      setHasFetchedCriteria(true);
+      loadCriteria(jobId)
+        .catch((): void => {
+          if (isSubscribed) {
+            setHasFetchedCriteria(false);
+          }
+        })
+        .finally((): void => {
+          if (isSubscribed) {
+            setIsLoadingCriteria(false);
+          }
+        });
     }
     return (): void => {
       isSubscribed = false;
     };
-  }, [jobId, loadCriteria]);
+  }, [jobId, loadCriteria, hasFetchedCriteria]);
 
   const dataIsLoading =
     forceIsLoading || isLoadingJob || isLoadingTasks || isLoadingCriteria;
@@ -120,8 +137,10 @@ const JobBuilderStep: React.FunctionComponent<JobBuilderStepProps> = ({
     }
   }, [departments, loadDepartments]);
   useEffect((): void => {
-    loadSkills();
-  }, [loadSkills]);
+    if (skills.length === 0) {
+      loadSkills();
+    }
+  }, [skills, loadSkills]);
 
   useEffect((): void => {
     if (jobId !== null && job === null) {

--- a/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
+++ b/resources/assets/js/components/JobBuilder/JobBuilderStep.tsx
@@ -12,7 +12,7 @@ import {
   useLoadJob,
   useLoadSkills,
   useLoadTasks,
-} from "./jobBuilderHooks";
+} from "../../hooks/jobBuilderHooks";
 
 interface JobBuilderStepProps {
   jobId: number | null;

--- a/resources/assets/js/components/JobBuilder/jobBuilderHooks.ts
+++ b/resources/assets/js/components/JobBuilder/jobBuilderHooks.ts
@@ -1,0 +1,148 @@
+import { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { DispatchType } from "../../configureStore";
+import {
+  Criteria,
+  Department,
+  Job,
+  JobPosterKeyTask,
+  Skill,
+} from "../../models/types";
+import {
+  getDepartments,
+  departmentsIsLoading,
+} from "../../store/Department/deptSelector";
+import { getDepartments as fetchDepartments } from "../../store/Department/deptActions";
+import {
+  getCriteriaByJob,
+  getCriteriaForJobIsUpdating,
+  getJob,
+  getJobIsUpdating,
+  getTasksByJob,
+  getTasksForJobIsUpdating,
+} from "../../store/Job/jobSelector";
+import { RootState } from "../../store/store";
+import {
+  fetchCriteria,
+  fetchJob,
+  setSelectedJob,
+} from "../../store/Job/jobActions";
+import { getSkills, getSkillsUpdating } from "../../store/Skill/skillSelector";
+import { fetchSkills } from "../../store/Skill/skillActions";
+
+export function useLoadJob(
+  jobId: number | null,
+  dispatch: DispatchType,
+): { job: Job | null; isLoadingJob: boolean } {
+  const job = useSelector((state: RootState) =>
+    jobId !== null ? getJob(state, { jobId }) : null,
+  );
+  const isLoadingJob = useSelector((state: RootState) =>
+    jobId !== null ? getJobIsUpdating(state, jobId) : false,
+  );
+  useEffect(() => {
+    if (jobId !== null && job === null && !isLoadingJob) {
+      dispatch(fetchJob(jobId));
+    }
+  }, [jobId, job, isLoadingJob, dispatch]);
+  useEffect(() => {
+    dispatch(setSelectedJob(jobId));
+  }, [jobId, dispatch]);
+  return { job, isLoadingJob };
+}
+
+export function useLoadTasks(
+  jobId: number | null,
+  dispatch: DispatchType,
+): { tasks: JobPosterKeyTask[]; isLoadingTasks: boolean } {
+  const tasks = useSelector((state: RootState) =>
+    jobId !== null ? getTasksByJob(state, { jobId }) : [],
+  );
+  const isLoadingTasks = useSelector((state: RootState) =>
+    jobId !== null ? getTasksForJobIsUpdating(state, jobId) : false,
+  );
+  const [hasFetchedTasks, setHasFetchedTasks] = useState(false);
+  useEffect((): (() => void) => {
+    let isSubscribed = true;
+    if (jobId && tasks.length === 0 && !isLoadingTasks && !hasFetchedTasks) {
+      setHasFetchedTasks(true);
+      dispatch(fetchJob(jobId)).catch((): void => {
+        if (isSubscribed) {
+          setHasFetchedTasks(false);
+        }
+      });
+    }
+    return (): void => {
+      isSubscribed = false;
+    };
+  }, [jobId, tasks.length, isLoadingTasks, hasFetchedTasks, dispatch]);
+  return { tasks, isLoadingTasks };
+}
+
+export function useLoadCriteria(
+  jobId: number | null,
+  dispatch: DispatchType,
+): {
+  criteria: Criteria[];
+  isLoadingCriteria: boolean;
+} {
+  const criteria = useSelector((state: RootState) =>
+    jobId ? getCriteriaByJob(state, { jobId }) : [],
+  );
+  const isLoadingCriteria = useSelector((state: RootState) =>
+    jobId ? getCriteriaForJobIsUpdating(state, jobId) : false,
+  );
+  const [hasFetchedCriteria, setHasFetchedCriteria] = useState(false);
+  useEffect((): (() => void) => {
+    let isSubscribed = true;
+    if (
+      jobId &&
+      criteria.length === 0 &&
+      !isLoadingCriteria &&
+      !hasFetchedCriteria
+    ) {
+      setHasFetchedCriteria(true);
+      dispatch(fetchCriteria(jobId)).catch((): void => {
+        if (isSubscribed) {
+          setHasFetchedCriteria(false);
+        }
+      });
+    }
+    return (): void => {
+      isSubscribed = false;
+    };
+  }, [jobId, criteria.length, isLoadingCriteria, hasFetchedCriteria, dispatch]);
+  return { criteria, isLoadingCriteria };
+}
+
+export function useLoadDepartments(
+  dispatch: DispatchType,
+): {
+  departments: Department[];
+  isLoadingDepartments: boolean;
+} {
+  const departments = useSelector(getDepartments);
+  const isLoading = useSelector(departmentsIsLoading);
+  useEffect((): void => {
+    if (departments.length === 0 && !isLoading) {
+      dispatch(fetchDepartments());
+    }
+  }, [departments.length, isLoading, dispatch]);
+  return { departments, isLoadingDepartments: isLoading };
+}
+
+export function useLoadSkills(
+  dispatch: DispatchType,
+): {
+  skills: Skill[];
+  isLoadingSkills: boolean;
+} {
+  const skills = useSelector(getSkills);
+  const isLoading = useSelector(getSkillsUpdating);
+  useEffect((): void => {
+    if (skills.length === 0 && !isLoading) {
+      dispatch(fetchSkills());
+    }
+  }, [skills.length, isLoading, dispatch]);
+  return { skills, isLoadingSkills: isLoading };
+}

--- a/resources/assets/js/hooks/jobBuilderHooks.ts
+++ b/resources/assets/js/hooks/jobBuilderHooks.ts
@@ -1,18 +1,18 @@
 import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
-import { DispatchType } from "../../configureStore";
+import { DispatchType } from "../configureStore";
 import {
   Criteria,
   Department,
   Job,
   JobPosterKeyTask,
   Skill,
-} from "../../models/types";
+} from "../models/types";
 import {
   getDepartments,
   departmentsIsLoading,
-} from "../../store/Department/deptSelector";
-import { getDepartments as fetchDepartments } from "../../store/Department/deptActions";
+} from "../store/Department/deptSelector";
+import { getDepartments as fetchDepartments } from "../store/Department/deptActions";
 import {
   getCriteriaByJob,
   getCriteriaForJobIsUpdating,
@@ -20,15 +20,15 @@ import {
   getJobIsUpdating,
   getTasksByJob,
   getTasksForJobIsUpdating,
-} from "../../store/Job/jobSelector";
-import { RootState } from "../../store/store";
+} from "../store/Job/jobSelector";
+import { RootState } from "../store/store";
 import {
   fetchCriteria,
   fetchJob,
   setSelectedJob,
-} from "../../store/Job/jobActions";
-import { getSkills, getSkillsUpdating } from "../../store/Skill/skillSelector";
-import { fetchSkills } from "../../store/Skill/skillActions";
+} from "../store/Job/jobActions";
+import { getSkills, getSkillsUpdating } from "../store/Skill/skillSelector";
+import { fetchSkills } from "../store/Skill/skillActions";
 
 export function useLoadJob(
   jobId: number | null,

--- a/resources/assets/js/store/Department/deptSelector.ts
+++ b/resources/assets/js/store/Department/deptSelector.ts
@@ -16,3 +16,6 @@ export const getDepartmentById = (
   id: number,
 ): Department | null =>
   hasKey(getDeptState(state), id) ? getDeptState(state)[id] : null;
+
+export const departmentsIsLoading = (state: RootState): boolean =>
+  state.department.loading;


### PR DESCRIPTION
Resolves #4613.

### Notes:
- Rewrites data fetching functions to hooks, modeled after the more recent applicationHooks. 
- Avoids re-fetching job, tasks and criteria when navigating between steps of Job Poster Builder.
- Allows the links in progress bar to be clicked even while data is updating, as long as they've previously been visited.
