### PR TITLE
Task - show password button accessibility

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1370,4 +1370,22 @@
   }
 
   formPreventMultipleSubmit();
+
+  /**
+   * Trigged when user clicks on hide/show icon in registration/login forms.
+   * It toggles the aria-pressed field btw true and false.
+   * This alerts users using a screen reader that the show password button has been pressed, or not pressed.
+   */
+  function showOrHidePasswordToggle() {
+    $(".showPassword").on("click", function(e) {
+      var pressed = e.currentTarget.getAttribute('aria-pressed');
+      if (pressed === "false") {
+        e.currentTarget.setAttribute('aria-pressed', "true");
+      } else {
+        e.currentTarget.setAttribute('aria-pressed', "false");
+      }
+    });
+  }
+
+  showOrHidePasswordToggle();
 })(jQuery);

--- a/resources/lang/en/common/auth/login.php
+++ b/resources/lang/en/common/auth/login.php
@@ -20,4 +20,5 @@ return [
     'remember_me' => 'Remember Me',
     'forgot_password' => 'Forgot Password',
     'login' => 'Login',
+    'show_password' => 'Show password',
 ];

--- a/resources/lang/en/common/auth/register.php
+++ b/resources/lang/en/common/auth/register.php
@@ -35,4 +35,5 @@ return [
     'gov_email' => 'Your Government Email',
     'register' => 'Register',
     'already_have_account' => 'Already have an account?',
+    'show_password' => 'Show password'
 ];

--- a/resources/lang/en/common/auth/reset_password.php
+++ b/resources/lang/en/common/auth/reset_password.php
@@ -19,4 +19,5 @@ return [
     'confirm_password' => 'Confirm Password',
     'submit' => 'Reset Password',
     'password_copy' => 'Create a password that contains at least one character from each of the following categories: lower-case characters (a-z), upper-case characters (A-Z), digits (0-9), and non-alphanumeric symbols (%, $, !, etc.).',
+    'show_password' => 'Show password',
 ];

