### PR TITLE
Update subresource integrity value for html2canvas

### DIFF
--- a/resources/views/common/head.html.twig
+++ b/resources/views/common/head.html.twig
@@ -112,7 +112,7 @@
 
     <script
         src="https://html2canvas.hertzen.com/dist/html2canvas.js"
-        integrity="sha384-ykPvSxxyEw+EG/DdV/CahiysBAKSP1ZWwXtdk8PwqbpMg81lpDB/f2aon91e366p"
+        integrity="sha384-HXB9y1Yt88gDQ1fUkZ6okLjcbXSijbzNJFiOVsO08NsbruMKdqJ42lMfKk7M7Nwt"
         crossorigin="anonymous">
     </script>
 


### PR DESCRIPTION
### Notes:
Updates the integrity attribute for html2canvas to a valid value. The value becomes invalid any time a change is made to the code at https://html2canvas.hertzen.com/dist/html2canvas.js. To avoid having to change this every time that the remote file changes, it may be worth [installing html2canvas via npm](https://html2canvas.hertzen.com/getting-started) instead.

#### Screenshot:
![Screen Shot 2021-02-22 at 17 51 13](https://user-images.githubusercontent.com/3046459/108780702-cf356980-7536-11eb-9fad-416dbbf77287.png)


