### PR TITLE
Bugfix - Removing Applicant Skills deletes ExperienceSkills

### DIFF
--- a/app/Http/Controllers/Api/ApplicantSkillsController.php
+++ b/app/Http/Controllers/Api/ApplicantSkillsController.php
@@ -4,6 +4,9 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\UpdateApplicantSkills;
 use App\Models\Applicant;
+use App\Models\ExperienceSkill;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\DB;
 
 class ApplicantSkillsController extends Controller
 {
@@ -18,8 +21,15 @@ class ApplicantSkillsController extends Controller
     {
         $skillIds = $request->validated()['skill_ids'];
         $applicant->skills()->sync($skillIds);
+
+        // $deletedExperienceSkills = $applicant->experienceSkillsQuery()->whereNotIn('skill_id', $skillIds)->get();
+        // I'm leaving the above line commented out for now, but if we want to do something with the
+        // deleted ExperienceSkill objects, we can retrieve them before deleting and include
+        // them in the api response.
+        $applicant->experienceSkillsQuery()->whereNotIn('skill_id', $skillIds)->delete();
         return [
-            'skill_ids' => $skillIds
+            'skill_ids' => $skillIds,
+            // 'deleted_experience_skills' => JsonResource::collection($deletedExperienceSkills),
         ];
     }
 }

--- a/app/Models/Applicant.php
+++ b/app/Models/Applicant.php
@@ -40,6 +40,8 @@ use App\Traits\TalentCloudCrudTrait as CrudTrait;
  * @property \Illuminate\Database\Eloquent\Collection $experiences_education
  * @property \Illuminate\Database\Eloquent\Collection $experiences_award
  * @property \Illuminate\Database\Eloquent\Collection $experiences_community
