### PR TITLE
Collapse redux logs that appear in console

### DIFF
--- a/resources/assets/js/configureStore.ts
+++ b/resources/assets/js/configureStore.ts
@@ -16,7 +16,9 @@ export type DispatchType = Dispatch<AnyAction, RootState> &
   ThunkDispatch<any, any, AnyAction>;
 
 export const configureStore = (): Store<RootState, AnyAction> => {
-  const logger = createLogger();
+  const logger = createLogger({
+    collapsed: true,
+  });
 
   const isDev = process.env.NODE_ENV === "development";
 


### PR DESCRIPTION
This is a QOL change for devs, as the logs don't appear in production anyway.