### PR TITLE
Replace Travis CI badge with GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GC Talent Cloud / Nuage de talents du GC
 
-[![Build Status](https://travis-ci.com/GCTC-NTGC/TalentCloud.svg?branch=dev)](https://travis-ci.com/GCTC-NTGC/TalentCloud) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/GCTC-NTGC/TalentCloud/badges/quality-score.png?b=dev)](https://scrutinizer-ci.com/g/GCTC-NTGC/TalentCloud/?branch=dev) [![codecov](https://codecov.io/gh/GCTC-NTGC/TalentCloud/branch/dev/graph/badge.svg)](https://codecov.io/gh/GCTC-NTGC/TalentCloud/?branch=dev)
+![Workflow Status](https://github.com/GCTC-NTGC/TalentCloud/actions/workflows/tests.yml/badge.svg?branch=dev) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/GCTC-NTGC/TalentCloud/badges/quality-score.png?b=dev)](https://scrutinizer-ci.com/g/GCTC-NTGC/TalentCloud/?branch=dev) [![codecov](https://codecov.io/gh/GCTC-NTGC/TalentCloud/branch/dev/graph/badge.svg)](https://codecov.io/gh/GCTC-NTGC/TalentCloud/?branch=dev)
 
 ## About
 


### PR DESCRIPTION
### Notes:
- Travis CI badge no longer relevant since the service is no longer used.
