### PR TITLE
Fix chmod error stopping phpunit tests from running

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
       run: php artisan key:generate
 
     - name: Directory Permissions
-      run: chmod -R 777 storage bootstrap/cache
+      run: chmod -R 777 storage
 
     - name: Generate certificates
       run: make gen-certs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
       run: php artisan key:generate
 
     - name: Directory Permissions
-      run: chmod -R 777 storage vendor bootstrap/cache
+      run: chmod -R 777 storage bootstrap/cache
 
     - name: Generate certificates
       run: make gen-certs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
       run: php artisan key:generate
 
     - name: Directory Permissions
-      run: @chmod -R 777 storage vendor bootstrap/cache
+      run: chmod -R 777 storage vendor bootstrap/cache
 
     - name: Generate certificates
       run: make gen-certs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,17 +33,18 @@ jobs:
     - name: Copy .env
       run: cp .env.actions .env
 
-    - name: Cache Composer packages
+    - name: Get Composer Cache Directory
       id: composer-cache
-      uses: actions/cache@v2
+      run: |
+        echo "::set-output name=dir::$(composer config cache-files-dir)"
+    - uses: actions/cache@v2
       with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
-          ${{ runner.os }}-php-
+          ${{ runner.os }}-composer-
 
     - name: Install dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'true'
       uses: MilesChou/composer-action/7.2/install@master
       with:
         args: install --no-interaction --prefer-dist --no-progress --no-suggest
@@ -73,7 +74,7 @@ jobs:
       run: php artisan key:generate
 
     - name: Directory Permissions
-      run: chmod -R 777 storage vendor bootstrap/cache
+      run: @chmod -R 777 storage vendor bootstrap/cache
 
     - name: Generate certificates
       run: make gen-certs


### PR DESCRIPTION
Though the Github Action tests passed in their original PR (#4814) the phpunit tests have been failing on other branches. The cause is an error that occurs when using chmod on the vendor folder. This PR is an attempt to fix the problem.

![error screenshot](https://user-images.githubusercontent.com/4313717/101092516-c6f90e00-3587-11eb-9fe8-b6ff7ccdb7cb.png)
