### PR TITLE
Bugfix - Eslint's format on save

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
         "plugin:react/recommended",
         "plugin:testcafe/recommended",
         "plugin:@typescript-eslint/recommended",
+        "plugin:prettier/recommended",
         "prettier"
     ],
     "globals": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,9 +11,8 @@
   "workbench.settings.useSplitJSON": true,
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "editor.formatOnSave": false,
-  "editor.codeActionsOnSaveTimeout": 1500
 }


### PR DESCRIPTION
### Notes:
- Fixes Eslint's auto format on save feature. The eslint-prettier plugin was accidentally removed in a previous [PR](https://github.com/GCTC-NTGC/TalentCloud/pull/5275).