--- a/resources/lang/en/common/settings.php
+++ b/resources/lang/en/common/settings.php
@@ -62,6 +62,7 @@ return [
     'new_password_label' => 'New Password',
     'confirm_password_label' => 'Confirm New Password',
     'password_save' => 'Submit New Password',
+    'show_password' => 'Show Password',
     'two_factor_legend' => 'Two-factor Authentication',
     'two_factor_button_text' => 'Set up Two-factor Authentication',
     'two_factor_recovery_legend' => 'Recovery Codes',

--- a/resources/lang/fr/common/auth/login.php
+++ b/resources/lang/fr/common/auth/login.php
@@ -20,4 +20,5 @@ return [
     'remember_me' => 'Se rappeler de moi',
     'forgot_password' => 'Mot de passe oublié',
     'login' => 'Ouvrir la séance',
+    'show_password' => 'Afficher le mot de passe',
 ];

--- a/resources/lang/fr/common/auth/register.php
+++ b/resources/lang/fr/common/auth/register.php
@@ -35,4 +35,5 @@ return [
     'gov_email' => 'Votre courriel gouvernemental',
     'register' => 'S\'inscrire',
     'already_have_account' => 'Vous avez déjà un compte?',
+    'show_password' => 'Afficher le mot de passe'
 ];

--- a/resources/lang/fr/common/auth/reset_password.php
+++ b/resources/lang/fr/common/auth/reset_password.php
@@ -19,4 +19,5 @@ return [
     'confirm_password' => 'Confirmez le mot de passe',
     'submit' => 'Réinitialiser le mot de passe',
     'password_copy' => 'Créez un mot de passe contenant au moins un caractère de chacune des catégories suivantes: caractères minuscules (az), majuscules (AZ), chiffres (0-9) et symboles non alphanumériques (%, $,!!). , etc.).',
+    'show_password' => 'Afficher le mot de passe',
 ];

--- a/resources/lang/fr/common/settings.php
+++ b/resources/lang/fr/common/settings.php
@@ -59,6 +59,7 @@ return [
     'new_password_label' => 'Nouveau mot de passe',
     'confirm_password_label' => 'Confirmer le nouveau mot de passe',
     'password_save' => 'Soumettre le nouveau mot de passe',
+    'show_password' => 'Afficher le mot de passe',
     'two_factor_legend' => 'Authentification à deux facteurs',
     'two_factor_button_text' => 'Configuration de l\'authentification à deux facteurs',
     'two_factor_recovery_legend' => 'Codes de récupération',

--- a/resources/views/auth/login.html.twig
+++ b/resources/views/auth/login.html.twig
@@ -42,8 +42,8 @@
                                     <div>
                                         <input id="password" name="password" required type="password" />
                                         <button class="showPassword" aria-label={{login.show_password}} aria-pressed="false" type="button">
-                                            <i class="fas fa-eye"></i>
-                                            <i class="fas fa-eye-slash"></i>
+                                            <i class="fas fa-eye" aria-hidden="true"></i>
+                                            <i class="fas fa-eye-slash" aria-hidden="true"></i>
                                         </button>
                                     </div>
                                     <span>{{ trans("forms.error") }}</span>

--- a/resources/views/auth/login.html.twig
+++ b/resources/views/auth/login.html.twig
@@ -41,7 +41,7 @@
                                     <span>{{ trans("forms.required") }}</span>
                                     <div>
                                         <input id="password" name="password" required type="password" />
-                                        <button type="button">
+                                        <button class="showPassword" aria-label={{login.show_password}} aria-pressed="false" type="button">
                                             <i class="fas fa-eye"></i>
                                             <i class="fas fa-eye-slash"></i>
                                         </button>

--- a/resources/views/auth/passwords/reset.html.twig
+++ b/resources/views/auth/passwords/reset.html.twig
@@ -50,8 +50,8 @@
                                             <input id="password" required type="password" name="password"
                                             autocomplete="off" />
                                             <button class="showPassword" aria-label={{reset_password.show_password}} aria-pressed="false" type="button">
-                                                <i class="fas fa-eye"></i>
-                                                <i class="fas fa-eye-slash"></i>
+                                                <i class="fas fa-eye" aria-hidden="true"></i>
+                                                <i class="fas fa-eye-slash" aria-hidden="true"></i>
                                             </button>
                                         </div>
                                         <span>This input has an error.</span>
@@ -64,8 +64,8 @@
                                             <input id="password-confirm" required type="password" name="password_confirmation"
                                             autocomplete="off" />
                                             <button class="showPassword" aria-label={{reset_password.show_password}} aria-pressed="false" type="button">
-                                                <i class="fas fa-eye"></i>
-                                                <i class="fas fa-eye-slash"></i>
+                                                <i class="fas fa-eye" aria-hidden="true"></i>
+                                                <i class="fas fa-eye-slash" aria-hidden="true"></i>
                                             </button>
                                         </div>
                                         <span>This input has an error.</span>

--- a/resources/views/auth/passwords/reset.html.twig
+++ b/resources/views/auth/passwords/reset.html.twig
@@ -49,7 +49,7 @@
                                         <div>
                                             <input id="password" required type="password" name="password"
                                             autocomplete="off" />
-                                            <button type="button">
+                                            <button class="showPassword" aria-label={{reset_password.show_password}} aria-pressed="false" type="button">
                                                 <i class="fas fa-eye"></i>
                                                 <i class="fas fa-eye-slash"></i>
                                             </button>
@@ -63,7 +63,7 @@
                                         <div>
                                             <input id="password-confirm" required type="password" name="password_confirmation"
                                             autocomplete="off" />
-                                            <button type="button">
+                                            <button class="showPassword" aria-label={{reset_password.show_password}} aria-pressed="false" type="button">
                                                 <i class="fas fa-eye"></i>
                                                 <i class="fas fa-eye-slash"></i>
                                             </button>

--- a/resources/views/auth/register.html.twig
+++ b/resources/views/auth/register.html.twig
@@ -106,9 +106,9 @@
 										<span>{{ trans('forms.required') }}</span>
 										<div>
 											<input id="password" required type="password" name="password" autocomplete="off"/>
-											<button type="button">
-												<i class="fas fa-eye"></i>
-												<i class="fas fa-eye-slash"></i>
+											<button class="showPassword" aria-label={{register.show_password}} aria-pressed="false" type="button">
+												<i class="fas fa-eye" aria-hidden="true"></i>
+												<i class="fas fa-eye-slash" aria-hidden="true"></i>
 											</button>
 										</div>
 										<span>{{ trans('forms.error') }}</span>
@@ -119,7 +119,7 @@
 										<span>{{ trans('forms.required') }}</span>
 										<div>
 											<input id="password-confirm" required type="password" name="password_confirmation" autocomplete="off"/>
-											<button type="button">
+											<button class="showPassword" aria-label={{register.show_password}} aria-pressed="false" type="button">
 												<i class="fas fa-eye"></i>
 												<i class="fas fa-eye-slash"></i>
 											</button>

--- a/resources/views/auth/register.html.twig
+++ b/resources/views/auth/register.html.twig
@@ -120,8 +120,8 @@
 										<div>
 											<input id="password-confirm" required type="password" name="password_confirmation" autocomplete="off"/>
 											<button class="showPassword" aria-label={{register.show_password}} aria-pressed="false" type="button">
-												<i class="fas fa-eye"></i>
-												<i class="fas fa-eye-slash"></i>
+												<i class="fas fa-eye" aria-hidden="true"></i>
+												<i class="fas fa-eye-slash" aria-hidden="true"></i>
 											</button>
 										</div>
 										<span>{{ trans('forms.error') }}</span>

--- a/resources/views/common/settings.html.twig
+++ b/resources/views/common/settings.html.twig
@@ -215,7 +215,7 @@
                                         <span>{{ settings.required }}</span>
                                         <div>
                                             <input id="current_password" name="current_password" required type="password" value="" autocomplete="off"/>
-                                            <button type="button">
+                                            <button class="showPassword" aria-label={{ settings.show_password }} aria-pressed="false" type="button">
                                                 <i class="fas fa-eye"></i>
                                                 <i class="fas fa-eye-slash"></i>
                                             </button>
@@ -227,7 +227,7 @@
                                         <span>{{ settings.required }}</span>
                                         <div>
                                             <input id="new_password" name="new_password" required type="password" autocomplete="off"/>
-                                            <button type="button">
+                                            <button class="showPassword" aria-label={{ settings.show_password }} aria-pressed="false" type="button">
                                                 <i class="fas fa-eye"></i>
                                                 <i class="fas fa-eye-slash"></i>
                                             </button>
@@ -239,7 +239,7 @@
                                         <span>{{ settings.required }}</span>
                                         <div>
                                             <input id="new_confirm_password" name="new_confirm_password" required type="password" autocomplete="off"/>
-                                            <button type="button">
+                                            <button class="showPassword" aria-label={{ settings.show_password }} aria-pressed="false" type="button">
                                                 <i class="fas fa-eye"></i>
                                                 <i class="fas fa-eye-slash"></i>
                                             </button>

--- a/resources/views/common/settings.html.twig
+++ b/resources/views/common/settings.html.twig
@@ -216,8 +216,8 @@
                                         <div>
                                             <input id="current_password" name="current_password" required type="password" value="" autocomplete="off"/>
                                             <button class="showPassword" aria-label={{ settings.show_password }} aria-pressed="false" type="button">
-                                                <i class="fas fa-eye"></i>
-                                                <i class="fas fa-eye-slash"></i>
+                                                <i class="fas fa-eye" aria-hidden="true"></i>
+                                                <i class="fas fa-eye-slash" aria-hidden="true"></i>
                                             </button>
                                         </div>
                                         <span>{{ settings.error }}</span>
@@ -228,8 +228,8 @@
                                         <div>
                                             <input id="new_password" name="new_password" required type="password" autocomplete="off"/>
                                             <button class="showPassword" aria-label={{ settings.show_password }} aria-pressed="false" type="button">
-                                                <i class="fas fa-eye"></i>
-                                                <i class="fas fa-eye-slash"></i>
+                                                <i class="fas fa-eye" aria-hidden="true"></i>
+                                                <i class="fas fa-eye-slash" aria-hidden="true"></i>
                                             </button>
                                         </div>
                                         <span>{{ settings.error }}</span>
@@ -240,8 +240,8 @@
                                         <div>
                                             <input id="new_confirm_password" name="new_confirm_password" required type="password" autocomplete="off"/>
                                             <button class="showPassword" aria-label={{ settings.show_password }} aria-pressed="false" type="button">
-                                                <i class="fas fa-eye"></i>
-                                                <i class="fas fa-eye-slash"></i>
+                                                <i class="fas fa-eye" aria-hidden="true"></i>
+                                                <i class="fas fa-eye-slash" aria-hidden="true"></i>
                                             </button>
                                         </div>
                                         <span>{{ settings.error }}</span>


### PR DESCRIPTION
Resolves #5160

### Notes:
- I wasn't able to add any text into the button without breaking the styling of the show/hide icons. We could fix this by changing [Clone's password component](https://designwithclone.ca/components/input/password/). However, I think I found another solution using a combo of the `aria-label` and `aria-pressed` attributes. When the user clicks the button, the screen reader will hopefully read, "Show password button pressed".  