+ *
+ * @method \Illuminate\Database\Query\Builder experienceSkillsQuery
  */
 class Applicant extends BaseModel
 {
@@ -169,5 +171,70 @@ class Applicant extends BaseModel
     {
         return $this->morphMany(\App\Models\ExperienceCommunity::class, 'experienceable')
             ->orderBy('end_date', 'desc');
+    }
+
+    /**
+     * Returns a Laravel QueryBuilder object which will retrieve all ExperienceSkills
+     * which are linked to this Applicant, through this Applicant's Experiences.
+     *
+     * It returns the query builder object instead of the results of the query, so that additional
+     * clauses can be added by other code.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function experienceSkillsQuery()
+    {
+        $applicantId = $this->id;
+        return ExperienceSkill::where(function ($query) use ($applicantId) {
+            // A single where clause wraps 5 OR WHERE clauses.
+            // Each WHERE clause gets all the ExperienceSkills linked to a particular Experience type (and this Applicant).
+
+            $query->orWhere(function ($query) use ($applicantId) {
+                $query->whereIn('id', function ($query) use ($applicantId) {
+                    $query->select('experience_skills.id')->from('experience_skills')->join('experiences_work', function ($join) use ($applicantId) {
+                        $join->on('experience_skills.experience_id', '=', 'experiences_work.id')
+                            ->where('experience_skills.experience_type', 'experience_work')
+                            ->where('experiences_work.experienceable_type', 'applicant')
+                            ->where('experiences_work.experienceable_id', $applicantId);
+                    });
+                });
+            })->orWhere(function ($query) use ($applicantId) {
+                $query->whereIn('id', function ($query) use ($applicantId) {
+                    $query->select('experience_skills.id')->from('experience_skills')->join('experiences_personal', function ($join) use ($applicantId) {
+                        $join->on('experience_skills.experience_id', '=', 'experiences_personal.id')
+                            ->where('experience_skills.experience_type', 'experience_personal')
+                            ->where('experiences_personal.experienceable_type', 'applicant')
+                            ->where('experiences_personal.experienceable_id', $applicantId);
+                    });
+                });
+            })->orWhere(function ($query) use ($applicantId) {
+                $query->whereIn('id', function ($query) use ($applicantId) {
+                    $query->select('experience_skills.id')->from('experience_skills')->join('experiences_education', function ($join) use ($applicantId) {
+                        $join->on('experience_skills.experience_id', '=', 'experiences_education.id')
+                            ->where('experience_skills.experience_type', 'experience_education')
+                            ->where('experiences_education.experienceable_type', 'applicant')
+                            ->where('experiences_education.experienceable_id', $applicantId);
+                    });
+                });
+            })->orWhere(function ($query) use ($applicantId) {
+                $query->whereIn('id', function ($query) use ($applicantId) {
+                    $query->select('experience_skills.id')->from('experience_skills')->join('experiences_award', function ($join) use ($applicantId) {
+                        $join->on('experience_skills.experience_id', '=', 'experiences_award.id')
+                            ->where('experience_skills.experience_type', 'experience_award')
+                            ->where('experiences_award.experienceable_type', 'applicant')
+                            ->where('experiences_award.experienceable_id', $applicantId);
+                    });
+                });
+            })->orWhere(function ($query) use ($applicantId) {
+                $query->whereIn('id', function ($query) use ($applicantId) {
+                    $query->select('experience_skills.id')->from('experience_skills')->join('experiences_community', function ($join) use ($applicantId) {
+                        $join->on('experience_skills.experience_id', '=', 'experiences_community.id')
+                            ->where('experience_skills.experience_type', 'experience_community')
+                            ->where('experiences_community.experienceable_type', 'applicant')
+                            ->where('experiences_community.experienceable_id', $applicantId);
+                    });
+                });
+            });
+        });
     }
 }

--- a/app/Models/Applicant.php
+++ b/app/Models/Applicant.php
@@ -185,55 +185,35 @@ class Applicant extends BaseModel
     public function experienceSkillsQuery()
     {
         $applicantId = $this->id;
-        return ExperienceSkill::where(function ($query) use ($applicantId) {
-            // A single where clause wraps 5 OR WHERE clauses.
-            // Each WHERE clause gets all the ExperienceSkills linked to a particular Experience type (and this Applicant).
 
-            $query->orWhere(function ($query) use ($applicantId) {
-                $query->whereIn('id', function ($query) use ($applicantId) {
-                    $query->select('experience_skills.id')->from('experience_skills')->join('experiences_work', function ($join) use ($applicantId) {
-                        $join->on('experience_skills.experience_id', '=', 'experiences_work.id')
-                            ->where('experience_skills.experience_type', 'experience_work')
-                            ->where('experiences_work.experienceable_type', 'applicant')
-                            ->where('experiences_work.experienceable_id', $applicantId);
-                    });
-                });
-            })->orWhere(function ($query) use ($applicantId) {
-                $query->whereIn('id', function ($query) use ($applicantId) {
-                    $query->select('experience_skills.id')->from('experience_skills')->join('experiences_personal', function ($join) use ($applicantId) {
-                        $join->on('experience_skills.experience_id', '=', 'experiences_personal.id')
-                            ->where('experience_skills.experience_type', 'experience_personal')
-                            ->where('experiences_personal.experienceable_type', 'applicant')
-                            ->where('experiences_personal.experienceable_id', $applicantId);
-                    });
-                });
-            })->orWhere(function ($query) use ($applicantId) {
-                $query->whereIn('id', function ($query) use ($applicantId) {
-                    $query->select('experience_skills.id')->from('experience_skills')->join('experiences_education', function ($join) use ($applicantId) {
-                        $join->on('experience_skills.experience_id', '=', 'experiences_education.id')
-                            ->where('experience_skills.experience_type', 'experience_education')
-                            ->where('experiences_education.experienceable_type', 'applicant')
-                            ->where('experiences_education.experienceable_id', $applicantId);
-                    });
-                });
-            })->orWhere(function ($query) use ($applicantId) {
-                $query->whereIn('id', function ($query) use ($applicantId) {
-                    $query->select('experience_skills.id')->from('experience_skills')->join('experiences_award', function ($join) use ($applicantId) {
-                        $join->on('experience_skills.experience_id', '=', 'experiences_award.id')
-                            ->where('experience_skills.experience_type', 'experience_award')
-                            ->where('experiences_award.experienceable_type', 'applicant')
-                            ->where('experiences_award.experienceable_id', $applicantId);
-                    });
-                });
-            })->orWhere(function ($query) use ($applicantId) {
-                $query->whereIn('id', function ($query) use ($applicantId) {
-                    $query->select('experience_skills.id')->from('experience_skills')->join('experiences_community', function ($join) use ($applicantId) {
-                        $join->on('experience_skills.experience_id', '=', 'experiences_community.id')
-                            ->where('experience_skills.experience_type', 'experience_community')
-                            ->where('experiences_community.experienceable_type', 'applicant')
-                            ->where('experiences_community.experienceable_id', $applicantId);
-                    });
-                });
+        // Create a subquery which gets all ExperienceSkill ids associated with one Experience type.
+        $makeSubQuery = function ($experienceTable, $experienceType) use ($applicantId) {
+            return function ($query) use ($experienceTable, $experienceType, $applicantId) {
+                $query->select('experience_skills.id')->from('experience_skills')->join(
+                    $experienceTable,
+                    function ($join) use ($experienceTable, $experienceType, $applicantId) {
+                        $join->on('experience_skills.experience_id', '=', "$experienceTable.id")
+                            ->where('experience_skills.experience_type', $experienceType)
+                            ->where("$experienceTable.experienceable_type", 'applicant')
+                            ->where("$experienceTable.experienceable_id", $applicantId);
+                    }
+                );
+            };
+        };
+
+        return ExperienceSkill::where(function ($query) use ($makeSubQuery) {
+            // A single where clause wraps five OR WHERE clauses.
+            // Each WHERE clause gets all the ExperienceSkills linked to a particular Experience type (and this Applicant).
+            $query->orWhere(function ($query) use ($makeSubQuery) {
+                $query->whereIn('id', $makeSubQuery('experiences_work', 'experience_work'));
+            })->orWhere(function ($query) use ($makeSubQuery) {
+                $query->whereIn('id', $makeSubQuery('experiences_personal', 'experience_personal'));
+            })->orWhere(function ($query) use ($makeSubQuery) {
+                $query->whereIn('id', $makeSubQuery('experiences_education', 'experience_education'));
+            })->orWhere(function ($query) use ($makeSubQuery) {
+                $query->whereIn('id', $makeSubQuery('experiences_award', 'experience_award'));
+            })->orWhere(function ($query) use ($makeSubQuery) {
+                $query->whereIn('id', $makeSubQuery('experiences_community', 'experience_community'));
             });
         });
     }

--- a/tests/Feature/Api/ApplicantSkillsControllerTest.php
+++ b/tests/Feature/Api/ApplicantSkillsControllerTest.php
@@ -3,6 +3,9 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Applicant;
+use App\Models\ExperiencePersonal;
+use App\Models\ExperienceSkill;
+use App\Models\ExperienceWork;
 use App\Models\Skill;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -64,5 +67,55 @@ class ApplicantSkillsControllerTest extends TestCase
             'skill_ids' => $newSkillIds
         ]);
         $this->assertEquals($newSkillIds, $applicant->fresh()->skills->pluck('id')->all());
+
+        // Test that experience skills are deleted when matching Applicant Skills are.
+        $workExperience = factory(ExperienceWork::class)->create([
+            'experienceable_id' => $applicant->id,
+            'experienceable_type' => 'applicant',
+        ]);
+        $personalExperience = factory(ExperiencePersonal::class)->create([
+            'experienceable_id' => $applicant->id,
+            'experienceable_type' => 'applicant',
+        ]);
+        $expSkill1 = factory(ExperienceSkill::class)->create([
+            'skill_id' => 20,
+            'experience_type' => 'experience_work',
+            'experience_id' => $workExperience->id
+        ]);
+        $expSkill2 = factory(ExperienceSkill::class)->create([
+            'skill_id' => 25,
+            'experience_type' => 'experience_work',
+            'experience_id' => $workExperience->id
+        ]);
+        $expSkill3 = factory(ExperienceSkill::class)->create([
+            'skill_id' => 20,
+            'experience_type' => 'experience_personal',
+            'experience_id' => $personalExperience->id
+        ]);
+        $expSkill4 = factory(ExperienceSkill::class)->create([
+            'skill_id' => 25,
+            'experience_type' => 'experience_personal',
+            'experience_id' => $personalExperience->id
+        ]);
+
+        // If skill 25 is removed from Applicant Skills, expSkills 2 and 4 should be soft deleted.
+        $newSkillIds = [20];
+        $response = $this->actingAs($applicant->user)->json(
+            'put',
+            route('api.v1.applicant.skills.update', $applicant),
+            ['skill_ids' => $newSkillIds]
+        );
+        $response->assertOk();
+        $this->assertSoftDeleted('experience_skills', ['id' => $expSkill2->id]);
+        $this->assertSoftDeleted('experience_skills', ['id' => $expSkill4->id]);
+        $this->assertDatabaseHas('experience_skills', [
+            'id' => $expSkill1->id,
+            'deleted_at' => null,
+        ]);
+        $this->assertDatabaseHas('experience_skills', [
+            'id' => $expSkill3->id,
+            'deleted_at' => null,
+        ]);
+
     }
 }


### PR DESCRIPTION
Resolves #5159 .

### Notes:
- Added a method to Applicant eloquent model which returns a query (not the results) which gets all ExperienceSkills belonging to that applicant.
