### PR TITLE
Task - Improve storybook build performance

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,5 @@
 module.exports = {
-    stories: ['../**/*.stories.@(tsx)'],
+    stories: ['../resources/assets/js/**/*.stories.@(tsx)'],
     addons: [
         '@storybook/addon-knobs/register',
         '@storybook/addon-actions/register',

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,15 +1,20 @@
 <link href="https://talent.test/css/app.css" rel="stylesheet" type="text/css" />
+<link href="https://talent.test/css/h2.css" rel="stylesheet" type="text/css" />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Euphoria+Script&amp;subset=latin-ext" />
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css"
   integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay" crossorigin="anonymous" />
 <script src="https://talent.test/js/modernizr.js"></script>
 <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
 <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
+<script
+  src="https://cdn.jsdelivr.net/npm/@hydrogen-design-system/system@latest/dist/compiled/latest/system.min.js">
+</script>
 <script>
-  const addClone = setInterval(function () {
+  const addDesignSystems = setInterval(function () {
     if (document.getElementById('root')) {
       document.querySelector('#root').setAttribute('data-clone', '');
-      clearInterval(addClone);
+      document.querySelector('#root').setAttribute('data-h2-system', '');
+      clearInterval(addDesignSystems);
     }
   }, 200);
 </script>

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,11 +1,18 @@
+var path = require("path");
 module.exports = ({ config }) => {
   config.module.rules.push({
     test: /\.(ts|tsx)$/,
+    include: path.resolve(__dirname, "..", "resources/assets/js"),
     use: [
-      require.resolve("ts-loader"),
-      require.resolve("react-docgen-typescript-loader"),
-    ]
+      {
+        loader: require.resolve("ts-loader"),
+        options: {
+          transpileOnly: true,
+        }
+      }
+    ],
   });
+
   config.resolve.extensions.push(".ts", ".tsx");
   return config;
 };


### PR DESCRIPTION
### Notes:
- Removes [react-docgen-typescript-loader](https://github.com/strothj/react-docgen-typescript-loader). Removing this improved performance significantly (build and hot-reload). 
- Explicitly sets the `include` key within `webpack.config.js` to only check within `/js` folder.
- Sets the `stories` value, in the storybook config (`main.ts`), to only parse within the `/js` folder.

Previous build (~1.95 min) and hot-reload(~7 sec) performance:
![image](https://user-images.githubusercontent.com/22059495/104658039-08550100-5690-11eb-90ed-862190a6bccf.png)

New build (25 sec) and hot-reload (~2 sec ) performance: 
![image](https://user-images.githubusercontent.com/22059495/104657830-b14f2c00-568f-11eb-9146-85071afea323.png)
