### PR TITLE
Bugfix - Update route admin/jobs/create/as-manager

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -770,7 +770,7 @@ Route::group(
             function (): void {
                 // This page is non-localized, because the middleware that redirects to localized
                 // pages changes POSTs to GETs and messes up the request.
-                Route::post('jobs/create/as-manager/{manager}', 'JobController@createAsManager')
+                Route::match(['get','post'], 'jobs/create/as-manager/{manager}', 'JobController@createAsManager')
                     ->middleware('can:create,App\Models\JobPoster')
                     ->name('admin.jobs.create_as_manager');
 


### PR DESCRIPTION
Resolves #4092 

### Notes:
- Fixes 405 status code that appears when trying to create a job as a manager via the backpack admin.