### PR TITLE
Bugfix - testUpdateProfile unit test 

### DIFF
--- a/tests/Feature/ApplicantControllerTest.php
+++ b/tests/Feature/ApplicantControllerTest.php
@@ -89,7 +89,7 @@ class ApplicantControllerTest extends TestCase
         $newApplicantClassification = array_replace(
             $newApplicantClassification,
             [
-                'classification_id' => $oldApplicantClassification['classification_id'] + 1,
+                'classification_id' => Classification::inRandomOrder()->first()->id,
                 'level' => $newApplicantClassification['level'] + 1,
             ]
         );


### PR DESCRIPTION
### Notes:
- I think will stop the test from failing. There was `classification_id` field being set by adding 1 to another `classification_id` value. So, there was the possibility that the value would be set to a number greater then the highest id value. 
